### PR TITLE
Make C# almost twice faster

### DIFF
--- a/PrimeSieveCS/PrimeCS.cs
+++ b/PrimeSieveCS/PrimeCS.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace PrimeSieveCS
 {
@@ -48,21 +49,23 @@ namespace PrimeSieveCS
                 return false;
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private bool GetBit(int index)
             {
-                if (index % 2 == 0)
+                if ((index & 1) == 0)
                     return false;
-                return bitArray[index / 2];
+                return bitArray[(int)((uint)index / 2)];
             }
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
             private void ClearBit(int index)
             {
-                if (index % 2 == 0)
+                if ((index & 1) == 0)
                 {
                     Console.WriteLine("You are setting even bits, which is sub-optimal");
                     return;
                 }
-                bitArray[index / 2] = false;      
+                bitArray[(int)((uint)index / 2)] = false;      
             }
 
             // primeSieve

--- a/PrimeSieveCS/PrimeSieveCS.csproj
+++ b/PrimeSieveCS/PrimeSieveCS.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
A few peephole optimizations:

`x % 2 == 0` to `x % 1 == 0` - there is a PR to .NET jit for it but it's still not landed yet.

`AggressiveInlining` shouldn't be needed there with PGO-based inlining but it's not enabled by default.


Before:
```
4650 passes
```
After:
```
8732 passes
```
