### PR TITLE
 Adding a faithful implementation of the C# solution

### DIFF
--- a/PrimeCSharp/solution_3/Dockerfile
+++ b/PrimeCSharp/solution_3/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/dotnet/sdk:5.0-focal AS build
+WORKDIR /source
+
+# copy csproj and restore as distinct layers
+COPY *.csproj /source
+RUN dotnet restore
+
+# copy and publish app and libraries
+COPY *.cs /source
+RUN dotnet publish -c release -o /app --no-restore
+
+# final stage/image
+FROM mcr.microsoft.com/dotnet/runtime:5.0-focal
+WORKDIR /app
+COPY --from=build /app .
+ENTRYPOINT ["/app/PrimeSieveCS"]

--- a/PrimeCSharp/solution_3/PrimeCS.cs
+++ b/PrimeCSharp/solution_3/PrimeCS.cs
@@ -137,6 +137,9 @@ namespace PrimeSieveCS
                 if (showResults)
                     Console.WriteLine();
                 Console.WriteLine($"Passes: {passes}, Time: {duration}, Avg: {duration / passes}, Limit: {sieveSize}, Count: {countPrimes()}, Valid: {validateResults()}");
+
+                Console.WriteLine();
+                Console.WriteLine($"tannergooding;{passes};{duration};1", passes, duration);
             }
 
             [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/PrimeCSharp/solution_3/PrimeCS.cs
+++ b/PrimeCSharp/solution_3/PrimeCS.cs
@@ -1,0 +1,172 @@
+﻿// ---------------------------------------------------------------------------
+// PrimeCS.cs : Dave's Garage Prime Sieve in C#
+// ---------------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+namespace PrimeSieveCS
+{
+    class PrimeCS
+    {
+        private static readonly Dictionary<ulong, ulong> myDict = new Dictionary<ulong, ulong>
+        {
+            [10] = 4,                 // Historical data for validating our results - the number of primes
+            [100] = 25,               // to be found under some limit, such as 168 primes under 1000
+            [1000] = 168,
+            [10000] = 1229,
+            [100000] = 9592,
+            [1000000] = 78498,
+            [10000000] = 664579,
+            [100000000] = 5761455,
+            [1000000000] = 50847534,
+            [10000000000] = 455052511,
+        };
+
+        class prime_sieve
+        {
+            private readonly ulong sieveSize;
+            private readonly byte[] rawbits;
+
+            [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+            public prime_sieve(ulong n)
+            {
+                sieveSize = n;
+                rawbits = GC.AllocateUninitializedArray<byte>((int)((n / 8) + 1), pinned: true);
+                rawbits.AsSpan().Fill(0xFF);
+            }
+
+            public ulong countPrimes()
+            {
+                var sieveSize = this.sieveSize;
+                var rawbits = this.rawbits;
+
+                // hoist null check
+                _ = getrawbits(rawbits, 0);
+
+                ulong count = (sieveSize >= 2) ? 1UL : 0UL;
+                for (ulong i = 3; i < sieveSize; i+=2)
+                    if (GetBit(rawbits, i))
+                        count++;
+                return count;
+            }
+
+            private bool validateResults()
+            {
+                return myDict.TryGetValue(sieveSize, out ulong sieveResult) && (sieveResult == countPrimes());
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static bool GetBit(byte[] rawbits, ulong index)
+            {
+                Debug.Assert((index % 2) != 0);
+                index /= 2;
+                return (getrawbits(rawbits, index / 8U) & (1u << (int)(index % 8))) != 0;
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static void ClearBit(byte[] rawbits, ulong index)
+            {
+                Debug.Assert((index % 2) != 0);
+                index /= 2;
+                getrawbits(rawbits, index / 8) &= (byte)~(1u << (int)(index % 8));
+            }
+
+            // primeSieve
+            // 
+            // Calculate the primes up to the specified limit
+
+            [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+            public void runSieve()
+            {
+                var sieveSize = this.sieveSize;
+                var rawbits = this.rawbits;
+
+                // hoist null check
+                _ = getrawbits(rawbits, 0);
+
+                ulong factor = 3;
+                ulong q = (ulong)Math.Sqrt(sieveSize);
+
+                while (factor <= q)
+                {
+                    for (ulong num = factor; num < sieveSize; num += 2)
+                    {
+                        if (GetBit(rawbits, num))
+                        {
+                            factor = num;
+                            break;
+                        }
+                    }
+
+                    // If marking factor 3, you wouldn't mark 6 (it's a mult of 2) so start with the 3rd instance of this factor's multiple.
+                    // We can then step by factor * 2 because every second one is going to be even by definition
+
+                    for (ulong num = factor * factor; num < sieveSize; num += factor * 2)
+                        ClearBit(rawbits, num);
+
+                    factor += 2;
+                }
+            }
+
+            public void printResults(bool showResults, double duration, ulong passes)
+            {
+                var sieveSize = this.sieveSize;
+                var rawbits = this.rawbits;
+
+                // hoist null check
+                _ = getrawbits(rawbits, 0);
+
+                if (showResults)
+                    Console.Write("2, ");
+
+                ulong count = (sieveSize >= 2) ? 1UL : 0UL;
+                for (ulong num = 3; num <= sieveSize; num += 2)
+                {
+                    if (GetBit(rawbits, num))
+                    {
+                        if (showResults)
+                            Console.Write(num + ", ");
+                        count++;
+                    }
+                }
+
+                if (showResults)
+                    Console.WriteLine();
+                Console.WriteLine($"Passes: {passes}, Time: {duration}, Avg: {duration / passes}, Limit: {sieveSize}, Count: {countPrimes()}, Valid: {validateResults()}");
+            }
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            private static ref byte getrawbits(byte[] rawbits, ulong index)
+            {
+                return ref Unsafe.Add(ref MemoryMarshal.GetArrayDataReference(rawbits), (nint)index);
+            }
+        }
+
+        static void Main(string[] args)
+        {
+            const ulong SieveSize = 1000000;
+            const long MillisecondsPerSecond = 1000;
+            const long MicrosecondsPerSecond = 1000000;
+
+            ulong passes = 0;
+            prime_sieve sieve = null;
+
+            var stopwatch = Stopwatch.StartNew();
+
+            while (stopwatch.ElapsedMilliseconds < (5 * MillisecondsPerSecond))
+            {
+                sieve = new prime_sieve(SieveSize);
+                sieve.runSieve();
+                passes++;
+            }
+            stopwatch.Stop();
+
+            if (sieve != null)
+                sieve.printResults(false, (stopwatch.Elapsed.TotalSeconds * MicrosecondsPerSecond) / SieveSize, passes);
+        }
+    }
+}

--- a/PrimeCSharp/solution_3/PrimeSieveCS.csproj
+++ b/PrimeCSharp/solution_3/PrimeSieveCS.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/PrimeCSharp/solution_3/PrimeSieveCS.sln
+++ b/PrimeCSharp/solution_3/PrimeSieveCS.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31112.23
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PrimeSieveCS", "PrimeSieveCS.csproj", "{02AF9EB8-1B7E-42E2-89A9-73674EF99E5C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{02AF9EB8-1B7E-42E2-89A9-73674EF99E5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{02AF9EB8-1B7E-42E2-89A9-73674EF99E5C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{02AF9EB8-1B7E-42E2-89A9-73674EF99E5C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{02AF9EB8-1B7E-42E2-89A9-73674EF99E5C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8BF73573-411C-4401-B939-7841524DED02}
+	EndGlobalSection
+EndGlobal

--- a/PrimeCSharp/solution_3/README.md
+++ b/PrimeCSharp/solution_3/README.md
@@ -9,4 +9,8 @@
 
 ## Output
 
-Passes: 7877, Time: 5.0005804, Avg: 0.0006348331090516694, Limit: 1000000, Count: 78498, Valid: True
+```
+Passes: 7883, Time: 5.0001565, Avg: 0.0006342961436001523, Limit: 1000000, Count: 78498, Valid: True
+
+tannergooding;7883;5.0001565;1
+```

--- a/PrimeCSharp/solution_3/README.md
+++ b/PrimeCSharp/solution_3/README.md
@@ -1,0 +1,12 @@
+# C# solution by tannergooding
+
+![Category](https://img.shields.io/badge/Category-faithful-green)
+
+## Run instructions
+
+1. Get the latest version of .NET 5 or later: https://dotnet.microsoft.com/download
+2. From the solution root, run `dotnet run -c Release`
+
+## Output
+
+Passes: 7877, Time: 5.0005804, Avg: 0.0006348331090516694, Limit: 1000000, Count: 78498, Valid: True


### PR DESCRIPTION
On my own box, C++ measures:
```
Passes: 8665, Time: 5.000000, Avg: 0.000577, Limit: 1000000, Count1: 78498, Count2: 78498, Valid: 1

davepl;8665;5.000000;1
```

This builds on @EgorBo's PR in https://github.com/davepl/Primes/pull/4 and gets the C# version to:
```
Passes: 7883, Time: 5.0001565, Avg: 0.0006342961436001523, Limit: 1000000, Count: 78498, Valid: True

tannergooding;7883;5.0001565;1
```

The key points are to elide bounds checks and more closely mirror what C++ in terms of types and code used to make it a more fair comparison. C# inherently does things C++ doesn't, like bounds checks.
If the version to version comparisons were to be equally safe (with C++ using things like `std::array` and doing bounds checking before accesses, eliding where it is statically determined to be "safe"), then C++ wouldn't have such a "clear lead" 😄 