### PR TITLE
Small optimizations

### DIFF
--- a/PrimeSievePY/PrimePY.py
+++ b/PrimeSievePY/PrimePY.py
@@ -29,7 +29,7 @@ class prime_sieve(object):
 
     def __init__(this, limit):
         this.sieveSize = limit
-        this.rawbits = [True] * (int((this.sieveSize+1)/2))
+        this.rawbits = [True] * ((this.sieveSize+1)//2)
 
     # Look up our count of primes in the historical data (if we have it) to see if it matches
 
@@ -48,7 +48,7 @@ class prime_sieve(object):
         if (index % 2 == 0): # even numbers are automaticallty returned as non-prime
             return False
         else:
-            return this.rawbits[int(index/2)]
+            return this.rawbits[index//2]
 
     # ClearBit
     #
@@ -61,7 +61,7 @@ class prime_sieve(object):
             assert("If you're setting even bits, you're sub-optimal for some reason!")
             return False
         else:
-            this.rawbits[int(index/2)] = False
+            this.rawbits[index//2] = False
 
     # primeSieve
     # 
@@ -70,7 +70,7 @@ class prime_sieve(object):
     def runSieve(this):
 
         factor = 3
-        q = sqrt(this.sieveSize)
+        q = this.sieveSize**0.5
 
         while (factor < q):
             for num in range (factor, this.sieveSize):


### PR DESCRIPTION
% python3 -m timeit 'int(9 / 2)' 
5000000 loops, best of 5: 69.5 nsec per loop
% python3 -m timeit '9 // 2'    
50000000 loops, best of 5: 8.39 nsec per loop

Also it's faster using this.sieveSize ** .5 than sqrt(this.sieveSize)