### PR TITLE
add implementation using C++20 std::bitset instead of std::vector<bool>

### DIFF
--- a/PrimeCPP20-bitset/PrimeCPP20-bitset.cpp
+++ b/PrimeCPP20-bitset/PrimeCPP20-bitset.cpp
@@ -1,0 +1,136 @@
+// ---------------------------------------------------------------------------
+// PrimeCPP20-bitset.cpp : Dave's Garage Prime Sieve in C++ (using C++20 std::bitset)
+// ---------------------------------------------------------------------------
+
+#include <chrono>
+#include <ctime>
+#include <iostream>
+#include <bitset>
+#include <map>
+#include <cstring>
+#include <cmath>
+#include <bitset>
+#include <limits>
+
+using namespace std;
+using namespace std::chrono;
+
+template <size_t n>
+class prime_sieve
+{
+  private:
+
+      long sieveSize = 0;
+      bitset<n> Bits;
+      const std::map<const long, const int> myDict =
+      {
+            {          10L, 4         },                // Historical data for validating our results - the number of primes
+            {         100L, 25        },               // to be found under some limit, such as 168 primes under 1000
+            {        1000L, 168       },
+            {       10000L, 1229      },
+            {      100000L, 9592      },
+            {     1000000L, 78498     },
+            {    10000000L, 664579    },
+            {   100000000L, 5761455   },
+            {  1000000000L, 50847534  },
+            { 10000000000L, 455052511 },
+
+      };
+
+      bool validateResults()
+      {
+          if (myDict.end() == myDict.find(sieveSize))
+              return false;
+          return myDict.find(sieveSize)->second == countPrimes();
+      }
+
+   public:
+
+      prime_sieve()
+        : sieveSize(n)
+      {
+          Bits.set();
+      }
+
+      ~prime_sieve()
+      {
+      }
+
+      void runSieve()
+      {
+          int factor = 3;
+          int q = sqrt(sieveSize);
+
+          while (factor <= q)
+          {
+              for (int num = factor; num < sieveSize; num += 2)
+              {
+                  if (Bits[num])
+                  {
+                      factor = num;
+                      break;
+                  }
+              }
+              for (int num = factor * factor; num < sieveSize; num += factor * 2)
+                  Bits[num] = false;
+
+              factor += 2;
+          }
+      }
+
+      void printResults(bool showResults, double duration, int passes)
+      {
+          if (showResults)
+              printf("2, ");
+
+          int count = 1;
+          for (int num = 3; num <= sieveSize; num+=2)
+          {
+              if (Bits[num])
+              {
+                  if (showResults)
+                      printf("%d, ", num);
+                  count++;
+              }
+          }
+
+          if (showResults)
+              printf("\n");
+
+          printf("Passes: %d, Time: %lf, Avg: %lf, Limit: %ld, Count1: %d, Count2: %d, Valid: %d\n",
+                 passes,
+                 duration,
+                 duration / passes,
+                 sieveSize,
+                 count,
+                 countPrimes(),
+                 validateResults());
+      }
+
+      int countPrimes()
+      {
+          int count = 1;
+          for (int i = 3; i < sieveSize; i+=2)
+              if (Bits[i])
+                  count++;
+          return count;
+      }
+};
+
+int main()
+{
+    auto passes = 0;
+    auto tStart = steady_clock::now();
+
+    while (true)
+    {
+        prime_sieve<1000000L> sieve;
+        sieve.runSieve();
+        passes++;
+        if (duration_cast<seconds>(steady_clock::now() - tStart).count() >= 5)
+        {
+            sieve.printResults(false, duration_cast<microseconds>(steady_clock::now() - tStart).count() / 1000000, passes);
+            break;
+        }
+    }
+}

--- a/PrimeCPP20-bitset/PrimeCPP20-bitset.sln
+++ b/PrimeCPP20-bitset/PrimeCPP20-bitset.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31112.23
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "PrimeCPP20-bitset", "PrimeCPP20-bitset.vcxproj", "{7111338C-BED1-45E2-8822-E7D66B15A3A5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7111338C-BED1-45E2-8822-E7D66B15A3A5}.Debug|x64.ActiveCfg = Debug|x64
+		{7111338C-BED1-45E2-8822-E7D66B15A3A5}.Debug|x64.Build.0 = Debug|x64
+		{7111338C-BED1-45E2-8822-E7D66B15A3A5}.Debug|x86.ActiveCfg = Debug|Win32
+		{7111338C-BED1-45E2-8822-E7D66B15A3A5}.Debug|x86.Build.0 = Debug|Win32
+		{7111338C-BED1-45E2-8822-E7D66B15A3A5}.Release|x64.ActiveCfg = Release|x64
+		{7111338C-BED1-45E2-8822-E7D66B15A3A5}.Release|x64.Build.0 = Release|x64
+		{7111338C-BED1-45E2-8822-E7D66B15A3A5}.Release|x86.ActiveCfg = Release|Win32
+		{7111338C-BED1-45E2-8822-E7D66B15A3A5}.Release|x86.Build.0 = Release|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {503FD3AB-6B88-4314-A8CD-3E970F3DFE36}
+	EndGlobalSection
+EndGlobal

--- a/PrimeCPP20-bitset/PrimeCPP20-bitset.vcxproj
+++ b/PrimeCPP20-bitset/PrimeCPP20-bitset.vcxproj
@@ -1,0 +1,150 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{7111338c-bed1-45e2-8822-e7d66b15a3a5}</ProjectGuid>
+    <RootNamespace>PrimeCPP20-bitset</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <Optimization>MaxSpeed</Optimization>
+      <ExceptionHandling>false</ExceptionHandling>
+      <BasicRuntimeChecks>Default</BasicRuntimeChecks>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="PrimeCPP20-bitset.cpp" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/PrimeCPP20-bitset/PrimeCPP20-bitset.vcxproj.filters
+++ b/PrimeCPP20-bitset/PrimeCPP20-bitset.vcxproj.filters
@@ -1,0 +1,22 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;c++;cppm;ixx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;h++;hm;inl;inc;ipp;xsd</Extensions>
+    </Filter>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="PrimeCPP20-bitset.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>

--- a/PrimeCPP20-bitset/PrimeCPP20-bitset.vcxproj.user
+++ b/PrimeCPP20-bitset/PrimeCPP20-bitset.vcxproj.user
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup />
+</Project>

--- a/PrimeCPP20-bitset/run.cmd
+++ b/PrimeCPP20-bitset/run.cmd
@@ -1,0 +1,2 @@
+msbuild /property:Configuration=Release
+.\x64\Release\PrimeCPP20-bitset.exe

--- a/PrimeCPP20-bitset/run.sh
+++ b/PrimeCPP20-bitset/run.sh
@@ -1,0 +1,2 @@
+g++ -Ofast  -std=c++20 PrimeCPP20-bitset.cpp -oPrimes.exe
+./Primes.exe


### PR DESCRIPTION
C++20 introduces `std::bitset`, which is a bitfield that does not pretend to be a vector. Other differences from `std::vector<bool>` include that its data resides on the stack and that its size must be given at compile time.

The results are interesting: On my Linux machine (gcc 10.2.0, Intel Core i5-8265U), using the bitset is slightly but consistently and measurably faster. On my Windows machine on the other hand (cl 19.28.29912, Visual Studio Community 2019 16.9.1, AMD Ryzen 5 3600), the vector seriously outpaces the bitset. Here are some stats (10 runs each):
```
Linux std::vector<bool>: min=6525 max=6638 avg=6603.8
Linux std::bitset:       min=6650 max=6745 avg=6694.9

Windows std::vector<bool>: min=8275 max=8303 avg=8291.4
Windows std::bitset:       min=7544 max=7577 avg=7561.7
```

Unfortunately, I don't have access to a Mac at the moment.