### PR TITLE
Fix integer rounding bug in CPP version

### DIFF
--- a/PrimeCPP/PrimeCPP.cpp
+++ b/PrimeCPP/PrimeCPP.cpp
@@ -127,7 +127,7 @@ int main()
         passes++;
         if (duration_cast<seconds>(steady_clock::now() - tStart).count() >= 5)
         {
-            sieve.printResults(false, duration_cast<microseconds>(steady_clock::now() - tStart).count() / 1000000, passes);
+            sieve.printResults(false, duration_cast<microseconds>(steady_clock::now() - tStart).count() / 1000000.0, passes);
             break;
         }
     } 


### PR DESCRIPTION
The number of microseconds returned is an integer, and since the divisor was also an integer, the result would always be exactly 5, even if it took slightly longer than that.