### PR TITLE
Setting CI base for multiple builds via Docker

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,13 +29,11 @@ jobs:
           string: ${{ matrix.solution }}
         
       - name: "Build container image"
-        continue-on-error: true
         run: |
           cd "${{ matrix.solution }}"
           docker build -t "${{ steps.container_name.outputs.lowercase }}" .
       
       - name: "Run tests"
-        continue-on-error: true
         run: |
           docker run --rm "${{ steps.container_name.outputs.lowercase }}" | tee "${{ matrix.solution }}-${{ matrix.os }}.txt"
       

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,3 +43,13 @@ jobs:
         with:
           name: ${{ matrix.solution }}
           path: "${{ matrix.solution }}.txt"
+
+  report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: "Download artifacts"
+        uses: actions/download-artifact@v2
+      
+      - name: "List all artifacts"
+        run: ls -R

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,6 +47,9 @@ jobs:
   report:
     runs-on: ubuntu-latest
 
+    needs: 
+      - test
+
     steps:
       - name: "Download artifacts"
         uses: actions/download-artifact@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -55,4 +55,4 @@ jobs:
         uses: actions/download-artifact@v2
       
       - name: "List all artifacts"
-        run: ls -R
+        run: tree

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 1
       matrix:
         solution: [ "PrimeCrystal" ]
-        os: ["macos-10.15", "ubuntu-20.04"]
+        os: ["ubuntu-20.04"]
     
     steps:
       - name: "Checkout code"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -29,11 +29,13 @@ jobs:
           string: ${{ matrix.solution }}
         
       - name: "Build container image"
+        continue-on-error: true
         run: |
           cd "${{ matrix.solution }}"
           docker build -t "${{ steps.container_name.outputs.lowercase }}" .
       
       - name: "Run tests"
+        continue-on-error: true
         run: |
           docker run --rm "${{ steps.container_name.outputs.lowercase }}" | tee "${{ matrix.solution }}-${{ matrix.os }}.txt"
       

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      max-parallel: 1
+      matrix:
+        solutions: [ "name1", "name2" ]
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        
+      - name: "Run job"
+        continue-on-error: true
+        run: "echo ${{ matrix.name }}"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        solutions: [ "name1", "name2" ]
+        solution: [ "name1", "name2" ]
     
     steps:
       - name: Checkout code
@@ -23,4 +23,5 @@ jobs:
         
       - name: "Run job"
         continue-on-error: true
-        run: "echo ${{ matrix.name }}"
+        run: |
+          "echo ${{ matrix.solution }}"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -20,13 +20,19 @@ jobs:
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v2
+
+      - name: "Normalize container name"
+        id: container_name
+        uses: ASzc/change-string-case-action@v1
+        with:
+          string: ${{ matrix.solution }}
         
       - name: "Build container image"
         continue-on-error: true
         run: |
           cd "${{ matrix.solution }}"
-          docker build -t "${{ matrix.solution }}" .
+          docker build -t "${{ steps.container_name.outputs.lowercase }}" .
       
       - name: "Run tests"
         continue-on-error: true
-        run: docker run --rm "${{ matrix.solution }}"
+        run: docker run --rm "${{ steps.container_name.outputs.lowercase }}"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,12 +10,13 @@ on:
   
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: "${{ matrix.os }}"
 
     strategy:
       max-parallel: 1
       matrix:
         solution: [ "PrimeCrystal" ]
+        os: ["macos-10.15", "ubuntu-20.04"]
     
     steps:
       - name: "Checkout code"
@@ -36,13 +37,13 @@ jobs:
       - name: "Run tests"
         continue-on-error: true
         run: |
-          docker run --rm "${{ steps.container_name.outputs.lowercase }}" | tee "${{ matrix.solution }}.txt"
+          docker run --rm "${{ steps.container_name.outputs.lowercase }}" | tee "${{ matrix.solution }}-${{ matrix.os }}.txt"
       
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.solution }}
-          path: "${{ matrix.solution }}.txt"
+          path: "${{ matrix.solution }}-${{ matrix.os }}.txt"
 
   report:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -35,4 +35,11 @@ jobs:
       
       - name: "Run tests"
         continue-on-error: true
-        run: docker run --rm "${{ steps.container_name.outputs.lowercase }}"
+        run: |
+          docker run --rm "${{ steps.container_name.outputs.lowercase }}" | tee "${{ matrix.solution }}.txt"
+      
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.solution }}
+          path: "${{ matrix.solution }}.txt"

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,9 +5,9 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-
+    
   workflow_dispatch:
-
+  
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -15,13 +15,18 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        solution: [ "name1", "name2" ]
+        solution: [ "PrimeCrystal" ]
     
     steps:
-      - name: Checkout code
+      - name: "Checkout code"
         uses: actions/checkout@v2
         
-      - name: "Run job"
+      - name: "Build container image"
         continue-on-error: true
         run: |
-          "echo ${{ matrix.solution }}"
+          cd "${{ matrix.solution }}"
+          docker build -t "${{ matrix.solution }}" .
+      
+      - name: "Run tests"
+        continue-on-error: true
+        run: docker run --rm "${{ matrix.solution }}"


### PR DESCRIPTION
I've set up a build matrix using the implementation name(just one for now)  and the os for the runner (just Ubuntu for now). As the next steps, we need all to adhere to the same output, run duration, and the number of iterations to run (that can be controlled from the CI). Additionally, I've added one last step in the job to gather all the data and in the future, we can add a script to aggregate results and generate a report.