### PR TITLE
Pure Python, but 150 times faster

### DIFF
--- a/PrimePython/stl-faithful/ssovest/PrimePY.py
+++ b/PrimePython/stl-faithful/ssovest/PrimePY.py
@@ -1,0 +1,122 @@
+"""
+Python Prime Sieve
+
+MyFirstPython Program (tm) Dave Plummer 8/9/2018
+Updated 3/22/2021 for Dave's Garage episode comparing C++, C#, and Python
+"""
+
+from math import sqrt
+
+
+class PrimeSieve:
+
+    """This is the main PrimeSieve class. Call it with the number you wish as
+    an upper limit, then call the run_sieve method to do the calculation.
+    print_results will dump the count to check validity."""
+
+    prime_counts = { 10 : 4,                 # Historical data for validating our results - the number of primes
+                    100 : 25,                # to be found under some limit, such as 168 primes under 1000
+                    1000 : 168,
+                    10000 : 1229,
+                    100000 : 9592,
+                    1000000 : 78498,
+                    10000000 : 664579,
+                    100000000 : 5761455
+                  }
+
+    def __init__(self, limit):
+        self._size = limit
+        self._bits = bytearray(b"\x01") * ((self._size + 1) // 2)
+
+    def validate_results(self):                      # Check to see if this is an upper_limit we can
+
+        """Look up our count of primes in the historical data (if we have it)
+        to see if it matches"""
+
+        if self._size in self.prime_counts:                              # the data, and (b) our count matches. Since it will return
+            return self.prime_counts[self._size] == self.count_primes()  # false for an unknown upper_limit, can't assume false == bad
+        return False
+
+    def run_sieve(self):
+
+        """Calculate the primes up to the specified limit"""
+
+        factor = 1
+        # sqrt doesn't seem to make any difference in CPython,
+        # but works much faster than "x**.5" in Pypy
+        q = sqrt(self._size) / 2
+        bitslen = len(self._bits)
+
+        while factor <= q:
+            factor = self._bits.index(b"\x01", factor)
+
+            # If marking factor 3, you wouldn't mark 6 (it's a mult of 2) so start with the 3rd instance of this factor's multiple.
+            # We can then step by factor * 2 because every second one is going to be even by definition
+            start = factor * 3 + 1
+            step  = factor * 2 + 1
+            size  = bitslen - start
+            self._bits[start :: step] = b"\x00" * (size // step + bool(size % step))  # bool is (a subclass of) int in python
+
+            factor += 1
+
+    def count_primes(self):
+
+        """Return the count of bits that are still set in the sieve.
+        Assumes you've already called run_sieve, of course!"""
+
+        return self._bits.count(b"\x01") if self._size > 1 else 0
+
+    def get_primes(self):
+
+        """Returns a generator to iterate over the found prime numbers.
+        Requires a prior run_sieve call"""
+
+        if self._size > 1:
+            yield 2  # Since we auto-filter evens, we have to special case the number 2 which is prime
+        if self._size > 2:
+            num = 1
+            while num > 0:
+                yield num * 2 + 1
+                num = self._bits.find(1, num + 1)
+
+    def print_results(self, show_results, duration, passes):
+
+        """Displays the primes found (or just the total count,
+        depending on what you ask for)"""
+
+        count = 0
+        for num in self.get_primes():  # Count (and optionally dump) the primes that were found below the limit
+            count += 1
+            if show_results:
+                print("%s, " % num, end="")
+
+        if show_results:
+            print()
+        print("Passes: %s, Time: %s, Avg: %s, Limit: %s, Count: %s, Valid: %s" % (passes, duration, duration/passes, self._size, count, self.validate_results()))
+
+# MAIN Entry
+if __name__ == "__main__":
+    from argparse import ArgumentParser
+    from timeit import default_timer  # For timing the durations
+
+    parser = ArgumentParser(description="Python Prime Sieve")
+    parser.add_argument("--limit", "-l", help="Upper limit for calculating prime numbers", type=int, default=1_000_000)
+    parser.add_argument("--time", "-t", help="Time limit", type=float, default=10)
+    parser.add_argument("--show", "-s", help="Print found prime numbers", action="store_true")
+
+    args = parser.parse_args()
+    limit = args.limit
+    timeout = args.time
+    show_results = args.show
+
+    time_start = default_timer()                           # Record our starting time
+    passes = 0                                             # We're going to count how many passes we make in fixed window of time
+
+    while (default_timer() - time_start < timeout):        # Run until more than 10 seconds have elapsed
+        sieve = PrimeSieve(limit)                          # Calc the primes up to a million
+        sieve.run_sieve()                                  # Find the results
+        passes = passes + 1                                # Count this pass
+
+    time_delta = default_timer() - time_start              # After the "at least 10 seconds", get the actual elapsed
+
+    sieve.print_results(show_results, time_delta, passes)  # Display outcome

--- a/PrimePython/stl-faithful/ssovest/README.md
+++ b/PrimePython/stl-faithful/ssovest/README.md
@@ -1,0 +1,73 @@
+# Python Prime Sieve
+
+## Running with Python
+
+Install Python: https://www.python.org/downloads/
+
+
+```
+cd path/to/sieve
+python PrimePY.py
+```
+
+## Running with Pypy
+
+Download and extract Pypy3: https://www.pypy.org/download.html
+
+
+```
+cd path/to/pypy
+pypy3 path/to/sieve/PrimePY.py
+```
+
+## Command line arguments
+
+ - `--limit=X`, `-l X`: set upper limit for calculating primes. Default is 1_000_000.
+ - `--time=X`, `-t X`: set running time, in seconds. Default is 10.
+ - `--show`, `-s`: output the found primes.
+
+## Running tests
+
+```
+cd path/to/sieve
+python -m unittest
+```
+
+# Results on my machine
+
+ - AMD A4-3305M 1.9 GHz, Windows 7 64 bit
+ - Python: 3.8.1 64 bit
+ - PyPy: 7.3.3
+ - g++: 9.2.0
+
+Passes, average over 10 runs, 10 sec. duration each
+-
+|Limit      |Python     |PyPy        |Python (original)|PyPy (original)|C#         |C++
+|-----------|-----------|------------|-----------------|---------------|-----------|-----------
+|10         |1'460'684.6|14'054'698.3|      1'341'886.6|   20'563'347.0|9'012'584.3|3'441'332.0
+|100        |  654'359.3| 7'479'784.3|        238'464.1|    4'057'462.0|6'913'831.5|1'766'864.4
+|1000       |  309'068.4| 1'997'727.7|         22'573.2|      549'117.2|1'728'762.2|1'353'130.4
+|10000      |  118'406.0|   285'541.6|          1'937.1|       49'720.8|  171'218.5|  504'840.4
+|100000     |   28'074.0|    26'177.5|            166.2|        3'161.2|   15'153.7|   63'118.2
+|**1000000**|**2'222.2**| **1'710.4**|         **14.8**|      **203.8**|**1'377.7**|**4'870.8**
+|10000000   |       98.1|        86.7|              2.0|           15.0|      107.2|      193.5
+|100000000  |        7.3|         7.0|             1.0*|            2.0|        8.0|       14.0
+
+Passes/sec., average over 10 runs
+-
+|Limit      |Python       |PyPy           |Python (original)|PyPy (original)|C#           |C++
+|-----------|-------------|---------------|-----------------|---------------|-------------|-------------
+|10         |146'068.41190|1'405'459.97299|    134'188.61218|2'056'315.06029|901'206.88097|344'133.20000
+|100        | 65'435.74311|  747'974.69452|     23'846.33893|  405'743.77278|691'343.60515|176'686.44000
+|1000       | 30'906.63142|  199'771.71623|      2'257.27410|   54'911.30435|172'866.33205|135'313.04000
+|10000      | 11'840.54234|   28'553.94879|        193.64954|    4'972.00489| 17'120.87069| 50'484.04000
+|100000     |  2'807.29283|    2'617.65142|         16.58595|      316.07127|  1'515.28333|  6'311.82000
+|**1000000**|**222.16822**|  **170.97555**|      **1.42078**|   **20.32647**|**137.71392**|**487.08000**
+|10000000   |      9.76870|        8.60671|          0.12896|        1.46159|     10.67402|     19.35000
+|100000000  |      0.69502|        0.65422|         0.01194*|        0.11842|      0.72642|      1.40000
+
+_*Avg. over 3 runs. I wasn't patient enough._
+
+This implementation doesn't show significant performance on low limits, which is expectable. But then, as more and more work is delegated to Python's built-in methods, it becomes faster, with performance peaks at limits 100'000 and 1'000'000. Then performance somewhat drops again, but not much. I'm not 100% sure why, but my guess is the bytearray begins to take too much memory to fit in the cpu cache.
+
+Also, PyPy seems to do an amazing job optimizing things which CPython is slow at. But there are some things, like slice assignment, that are faster in CPython.

--- a/PrimePython/stl-faithful/ssovest/tests/test_sieve.py
+++ b/PrimePython/stl-faithful/ssovest/tests/test_sieve.py
@@ -1,0 +1,283 @@
+import unittest
+from io import StringIO
+from unittest.mock import patch
+from PrimePY import PrimeSieve
+
+
+class TestCountPrimes(unittest.TestCase):
+
+    def test_limit_0(self):
+        sieve = PrimeSieve(0)
+        sieve.run_sieve()
+        self.assertEqual(sieve.count_primes(), 0)
+
+    def test_limit_1(self):
+        sieve = PrimeSieve(1)
+        sieve.run_sieve()
+        self.assertEqual(sieve.count_primes(), 0)
+
+    def test_limit_2(self):
+        sieve = PrimeSieve(2)
+        sieve.run_sieve()
+        self.assertEqual(sieve.count_primes(), 1)
+
+    def test_prime_limit(self):
+        sieve = PrimeSieve(11)
+        sieve.run_sieve()
+        self.assertEqual(sieve.count_primes(), 5)
+
+    def test_limit_with_odd_sqr(self):
+        sieve = PrimeSieve(25)
+        sieve.run_sieve()
+        self.assertEqual(sieve.count_primes(), 9)
+
+    def test_limit_10(self):
+        sieve = PrimeSieve(10)
+        sieve.run_sieve()
+        self.assertEqual(sieve.count_primes(), 4)
+
+    def test_limit_100(self):
+        sieve = PrimeSieve(100)
+        sieve.run_sieve()
+        self.assertEqual(sieve.count_primes(), 25)
+
+    def test_limit_1000(self):
+        sieve = PrimeSieve(1000)
+        sieve.run_sieve()
+        self.assertEqual(sieve.count_primes(), 168)
+
+    def test_limit_10_000(self):
+        sieve = PrimeSieve(10_000)
+        sieve.run_sieve()
+        self.assertEqual(sieve.count_primes(), 1229)
+
+    def test_limit_100_000(self):
+        sieve = PrimeSieve(100_000)
+        sieve.run_sieve()
+        self.assertEqual(sieve.count_primes(), 9592)
+
+    def test_limit_1_000_000(self):
+        sieve = PrimeSieve(1_000_000)
+        sieve.run_sieve()
+        self.assertEqual(sieve.count_primes(), 78498)
+
+    def test_limit_10_000_000(self):
+        sieve = PrimeSieve(10_000_000)
+        sieve.run_sieve()
+        self.assertEqual(sieve.count_primes(), 664579)
+
+    def test_limit_100_000_000(self):
+        sieve = PrimeSieve(100_000_000)
+        sieve.run_sieve()
+        self.assertEqual(sieve.count_primes(), 5761455)
+
+
+class TestGetPrimes(unittest.TestCase):
+
+    def count(self, primes):
+        return sum(1 for _ in primes)
+
+    def test_limit_0(self):
+        sieve = PrimeSieve(0)
+        sieve.run_sieve()
+        primes = list(sieve.get_primes())
+        self.assertEqual(primes, [])
+
+    def test_limit_1(self):
+        sieve = PrimeSieve(1)
+        sieve.run_sieve()
+        primes = list(sieve.get_primes())
+        self.assertEqual(primes, [])
+
+    def test_limit_2(self):
+        sieve = PrimeSieve(2)
+        sieve.run_sieve()
+        primes = list(sieve.get_primes())
+        self.assertEqual(primes, [2])
+
+    def test_prime_limit(self):
+        sieve = PrimeSieve(11)
+        sieve.run_sieve()
+        primes = list(sieve.get_primes())
+        self.assertEqual(primes, [2,3,5,7,11])
+
+    def test_limit_with_odd_sqr(self):
+        sieve = PrimeSieve(25)
+        sieve.run_sieve()
+        primes = list(sieve.get_primes())
+        self.assertEqual(primes, [2,3,5,7,11,13,17,19,23])
+
+    def test_limit_10(self):
+        sieve = PrimeSieve(10)
+        sieve.run_sieve()
+        primes = list(sieve.get_primes())
+        self.assertEqual(primes, [2,3,5,7])
+
+    #Lists are too big starting from this point, checking only length
+    def test_limit_100(self):
+        sieve = PrimeSieve(100)
+        sieve.run_sieve()
+        primes_len = self.count(sieve.get_primes())
+        self.assertEqual(primes_len, 25)
+
+    def test_limit_1000(self):
+        sieve = PrimeSieve(1000)
+        sieve.run_sieve()
+        primes_len = self.count(sieve.get_primes())
+        self.assertEqual(primes_len, 168)
+
+    def test_limit_10_000(self):
+        sieve = PrimeSieve(10_000)
+        sieve.run_sieve()
+        primes_len = self.count(sieve.get_primes())
+        self.assertEqual(primes_len, 1229)
+
+    def test_limit_100_000(self):
+        sieve = PrimeSieve(100_000)
+        sieve.run_sieve()
+        primes_len = self.count(sieve.get_primes())
+        self.assertEqual(primes_len, 9592)
+
+    def test_limit_1_000_000(self):
+        sieve = PrimeSieve(1_000_000)
+        sieve.run_sieve()
+        primes_len = self.count(sieve.get_primes())
+        self.assertEqual(primes_len, 78498)
+
+    def test_limit_10_000_000(self):
+        sieve = PrimeSieve(10_000_000)
+        sieve.run_sieve()
+        primes_len = self.count(sieve.get_primes())
+        self.assertEqual(primes_len, 664579)
+
+    def test_limit_100_000_000(self):
+        sieve = PrimeSieve(100_000_000)
+        sieve.run_sieve()
+        primes_len = self.count(sieve.get_primes())
+        self.assertEqual(primes_len, 5761455)
+
+
+class TestPrintResults(unittest.TestCase):
+
+    def get_print_results_output(self, sieve, show_results, time, passes):
+        with patch("sys.stdout", new=StringIO()) as out:
+            sieve.print_results(show_results, time, passes)
+            output = out.getvalue()
+        return output
+
+    def parse_results(self, results):
+        return dict(map(lambda x: str.split(x, ": "), results.split(", ")))
+
+    def test_format(self):
+        sieve = PrimeSieve(10)
+        sieve.run_sieve()
+        output = self.get_print_results_output(sieve, False, 100, 1000)
+
+        lines = output.split("\n")
+        self.assertEqual(len(lines), 2)
+
+        parsed_keys = self.parse_results(output).keys()
+        self.assertEqual(len(parsed_keys), 6)
+
+    def test_passes(self):
+        sieve = PrimeSieve(10)
+        sieve.run_sieve()
+
+        output = self.get_print_results_output(sieve, False, 100, 1000)
+        results = self.parse_results(output)
+        self.assertIn("Passes", results)
+        self.assertEqual(results["Passes"], "1000")
+
+        output = self.get_print_results_output(sieve, False, 100, 123)
+        results = self.parse_results(output)
+        self.assertIn("Passes", results)
+        self.assertEqual(results["Passes"], "123")
+
+    def test_time(self):
+        sieve = PrimeSieve(10)
+        sieve.run_sieve()
+
+        output = self.get_print_results_output(sieve, False, 100, 1000)
+        results = self.parse_results(output)
+        self.assertIn("Time", results)
+        self.assertEqual(results["Time"], "100")
+
+        output = self.get_print_results_output(sieve, False, 42, 1000)
+        results = self.parse_results(output)
+        self.assertIn("Time", results)
+        self.assertEqual(results["Time"], "42")
+
+    def test_avg(self):
+        sieve = PrimeSieve(10)
+        sieve.run_sieve()
+
+        output = self.get_print_results_output(sieve, False, 100, 1000)
+        results = self.parse_results(output)
+        self.assertIn("Avg", results)
+        self.assertEqual(float(results["Avg"]), 0.1)
+
+        output = self.get_print_results_output(sieve, False, 100, 25)
+        results = self.parse_results(output)
+        self.assertIn("Avg", results)
+        self.assertEqual(float(results["Avg"]), 4)
+
+    def test_limit(self):
+        sieve = PrimeSieve(10)
+        sieve.run_sieve()
+
+        output = self.get_print_results_output(sieve, False, 1, 1)
+        results = self.parse_results(output)
+        self.assertIn("Limit", results)
+        self.assertEqual(results["Limit"], "10")
+
+        sieve = PrimeSieve(13)
+        sieve.run_sieve()
+
+        output = self.get_print_results_output(sieve, False, 1, 1)
+        results = self.parse_results(output)
+        self.assertIn("Limit", results)
+        self.assertEqual(results["Limit"], "13")
+
+    def test_count(self):
+        sieve = PrimeSieve(10)
+        sieve.run_sieve()
+
+        sieve.get_primes = lambda: (i for i in range(3))
+        output = self.get_print_results_output(sieve, False, 1, 1)
+        results = self.parse_results(output)
+        self.assertIn("Count", results)
+        self.assertEqual(results["Count"], "3")
+
+        sieve.get_primes = lambda: (i for i in range(10))
+        output = self.get_print_results_output(sieve, False, 1, 1)
+        results = self.parse_results(output)
+        self.assertIn("Count", results)
+        self.assertEqual(results["Count"], "10")
+
+    def test_valid(self):
+        sieve = PrimeSieve(10)
+        sieve.run_sieve()
+
+        sieve.validate_results = lambda: True
+        output = self.get_print_results_output(sieve, False, 1, 1)
+        results = self.parse_results(output)
+        self.assertIn("Valid", results)
+        self.assertEqual(results["Valid"], "True\n")
+
+        sieve.validate_results = lambda: False
+        output = self.get_print_results_output(sieve, False, 1, 1)
+        results = self.parse_results(output)
+        self.assertIn("Valid", results)
+        self.assertEqual(results["Valid"], "False\n")
+
+    def test_show_results(self):
+        sieve = PrimeSieve(10)
+        sieve.run_sieve()
+        output = self.get_print_results_output(sieve, True, 1, 1)
+
+        primes = output.split("\n")[0].strip().split(",")
+        if primes[-1] == "":  # There may be a trailing comma
+            primes.pop()
+
+        primes = list(map(str.strip, primes))
+        self.assertEqual(primes, ["2","3","5","7"])


### PR DESCRIPTION
# Results from my machine

 - AMD A4-3305M 1.9 GHz (Windows 7 64 bit)
 - Python: 3.8.1 64 bit
 - PyPy: 7.3.3
 - g++: 9.2.0

Passes, average over 10 runs, 10 sec. duration each
-
|Limit      |Python     |PyPy        |Python (original)|PyPy (original)|C#         |C++
|-----------|-----------|------------|-----------------|---------------|-----------|-----------
|10         |1'460'684.6|14'054'698.3|      1'341'886.6|   20'563'347.0|9'012'584.3|3'441'332.0
|100        |  654'359.3| 7'479'784.3|        238'464.1|    4'057'462.0|6'913'831.5|1'766'864.4
|1000       |  309'068.4| 1'997'727.7|         22'573.2|      549'117.2|1'728'762.2|1'353'130.4
|10000      |  118'406.0|   285'541.6|          1'937.1|       49'720.8|  171'218.5|  504'840.4
|100000     |   28'074.0|    26'177.5|            166.2|        3'161.2|   15'153.7|   63'118.2
|**1000000**|**2'222.2**| **1'710.4**|         **14.8**|      **203.8**|**1'377.7**|**4'870.8**
|10000000   |       98.1|        86.7|              2.0|           15.0|      107.2|      193.5
|100000000  |        7.3|         7.0|             1.0*|            2.0|        8.0|       14.0

Passes/sec., average over 10 runs
-
|Limit      |Python       |PyPy           |Python (original)|PyPy (original)|C#           |C++
|-----------|-------------|---------------|-----------------|---------------|-------------|-------------
|10         |146'068.41190|1'405'459.97299|    134'188.61218|2'056'315.06029|901'206.88097|344'133.20000
|100        | 65'435.74311|  747'974.69452|     23'846.33893|  405'743.77278|691'343.60515|176'686.44000
|1000       | 30'906.63142|  199'771.71623|      2'257.27410|   54'911.30435|172'866.33205|135'313.04000
|10000      | 11'840.54234|   28'553.94879|        193.64954|    4'972.00489| 17'120.87069| 50'484.04000
|100000     |  2'807.29283|    2'617.65142|         16.58595|      316.07127|  1'515.28333|  6'311.82000
|**1000000**|**222.16822**|  **170.97555**|      **1.42078**|   **20.32647**|**137.71392**|**487.08000**
|10000000   |      9.76870|        8.60671|          0.12896|        1.46159|     10.67402|     19.35000
|100000000  |      0.69502|        0.65422|         0.01194*|        0.11842|      0.72642|      1.40000

_*Avg. over 3 runs. I wasn't patient enough._

This implementation doesn't show significant performance on low limits, which is expectable. But then, as more and more work is delegated to Python's built-in methods, it becomes faster, with performance peaks at limits 100'000 and 1'000'000. Then performance somewhat drops again, but not much. I'm not 100% sure why, but my guess is the bytearray begins to take too much memory to fit in the cpu cache.

Also, PyPy seems to do an amazing job optimizing things which CPython is slow at. But there are some things, like slice assignment, that are faster in CPython.