### PR TITLE
Start from square of factor

### DIFF
--- a/PrimePHP/PrimePHP.php
+++ b/PrimePHP/PrimePHP.php
@@ -61,7 +61,7 @@ class PrimeSieve
                 }
             }
 
-            for ($i = $factor * 3; $i <= $this->sieveSize; $i += $factor * 2) {
+            for ($i = $factor * $factor; $i <= $this->sieveSize; $i += $factor * 2) {
                 $this->clearBit($i);
             }
 

--- a/PrimeSieveCS/PrimeCS.cs
+++ b/PrimeSieveCS/PrimeCS.cs
@@ -85,10 +85,14 @@ namespace PrimeSieveCS
                         }
                     }
 
-                    // If marking factor 3, you wouldn't mark 6 (it's a mult of 2) so start with the 3rd instance of this factor's multiple.
+                    // If marking factor 3, you wouldn't mark 6 (it's a mult of 2).
+                    // Similarly, if marking factor 5, you wouldn't mark 10 (it's a mult of 2), 15 (it's a mult of 3), or 20 (it's a mult of 2).
+                    // For any factor X, any of it's multiples below the smallest prime number that we haven't yet found,
+                    // which happens to be itself, will already be marked.
+                    // So start with the square of this factor.
                     // We can then step by factor * 2 because every second one is going to be even by definition
 
-                    for (int num = factor * 3; num <= this.sieveSize; num += factor * 2)
+                    for (int num = factor * factor; num <= this.sieveSize; num += factor * 2)
                         ClearBit(num);
 
                     factor += 2;

--- a/PrimeSieveDelphi/PrimePas.dpr
+++ b/PrimeSieveDelphi/PrimePas.dpr
@@ -177,9 +177,13 @@ begin
 			end;
 		end;
 
-		// If marking factor 3, you wouldn't mark 6 (it's a mult of 2) so start with the 3rd instance of this factor's multiple.
+		// If marking factor 3, you wouldn't mark 6 (it's a mult of 2).
+		// Similarly, if marking factor 5, you wouldn't mark 10 (it's a mult of 2), 15 (it's a mult of 3), or 20 (it's a mult of 2).
+		// For any factor X, any of it's multiples below the smallest prime number that we haven't yet found,
+		// which happens to be itself, will already be marked.
+		// So start with the square of this factor.
 		// We can then step by factor * 2 because every second one is going to be even by definition
-		num := factor*3;
+		num := factor*factor;
 		while num <= FSieveSize do
 		begin
 			ClearBit(num);

--- a/PrimeSieveJava/PrimeSieveJava/src/main/java/PrimeSieveJava.java
+++ b/PrimeSieveJava/PrimeSieveJava/src/main/java/PrimeSieveJava.java
@@ -72,7 +72,7 @@ public class PrimeSieveJava
 				}
 			}
 			
-			for (int num = factor * 3; num <= sieveSize; num += factor * 2)
+			for (int num = factor * factor; num <= sieveSize; num += factor * 2)
 				clearBit(num);
 			
 			factor += 2;

--- a/PrimeSieveJulia/PrimeSieveJulia.jl
+++ b/PrimeSieveJulia/PrimeSieveJulia.jl
@@ -34,7 +34,7 @@ function runSieve!(sieve::prime_sieve)
 			end
 		end
 
-		for num in factor*3:factor*2:sieve.sieveSize
+		for num in factor*factor:factor*2:sieve.sieveSize
 			sieve.rawbits[Int((num+1)/2)] = false
 		end
 

--- a/PrimeSieveLisp/PrimeSieve.lisp
+++ b/PrimeSieveLisp/PrimeSieve.lisp
@@ -54,7 +54,7 @@
             )
         )
         (loop for num from 
-            (* factor 3) to sieveSize by 
+            (* factor factor) to sieveSize by 
             (* factor 2) do 
             (clear-bit num))
         (setq factor 

--- a/PrimeSievePY/PrimePY.py
+++ b/PrimeSievePY/PrimePY.py
@@ -78,10 +78,14 @@ class prime_sieve(object):
                     factor = num
                     break
 
-            # If marking factor 3, you wouldn't mark 6 (it's a mult of 2) so start with the 3rd instance of this factor's multiple.
+            # If marking factor 3, you wouldn't mark 6 (it's a mult of 2).
+            # Similarly, if marking factor 5, you wouldn't mark 10 (it's a mult of 2), 15 (it's a mult of 3), or 20 (it's a mult of 2).
+            # For any factor X, any of it's multiples below the smallest prime number that we haven't yet found,
+            # which happens to be itself, will already be marked.
+            # So start with the square of this factor.
             # We can then step by factor * 2 because every second one is going to be even by definition
 
-            for num in range (factor * 3, this.sieveSize, factor * 2): 
+            for num in range (factor * factor, this.sieveSize, factor * 2): 
                 this.ClearBit(num)
 
             factor += 2 # No need to check evens, so skip to next odd (factor = 3, 5, 7, 9...)


### PR DESCRIPTION
Half of the implemented languages start from the square of `factor` when a new prime is found, which is a valid optimization. However, the other half did not, which is unfair for them when comparing performance.
Comparison in C# (.Net Core 3.1 x64):
Start at `factor*3`: `Passes: 5267, Time: 10.0007961, Avg: 0.0018987651604328842, Limit: 1000000, Count: 78498, Valid: True`
Start at `factor*factor`: `Passes: 5539, Time: 10.0009852, Avg: 0.0018055578985376422, Limit: 1000000, Count: 78498, Valid: True`