### PR TITLE
Use System.Diagnostics.Stopwatch

### DIFF
--- a/PrimeSieveCS/PrimeCS.cs
+++ b/PrimeSieveCS/PrimeCS.cs
@@ -24,10 +24,10 @@ namespace PrimeSieveCS
                 { 100000 , 9592 },
                 { 1000000 , 78498 },
                 { 10000000 , 664579 },
-                { 100000000 , 5761455 } 
+                { 100000000 , 5761455 },
             };
 
-            public prime_sieve(int size) 
+            public prime_sieve(int size)
             {
                 sieveSize = size;
                 bitArray = new BitArray((int)((this.sieveSize + 1) / 2), true);
@@ -63,17 +63,17 @@ namespace PrimeSieveCS
                     Console.WriteLine("You are setting even bits, which is sub-optimal");
                     return;
                 }
-                bitArray[index / 2] = false;      
+                bitArray[index / 2] = false;
             }
 
             // primeSieve
-            // 
+            //
             // Calculate the primes up to the specified limit
 
             public void runSieve()
             {
                 int factor = 3;
-                int q = (int) Math.Sqrt(this.sieveSize);
+                int q = (int)Math.Sqrt(this.sieveSize);
 
                 while (factor < q)
                 {

--- a/PrimeSieveCS/PrimeCS.cs
+++ b/PrimeSieveCS/PrimeCS.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace PrimeSieveCS
 {
@@ -116,22 +117,23 @@ namespace PrimeSieveCS
             }
         }
 
+        private const long TEN_SECONDS = 10 * 1000;
+
         static void Main(string[] args)
         {
-            var tStart = DateTime.UtcNow;
+            var watch = Stopwatch.StartNew();
             var passes = 0;
             prime_sieve sieve = null;
 
-            while ((DateTime.UtcNow - tStart).TotalSeconds < 10)
+            while (watch.ElapsedMilliseconds < TEN_SECONDS)
             {
                 sieve = new prime_sieve(1000000);
                 sieve.runSieve();
                 passes++;
             }
 
-            var tD = DateTime.UtcNow - tStart;
             if (sieve != null)
-                sieve.printResults(false, tD.TotalSeconds, passes);
+                sieve.printResults(false, watch.ElapsedMilliseconds / 1000.0, passes);
         }
     }
 }

--- a/PrimeSieveCS/PrimeCS.cs
+++ b/PrimeSieveCS/PrimeCS.cs
@@ -117,15 +117,13 @@ namespace PrimeSieveCS
             }
         }
 
-        private const long TEN_SECONDS = 10 * 1000;
-
         static void Main(string[] args)
         {
             var watch = Stopwatch.StartNew();
             var passes = 0;
             prime_sieve sieve = null;
 
-            while (watch.ElapsedMilliseconds < TEN_SECONDS)
+            while (watch.ElapsedMilliseconds < 5000)
             {
                 sieve = new prime_sieve(1000000);
                 sieve.runSieve();


### PR DESCRIPTION
In C#, instead of manually calculating the elapsed time using `System.DateTime.UtcNow`, we can use the built in `System.Diagnostics.Stopwatch` for potentially better readibility, though it is subjective imo