### PR TITLE
Normalize runtime to 5 seconds

### DIFF
--- a/PrimePHP/PrimePHP.php
+++ b/PrimePHP/PrimePHP.php
@@ -85,12 +85,12 @@ class PrimeSieve
 }
 
 //Entry
-$tStart = microtime(true);       //Init time
+$tStart = microtime(true);              //Init time
 $passes = 0;                            //Init passes
 $sieveSize = 1000000;                   //Set sieve size
 $printResults = false;                  //Print the prime numbers that are found
 $rawbitCount = null;                    //Init a rawbitCount to validate the result
-$runTime = 10;                          //The amount of seconds the script should be running for
+$runTime = 5;                           //The amount of seconds the script should be running for
 
 while (getTimeDiffInMs($tStart) < $runTime * 1000) {
     $sieve = new PrimeSieve($sieveSize);

--- a/PrimeSieveCS/PrimeCS.cs
+++ b/PrimeSieveCS/PrimeCS.cs
@@ -122,7 +122,7 @@ namespace PrimeSieveCS
             var passes = 0;
             prime_sieve sieve = null;
 
-            while ((DateTime.UtcNow - tStart).TotalSeconds < 10)
+            while ((DateTime.UtcNow - tStart).TotalSeconds < 5)
             {
                 sieve = new prime_sieve(1000000);
                 sieve.runSieve();

--- a/PrimeSieveDelphi/PrimePas.dpr
+++ b/PrimeSieveDelphi/PrimePas.dpr
@@ -229,7 +229,7 @@ begin
 	passes := 0;
 
 	sieve := nil;
-	while TTimeSpan.Subtract(Now, dtStart).TotalSeconds < 10 do
+	while TTimeSpan.Subtract(Now, dtStart).TotalSeconds < 5 do
 	begin
 		if Assigned(sieve) then
 			sieve.Free;

--- a/PrimeSieveJava/PrimeSieveJava/src/main/java/PrimeSieveJava.java
+++ b/PrimeSieveJava/PrimeSieveJava/src/main/java/PrimeSieveJava.java
@@ -114,7 +114,7 @@ public class PrimeSieveJava
 		int passes = 0;
 		PrimeSieveJava sieve = null;
 		
-		while ((System.currentTimeMillis() - start) < 10000)
+		while ((System.currentTimeMillis() - start) < 5000)
 		{
 			sieve = new PrimeSieveJava(1000000);
 			sieve.runSieve();

--- a/PrimeSieveLisp/PrimeSieve.lisp
+++ b/PrimeSieveLisp/PrimeSieve.lisp
@@ -71,7 +71,7 @@
     (get-universal-time))
 (loop 
     (if 
-        (<= (- (get-universal-time) start) 10)
+        (<= (- (get-universal-time) start) 5)
         (progn
             (prime-sieve 1000000)
             (run-sieve)

--- a/PrimeSievePY/PrimePY.py
+++ b/PrimeSievePY/PrimePY.py
@@ -119,12 +119,12 @@ class prime_sieve(object):
 tStart = timeit.default_timer()                         # Record our starting time
 passes = 0                                              # We're going to count how many passes we make in fixed window of time
 
-while (timeit.default_timer() - tStart < 10):           # Run until more than 10 seconds have elapsed
+while (timeit.default_timer() - tStart < 5):            # Run until more than 5 seconds have elapsed
     sieve = prime_sieve(1000000)                        #  Calc the primes up to a million
     sieve.runSieve()                                    #  Find the results
     passes = passes + 1                                 #  Count this pass
     
-tD = timeit.default_timer() - tStart                    # After the "at least 10 seconds", get the actual elapsed
+tD = timeit.default_timer() - tStart                    # After the "at least 5 seconds", get the actual elapsed
 
 sieve.printResults(False, tD, passes)                   # Display outcome
 

--- a/PrimeSieveSwift/Sources/PrimeSieveSwift/main.swift
+++ b/PrimeSieveSwift/Sources/PrimeSieveSwift/main.swift
@@ -118,7 +118,7 @@ let start = Date()
 var passes = 0
 var sieve: PrimeSieveSwift!
 
-while start.distance(to: Date()) < 10 {
+while start.distance(to: Date()) < 5 {
     sieve = PrimeSieveSwift(limit: 1_000_000)
     sieve.runSieve()
     passes += 1


### PR DESCRIPTION
Some implementations (namely in lisp, py swift, delphi, java, php and c#) run the benchmark for 10 seconds, while the rest run for 5 seconds.