### PR TITLE
Benchmark and CI workflow separation

### DIFF
--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: "0 20 * * *"
   workflow_dispatch:
-  
+
 jobs:
   test:
     runs-on: "${{ matrix.os }}"
@@ -16,7 +16,7 @@ jobs:
           - PrimeCrystal/stl-faithful/marghidanu
           - PrimeRust/stl-faithful/mike-barber
         os: ["ubuntu-20.04"]
-    
+
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v2
@@ -32,12 +32,12 @@ jobs:
         run: |
           cd "${{ matrix.solution }}"
           docker build -t "${{ steps.solution-name.outputs.normalized }}" .
-      
+
       - name: "Run tests"
         continue-on-error: true
         run: |
           docker run --rm "${{ steps.solution-name.outputs.normalized }}" | tee "${{ steps.solution-name.outputs.normalized }}-${{ matrix.os }}.out"
-      
+
       - name: "Upload artifacts"
         uses: actions/upload-artifact@v2
         with:
@@ -47,12 +47,12 @@ jobs:
   report:
     runs-on: ubuntu-latest
 
-    needs: 
+    needs:
       - test
 
     steps:
       - name: "Download artifacts"
         uses: actions/download-artifact@v2
-      
+
       - name: "List all artifacts"
         run: tree

--- a/.github/workflows/Benchmark.yml
+++ b/.github/workflows/Benchmark.yml
@@ -1,0 +1,58 @@
+name: Benchmark
+
+on:
+  schedule:
+    - cron: "0 20 * * *"
+  workflow_dispatch:
+  
+jobs:
+  test:
+    runs-on: "${{ matrix.os }}"
+
+    strategy:
+      max-parallel: 1
+      matrix:
+        solution:
+          - PrimeCrystal/stl-faithful/marghidanu
+          - PrimeRust/stl-faithful/mike-barber
+        os: ["ubuntu-20.04"]
+    
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@v2
+
+      - name: "Normalize solution name"
+        id: solution-name
+        run: |
+          NAME=$(echo "${{ matrix.solution }}" | sed -r 's/\//_/g' | tr '[:upper:]' '[:lower:]')
+          echo "::set-output name=normalized::${NAME}"
+
+      - name: "Build container image"
+        continue-on-error: true
+        run: |
+          cd "${{ matrix.solution }}"
+          docker build -t "${{ steps.solution-name.outputs.normalized }}" .
+      
+      - name: "Run tests"
+        continue-on-error: true
+        run: |
+          docker run --rm "${{ steps.solution-name.outputs.normalized }}" | tee "${{ steps.solution-name.outputs.normalized }}-${{ matrix.os }}.out"
+      
+      - name: "Upload artifacts"
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.solution-name.outputs.normalized }}
+          path: "*.out"
+
+  report:
+    runs-on: ubuntu-latest
+
+    needs: 
+      - test
+
+    steps:
+      - name: "Download artifacts"
+        uses: actions/download-artifact@v2
+      
+      - name: "List all artifacts"
+        run: tree

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,24 +2,20 @@ name: CI
 
 on:
   push:
-    branches: [ drag-race ]
+    branches: [drag-race]
   pull_request:
-    branches: [ drag-race ]
-    
-  workflow_dispatch:
-  
+    branches: [drag-race]
+
 jobs:
-  test:
-    runs-on: "${{ matrix.os }}"
+  build:
+    runs-on: ubuntu-20.04
 
     strategy:
-      max-parallel: 1
       matrix:
         solution:
           - PrimeCrystal/stl-faithful/marghidanu
           - PrimeRust/stl-faithful/mike-barber
-        os: ["ubuntu-20.04"]
-    
+
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v2
@@ -31,31 +27,6 @@ jobs:
           echo "::set-output name=normalized::${NAME}"
 
       - name: "Build container image"
-        continue-on-error: true
         run: |
           cd "${{ matrix.solution }}"
           docker build -t "${{ steps.solution-name.outputs.normalized }}" .
-      
-      - name: "Run tests"
-        continue-on-error: true
-        run: |
-          docker run --rm "${{ steps.solution-name.outputs.normalized }}" | tee "${{ steps.solution-name.outputs.normalized }}-${{ matrix.os }}.out"
-      
-      - name: "Upload artifacts"
-        uses: actions/upload-artifact@v2
-        with:
-          name: ${{ steps.solution-name.outputs.normalized }}
-          path: "*.out"
-
-  report:
-    runs-on: ubuntu-latest
-
-    needs: 
-      - test
-
-    steps:
-      - name: "Download artifacts"
-        uses: actions/download-artifact@v2
-      
-      - name: "List all artifacts"
-        run: tree

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [drag-race]
+    branches: ["**"]
   pull_request:
-    branches: [drag-race]
+    branches: ["**"]
 
 jobs:
   build:


### PR DESCRIPTION
## Description

This is directly related to #130. It will use the CI job to build the Docker images for designated solutions on each push or pull request. These jobs will run parallel using GitHub runners.

Additionally, I've added a Benchmark job that is scheduled to run daily to build and run the designated implementations. This job will eventually collect and generate the execution report once we standardize on the duration of execution, standard output, and the number of iterations.

