### PR TITLE
Corrected typo in Historical data

### DIFF
--- a/PrimePython/stl-faithful/davepl/PrimePY.py
+++ b/PrimePython/stl-faithful/davepl/PrimePY.py
@@ -17,7 +17,7 @@ class prime_sieve(object):
     rawbits = None   # Storage for sieve - since we filter evens, just half as many bits
     sieveSize = 0    # Upper limit, highest prime we'll consider
 
-    primeCounts = { 10 : 1,                 # Historical data for validating our results - the number of primes
+    primeCounts = { 10 : 4,                 # Historical data for validating our results - the number of primes
                     100 : 25,               # to be found under some limit, such as 168 primes under 1000
                     1000 : 168,
                     10000 : 1229,


### PR DESCRIPTION
## Description

The historical data in the Python version had 1 prime number under 10 instead of 4

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct category folder.
* [ ] I added a README.md or Dockerfile.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.

