### PR TITLE
Explicitly convert duration to double.

### DIFF
--- a/PrimeCPP/PrimeCPP.cpp
+++ b/PrimeCPP/PrimeCPP.cpp
@@ -127,7 +127,7 @@ int main()
         passes++;
         if (duration_cast<seconds>(steady_clock::now() - tStart).count() >= 5)
         {
-            sieve.printResults(false, duration_cast<microseconds>(steady_clock::now() - tStart).count() / 1000000, passes);
+            sieve.printResults(false, static_cast<double>(duration_cast<microseconds>(steady_clock::now() - tStart).count() / 1000000), passes);
             break;
         }
     } 


### PR DESCRIPTION
## Description

Since we're only expecting values in the order of 5, this should be
fine. This fixes the warning C4244 on MSVC Version 19.28.29914.

Machine code produced is the same before and after.

## Contributing requirements

* [Yes] I read the contribution guidelines in CONTRIBUTING.md.
* [N/A] I placed my solution in the correct category folder.
* [N/A] I added a README.md or Dockerfile.
* [N/A] I selected `drag-race` as the target branch.
* [Yes] All code herein is licensed compatible with BSD-3.

