### PR TITLE
Faster OCaml Docker builds

### DIFF
--- a/PrimeOCaml/solution_1/Dockerfile
+++ b/PrimeOCaml/solution_1/Dockerfile
@@ -1,22 +1,15 @@
-FROM ocaml/opam:alpine AS Build
+FROM boord/ocaml:4.12-r1 AS build
 
-WORKDIR primeocaml
+WORKDIR /home/opam/primeocaml
 
-RUN sudo apk add linux-headers
+COPY *.ml ./
 
-RUN opam install ocamlbuild
-RUN opam install core
-
-ENV PATH="/home/opam/.opam/4.12/bin:${PATH}"
-
-ADD . .
-
-RUN sudo chown -R opam:nogroup .
+# RUN sudo chown -R opam:nogroup .
 RUN corebuild PrimeOCaml.native
 
-FROM alpine
+FROM alpine:3.13
 
 WORKDIR /app
 COPY --from=build /home/opam/primeocaml/PrimeOCaml.native PrimeOCaml.native
 
-CMD ./PrimeOCaml.native
+ENTRYPOINT [ "./PrimeOCaml.native" ]

--- a/PrimeOCaml/solution_1/Dockerfile
+++ b/PrimeOCaml/solution_1/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /home/opam/primeocaml
 
 COPY *.ml ./
 
-# RUN sudo chown -R opam:nogroup .
+RUN sudo chown -R opam:nogroup .
 RUN corebuild PrimeOCaml.native
 
 FROM alpine:3.13

--- a/PrimeOCaml/solution_2/Dockerfile
+++ b/PrimeOCaml/solution_2/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /home/opam/primeocaml
 
 COPY *.ml ./
 
-# RUN sudo chown -R opam:nogroup .
+RUN sudo chown -R opam:nogroup .
 RUN corebuild PrimeOCamlFunctional.native
 
 FROM alpine:3.13

--- a/PrimeOCaml/solution_2/Dockerfile
+++ b/PrimeOCaml/solution_2/Dockerfile
@@ -1,22 +1,15 @@
-FROM ocaml/opam:alpine AS Build
+FROM boord/ocaml:4.12-r1 AS build
 
-WORKDIR primeocaml
+WORKDIR /home/opam/primeocaml
 
-RUN sudo apk add linux-headers
+COPY *.ml ./
 
-RUN opam install ocamlbuild
-RUN opam install core
-
-ENV PATH="/home/opam/.opam/4.12/bin:${PATH}"
-
-ADD . .
-
-RUN sudo chown -R opam:nogroup .
+# RUN sudo chown -R opam:nogroup .
 RUN corebuild PrimeOCamlFunctional.native
 
-FROM alpine
+FROM alpine:3.13
 
 WORKDIR /app
 COPY --from=build /home/opam/primeocaml/PrimeOCamlFunctional.native PrimeOCamlFunctional.native
 
-CMD ./PrimeOCamlFunctional.native
+ENTRYPOINT [ "./PrimeOCamlFunctional.native" ]


### PR DESCRIPTION
Initially, the OCaml Docker builds were between 8-9 minutes. I've created a separate image to deal with the dependencies and used it as a base image. The repository for the base images is available here: https://github.com/marghidanu/docker-ocaml

Pre-built images are available for **amd64** and **arm64**.