### PR TITLE
Small conformity fixes

### DIFF
--- a/PrimeRust/solution_4/Dockerfile
+++ b/PrimeRust/solution_4/Dockerfile
@@ -1,7 +1,13 @@
-FROM rust:1.51
+FROM rfvanbergen/rust AS build
 
 WORKDIR /app
 COPY . .
 
 RUN rustc -C opt-level=3 PrimeRust.rs
-CMD ["./PrimeRust"]
+
+FROM alpine:3.13
+WORKDIR /app
+
+# app and configuration
+COPY --from=build /app/PrimeRust PrimeRust
+ENTRYPOINT [ "./PrimeRust" ]

--- a/PrimeZig/solution_1/src/main.zig
+++ b/PrimeZig/solution_1/src/main.zig
@@ -28,5 +28,5 @@ pub fn main() anyerror!void {
 
     // Following 2 lines added by rbergen to conform to drag race output format
     print("\n", .{});
-    print("devblok;{};{d:.5};1\n", .{ passes, elapsed });
+    try std.io.getStdOut().writer().print("devblok;{};{d:.5};1\n", .{ passes, elapsed });
 }


### PR DESCRIPTION
- Based the PrimeRust/solution_4 Dockerfile on the same base image as the other Rust solutions
- Made PrimeZig/solution_1 put the guideline-compliant output line to stdout 