### PR TITLE
Make C++ reported times accurate.

### DIFF
--- a/PrimeCPP/solution_1/PrimeCPP.cpp
+++ b/PrimeCPP/solution_1/PrimeCPP.cpp
@@ -129,9 +129,11 @@ int main()
         prime_sieve sieve(1000000L);
         sieve.runSieve();
         passes++;
-        if (duration_cast<seconds>(steady_clock::now() - tStart).count() >= 5)
+	auto tEnd = steady_clock::now() - tStart;
+        if (duration_cast<seconds>(tEnd).count() >= 5)
         {
-            sieve.printResults(false, duration_cast<microseconds>(steady_clock::now() - tStart).count() / 1000000, passes);
+  	    std::chrono::duration<double, std::micro> tEnd_micro = tEnd;
+            sieve.printResults(false, tEnd_micro.count() / 1000000, passes);
             break;
         }
     } 

--- a/PrimeCPP/solution_2/PrimeCPP.cpp
+++ b/PrimeCPP/solution_2/PrimeCPP.cpp
@@ -150,7 +150,8 @@ int main()
     
     prime_sieve checkSieve(UPPER_LIMIT);
     checkSieve.runSieve();
-    checkSieve.printResults(false, duration_cast<microseconds>(tEnd).count() / 1000000.0, passes);
+    std::chrono::duration<double, std::micro> tEnd_micro = tEnd;
+    checkSieve.printResults(false, tEnd_micro.count() / 1000000.0, passes);
 
     return checkSieve.validateResults();
 }


### PR DESCRIPTION
## Description
On the drag-race branch, the C++ benchmarks round the reported times.
This PR reports them accurately.
On this PR, I get:
```sh
> g++ -march=native -mprefer-vector-width=512 -Ofast PrimeCPP.cpp
> ./a.out
Passes: 8584, Time: 5.000523, Avg: 0.000583, Limit: 1000000, Count1: 78498, Count2: 78498, Valid: 1

davepl;8584;5.000523;1
> cd ../solution_2
> g++ -march=native -mprefer-vector-width=512 -Ofast PrimeCPP.cpp -pthread
> ./a.out
Passes: 97272, Threads: 36, Time: 5.000744, Avg: 0.000051, Limit: 1000000, Count1: 78498, Count2: 78498, Valid: 1

davepl_par;97272;5.000744;36
```

* [ ] I read the contribution guidelines in CONTRIBUTING.md.
* [ ] I placed my solution in the correct solution folder.
* [ ] I added a README.md with the right category badge(s).
* [ ] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
