### PR TITLE
Fix duration calculation rounding error in PrimeCPP/solution_1

### DIFF
--- a/PrimeCPP/solution_1/PrimeCPP.cpp
+++ b/PrimeCPP/solution_1/PrimeCPP.cpp
@@ -131,7 +131,7 @@ int main()
         passes++;
         if (duration_cast<seconds>(steady_clock::now() - tStart).count() >= 5)
         {
-            sieve.printResults(false, duration_cast<microseconds>(steady_clock::now() - tStart).count() / 1000000, passes);
+            sieve.printResults(false, duration_cast<microseconds>(steady_clock::now() - tStart).count() / 1000000.0, passes);
             break;
         }
     } 


### PR DESCRIPTION
The run duration in PrimeCPP/solution_1 was calculated with an integer divide, which makes that the result was always an integer value (i.e. 5). This replaces the integer divide with a float one.

PRs to fix this issue were initially opened by @fatho and  @chriselrod, in that order.