### PR TITLE
Go: match bit twiddle memory handling to reduce cache pressure

### DIFF
--- a/PrimeGo/solution_1/main.go
+++ b/PrimeGo/solution_1/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"math"
 	"time"
@@ -17,28 +18,35 @@ var myDict = map[int]int{
 	1e8: 5761455,
 }
 
-func (s *Sieve) runSieve() {
-	factor := 3
-	var q = int(math.Sqrt(float64(s.sieveSize)))
+type Sieve struct {
+	sieveSize int
+	bitArray  []uint16
+}
 
-	for factor <= q {
-		for num := factor; num < s.sieveSize; num += 2 {
-			if s.bitArray[num] {
+func (s *Sieve) runSieve() {
+	q := int(math.Sqrt(float64(s.sieveSize)))
+
+	for factor := 3; factor <= q; factor += 2 {
+		for num := factor; num < s.sieveSize; {
+			if s.GetBit(num) {
 				factor = num
 				break
 			}
+			num += 2
 		}
 		for num := factor * factor; num < s.sieveSize; num += factor * 2 {
-			s.bitArray[num] = false
+			s.SetBit(num)
 		}
-		factor += 2
 	}
 }
 
-type Sieve struct {
-	sieveSize int
-	bitArray  []bool
-}
+const (
+	shift = 5
+	mask  = 0b1111
+)
+
+func (s Sieve) GetBit(i int) bool { return s.bitArray[i>>shift]&(1<<((i>>1)&mask)) == 0 }
+func (s Sieve) SetBit(i int)      { s.bitArray[i>>shift] |= (1 << ((i >> 1) & mask)) }
 
 func (s Sieve) Validate() bool {
 	count, ok := myDict[s.sieveSize]
@@ -46,46 +54,45 @@ func (s Sieve) Validate() bool {
 		return false
 	}
 	return count == s.countPrimes()
-
 }
 
 func (s Sieve) countPrimes() int {
 	count := 1
 	for i := 3; i < s.sieveSize; i += 2 {
-		if s.bitArray[i] {
+		if s.GetBit(i) {
 			count++
 		}
 	}
 	return count
 }
-func (s Sieve) Results(showResults bool, duration time.Duration, passes int) {
 
+func (s Sieve) Results(showResults bool, duration time.Duration, passes int) {
 	if showResults {
 		fmt.Printf("2, ")
 	}
 
 	count := 1
 	for num := 3; num <= s.sieveSize; num += 2 {
-		if s.bitArray[num] {
+		if s.GetBit(num) {
 			if showResults {
 				fmt.Printf("%d, ", num)
 			}
 			count++
 		}
 	}
-
 	if showResults {
 		fmt.Println()
 	}
 
-	fmt.Printf("Passes: %d, Time: %d, Avg: %f, Limit: %d, Count1: %d, Count2: %d, Valid: %v\n",
+	fmt.Printf("Passes: %d, Time: %v, Avg: %v, Limit: %d, Count1: %d, Count2: %d, Valid: %v\n",
 		passes,
 		duration,
-		float64(duration.Milliseconds()/int64(passes)),
+		time.Duration(int64(duration)/int64(passes)),
 		s.sieveSize,
 		count,           /* count */
 		s.countPrimes(), /* countPrimes() */
-		s.Validate() /* validateResults*/)
+		s.Validate(),    /* validateResults*/
+	)
 
 	// Following 2 lines added by rbergen to conform to drag race output format
 	fmt.Println()
@@ -93,20 +100,25 @@ func (s Sieve) Results(showResults bool, duration time.Duration, passes int) {
 }
 
 func main() {
+	var sz int
+	flag.IntVar(&sz, "size", 1e6, "enter the size as a multiple of 10")
+	flag.Parse()
+	run(sz)
+}
 
+func run(sz int) {
 	passes := 0
 	startClock := time.Now()
 
-	initBitArray := make([]bool, 1e6)
-	for i := range initBitArray {
-		initBitArray[i] = true
-	}
 	for {
-		sieve := Sieve{bitArray: initBitArray, sieveSize: 1e6}
+		sieve := Sieve{
+			bitArray:  make([]uint16, sz/32),
+			sieveSize: sz,
+		}
 		sieve.runSieve()
 		passes++
-		if time.Since(startClock).Seconds() >= 5 {
-			sieve.Results(false, time.Since(startClock), passes)
+		if t := time.Since(startClock); t.Seconds() >= 5 {
+			sieve.Results(false, t, passes)
 			break
 		}
 	}


### PR DESCRIPTION
## Description

Go's boolean slices are not compact bitmaps, but instead uint8 in
memory.  This means 7 of 8 bits are clogging cache without being
useful for the calculation.  Set and get using bit masking and
shifting.

Because Go memory is zeoroed on allocation, the bits are considered
"set" when they are zero.  This is the inverse of many other
implementations, due to how the Go runtime initializes memory.

Small bugfix included:  Array was only being initialized once, so the
subsequent passes were making non-op writes.  Each pass now allocates
new memory.


## Contributing requirements

* [X] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right category badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
