### PR TITLE
V: add -prod in the Dockerfile (turns on optimisation options) for a production build

### DIFF
--- a/PrimeV/solution_1/Dockerfile
+++ b/PrimeV/solution_1/Dockerfile
@@ -10,7 +10,7 @@ ENV PATH=/opt/vlang:$PATH
 WORKDIR /opt/app
 COPY *.v .
 
-RUN v primes.v
+RUN v -prod primes.v
 
 FROM alpine:3.13
 


### PR DESCRIPTION
## Description
V defaults to non optimised builds (to shorten the iteration cycle while developing).
The `-prod` flag is recommended when compiling for production / measuring performance.

## Contributing requirements
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [ ] I added a README.md with the right badge(s).
* [ ] I added a Dockerfile that builds and runs my solution.
* [ ] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
