### PR TITLE
Added missing COPY slash to Julia Dockerfiles

### DIFF
--- a/PrimeJulia/solution_1/Dockerfile
+++ b/PrimeJulia/solution_1/Dockerfile
@@ -2,6 +2,6 @@ FROM julia:1.6-alpine3.13
 
 WORKDIR /opt/app
 
-COPY *.jl .
+COPY *.jl ./
 
 ENTRYPOINT [ "julia", "PrimeSieveJulia.jl" ]

--- a/PrimeJulia/solution_2/Dockerfile
+++ b/PrimeJulia/solution_2/Dockerfile
@@ -2,6 +2,6 @@ FROM julia:1.6.1-alpine3.13
 
 WORKDIR /opt/app
 
-COPY *.jl .
+COPY *.jl ./
 
 ENTRYPOINT [ "julia", "Primes.jl" ]


### PR DESCRIPTION
The wildcard COPY in the Julia solution Dockerfiles didn't work outside of Docker Desktop contexts, because the target didn't end with a slash (/).