### PR TITLE
Fixed Dockerfile

### DIFF
--- a/PrimeZig/solution_1/Dockerfile
+++ b/PrimeZig/solution_1/Dockerfile
@@ -4,6 +4,6 @@ RUN pacman --noconfirm -Sy zig
 
 WORKDIR /opt/app
 COPY . .
-RUN zig build
+RUN zig build-exe src/main.zig -O ReleaseFast -femit-bin=PrimeZig
 
-ENTRYPOINT [ "./zig-cache/bin/PrimeZig" ]
+ENTRYPOINT [ "./PrimeZig" ]


### PR DESCRIPTION
The previous Dockerfile stopped working due to the built binary moving from zig-cache/bin to zig-out/bin. 

I have now changed the Dockerfile to explicitly build an executable that also optimizes for speed.