### PR TITLE
add -march/mtune=native to PrimeC/solution_1

### DIFF
--- a/PrimeC/solution_1/run
+++ b/PrimeC/solution_1/run
@@ -2,7 +2,7 @@
 # Compilation and execution on Git-Bash (GNU C Compiler)
 set -e
 
-OFLAGS="-Ofast -funroll-all-loops"
+OFLAGS="-Ofast -march=native -mtune=native -funroll-all-loops"
 SIZE=1000000
 
 while [[ $1 != "" ]]; do


### PR DESCRIPTION
We probably want the compiler to generate the best possible code. So this enables processor specific optimizations. `PrimeC/solution_2` already uses these flags.
