### PR TITLE
Rust solution_1 tweaks: docker performance regression + new bit reset algorithm

### DIFF
--- a/PrimeRust/solution_1/Dockerfile
+++ b/PrimeRust/solution_1/Dockerfile
@@ -2,7 +2,11 @@
 #   - run unit tests 
 #   - build executable
 #
-FROM primeimages/rust:1.52.1 AS build
+
+# Note: Debian based, not Alpine; for some reason, the 
+# Alpine malloc call is slower than it should be.
+#
+FROM rust:1.52.1 AS build
 
 WORKDIR /app
 COPY . .
@@ -14,7 +18,8 @@ RUN cargo build --release
 #   - copy built executable 
 # 
 
-FROM alpine:3.13
+# Debian base image, not Alpine, for reason noted above
+FROM debian:buster-slim AS runtime
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description
It looks like we're getting close to the finale, and there are a couple of things I've been meaning to do for a while. 
1. `Alpine` image causes a nasty performance regression due to some memory allocation inefficiency; Alpine has a different libc implementation and it doesn't appear to be playing well. This PR reverts to using the "normal" `Debian`-based Rust images for build and deploy. @rbergen I know you're overseeing the Docker images; this might be worth doing for the other Rust solutions too. Hope it doesn't create too much of a headache for you. 
2. Replaced the storage for the bit vector from u8 (bytes) to u32 (words) for a very slight performance bump, possibly due to alignment -- still bits, but in larger words.
3. Added a new bit storage variation that resets bits slightly differently by rotating a mask instead of having to do the shift every time. It outputs its own line. This one is quite fun. 

I don't think any of this will catch up with those Zig solutions though :) 

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
