### PR TITLE
Startup checks for docker and node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ report: sanity-node benchmark
 	@cd tools/; \
 	npm ci && npm start -- report -d "$(OUTPUT_DIR)"
 
-one:
+one: sanity-checks
 	@if [[ ! -z "$${SOLUTION}" ]]; then \
 		NAME=$$(echo "$${SOLUTION}" | sed -r 's/\//-/g' | tr '[:upper:]' '[:lower:]'); \
 		OUTPUT="$(OUTPUT_DIR)/$${NAME}.out"; \

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,9 @@ SOLUTIONS  := $(shell find Prime* -type f -name Dockerfile -exec dirname {} \; |
 OUTPUT_DIR := $(shell mktemp -d)
 ARCH_FILE  := ${shell case $$(uname -m) in x86_64) echo arch-amd64 ;; aarch64) echo arch-arm64 ;; esac}
 
-all: sanity-checks report
+all: report
 
-benchmark: $(SOLUTIONS)
+benchmark: sanity-docker $(SOLUTIONS)
 	@echo "--- Output files available in $(OUTPUT_DIR)"
 
 	@for s in $(SOLUTIONS); do \
@@ -22,7 +22,7 @@ benchmark: $(SOLUTIONS)
 		fi; \
 	done
 
-report: benchmark
+report: sanity-node benchmark
 	@cd tools/; \
 	npm ci && npm start -- report -d "$(OUTPUT_DIR)"
 

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,10 @@ SOLUTIONS  := $(shell find Prime* -type f -name Dockerfile -exec dirname {} \; |
 OUTPUT_DIR := $(shell mktemp -d)
 ARCH_FILE  := ${shell case $$(uname -m) in x86_64) echo arch-amd64 ;; aarch64) echo arch-arm64 ;; esac}
 
+.PHONY: all
 all: report
 
+.PHONY: benchmark
 benchmark: check-docker-works $(SOLUTIONS)
 	@echo "--- Output files available in $(OUTPUT_DIR)"
 
@@ -22,10 +24,12 @@ benchmark: check-docker-works $(SOLUTIONS)
 		fi; \
 	done
 
+.PHONY: report
 report: check-node-works benchmark
 	@cd tools/; \
 	npm ci && npm start -- report -d "$(OUTPUT_DIR)"
 
+.PHONY: one
 one: check-env
 	@if [[ ! -z "$${SOLUTION}" ]]; then \
 		NAME=$$(echo "$${SOLUTION}" | sed -r 's/\//-/g' | tr '[:upper:]' '[:lower:]'); \
@@ -37,12 +41,15 @@ one: check-env
 		echo "Not specified!"; \
 	fi
 
+.PHONY: check-env
 check-env: check-docker-works check-node-works
 
+.PHONY: check-node-works
 check-node-works:
 	@# Check it Node.js is installed. Needed to generate report.
 	@npm --version >/dev/null 2>&1 || (echo 'Please install Node.js. https://nodejs.org/en/download' && exit 1)
 
+.PHONY: check-docker-works
 check-docker-works:
 	@# Check if docker engine is installed
 	@docker --version >/dev/null 2>&1 || (echo 'Please install docker. https://docs.docker.com/engine/install' && exit 1)

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SOLUTIONS  := $(shell find Prime* -type f -name Dockerfile -exec dirname {} \; |
 OUTPUT_DIR := $(shell mktemp -d)
 ARCH_FILE  := ${shell case $$(uname -m) in x86_64) echo arch-amd64 ;; aarch64) echo arch-arm64 ;; esac}
 
-all: docker report
+all: sanity-checks report
 
 benchmark: $(SOLUTIONS)
 	@echo "--- Output files available in $(OUTPUT_DIR)"
@@ -37,7 +37,14 @@ one:
 		echo "Not specified!"; \
 	fi
 
-docker:
+sanity-checks: sanity-docker sanity-node
+
+sanity-node:
+	@# Check it node.js is installed. Needed to generate report.
+	@node --version >/dev/null 2>&1 || (echo 'Please install Node.js. https://nodejs.org/en/download' && exit 1)
+	@npm --version >/dev/null 2>&1 || (echo 'How is Npm not installed but Node.js is?' && exit 1)
+
+sanity-docker:
 	@# Check if docker engine is installed
 	@docker --version >/dev/null 2>&1 || (echo 'Please install docker. https://docs.docker.com/engine/install' && exit 1)
 	

--- a/Makefile
+++ b/Makefile
@@ -40,9 +40,8 @@ one: check-env
 check-env: check-docker-works check-node-works
 
 check-node-works:
-	@# Check it node.js is installed. Needed to generate report.
-	@node --version >/dev/null 2>&1 || (echo 'Please install Node.js. https://nodejs.org/en/download' && exit 1)
-	@npm --version >/dev/null 2>&1 || (echo 'How is Npm not installed but Node.js is?' && exit 1)
+	@# Check it Node.js is installed. Needed to generate report.
+	@npm --version >/dev/null 2>&1 || (echo 'Please install Node.js. https://nodejs.org/en/download' && exit 1)
 
 check-docker-works:
 	@# Check if docker engine is installed

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SOLUTIONS  := $(shell find Prime* -type f -name Dockerfile -exec dirname {} \; |
 OUTPUT_DIR := $(shell mktemp -d)
 ARCH_FILE  := ${shell case $$(uname -m) in x86_64) echo arch-amd64 ;; aarch64) echo arch-arm64 ;; esac}
 
-all: report
+all: docker report
 
 benchmark: $(SOLUTIONS)
 	@echo "--- Output files available in $(OUTPUT_DIR)"
@@ -36,3 +36,10 @@ one:
 	else \
 		echo "Not specified!"; \
 	fi
+
+docker:
+	@# Check if docker engine is installed
+	@docker --version >/dev/null 2>&1 || (echo 'Please install docker. https://docs.docker.com/engine/install' && exit 1)
+	
+	@# Check if docker is running and that we can connect to it
+	@docker ps >/dev/null

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ check-env: check-docker-works check-node-works
 
 .PHONY: check-node-works
 check-node-works:
-	@# Check it Node.js is installed. Needed to generate report.
+	@# Check if Node.js is installed. Needed to generate report.
 	@npm --version >/dev/null 2>&1 || (echo 'Please install Node.js. https://nodejs.org/en/download' && exit 1)
 
 .PHONY: check-docker-works

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ARCH_FILE  := ${shell case $$(uname -m) in x86_64) echo arch-amd64 ;; aarch64) e
 
 all: report
 
-benchmark: sanity-docker $(SOLUTIONS)
+benchmark: check-docker-works $(SOLUTIONS)
 	@echo "--- Output files available in $(OUTPUT_DIR)"
 
 	@for s in $(SOLUTIONS); do \
@@ -22,11 +22,11 @@ benchmark: sanity-docker $(SOLUTIONS)
 		fi; \
 	done
 
-report: sanity-node benchmark
+report: check-node-works benchmark
 	@cd tools/; \
 	npm ci && npm start -- report -d "$(OUTPUT_DIR)"
 
-one: sanity-checks
+one: check-env
 	@if [[ ! -z "$${SOLUTION}" ]]; then \
 		NAME=$$(echo "$${SOLUTION}" | sed -r 's/\//-/g' | tr '[:upper:]' '[:lower:]'); \
 		OUTPUT="$(OUTPUT_DIR)/$${NAME}.out"; \
@@ -37,14 +37,14 @@ one: sanity-checks
 		echo "Not specified!"; \
 	fi
 
-sanity-checks: sanity-docker sanity-node
+check-env: check-docker-works check-node-works
 
-sanity-node:
+check-node-works:
 	@# Check it node.js is installed. Needed to generate report.
 	@node --version >/dev/null 2>&1 || (echo 'Please install Node.js. https://nodejs.org/en/download' && exit 1)
 	@npm --version >/dev/null 2>&1 || (echo 'How is Npm not installed but Node.js is?' && exit 1)
 
-sanity-docker:
+check-docker-works:
 	@# Check if docker engine is installed
 	@docker --version >/dev/null 2>&1 || (echo 'Please install docker. https://docs.docker.com/engine/install' && exit 1)
 	


### PR DESCRIPTION
## Description
If you're running these without docker installed (or running), you get a whole lot of noisy errors that seem daunting. Let's make it more clear.

To be nice, we can also check if Node.js is installed at the start. The `Makefile` uses `npm` and `node` at the end to generate the report. It's a bummer to run the whole script only to get a node error at the end, especially since the work is done in a `mktmp` folder that is possibly difficult to find again.

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.