### PR TITLE
reset bitArray values between runs

### DIFF
--- a/PrimeGo/solution_1/main.go
+++ b/PrimeGo/solution_1/main.go
@@ -98,10 +98,10 @@ func main() {
 	startClock := time.Now()
 
 	initBitArray := make([]bool, 1e6)
-	for i := range initBitArray {
-		initBitArray[i] = true
-	}
 	for {
+		for i := range initBitArray {
+			initBitArray[i] = true
+		}
 		sieve := Sieve{bitArray: initBitArray, sieveSize: 1e6}
 		sieve.runSieve()
 		passes++


### PR DESCRIPTION
## Description
Go makes a shallow copy of slices. So, the existing go solution only performs the prime sieve once and after that gets the slice with the solution already in place. I just made a quick fix to initialize the slice before every run.

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
