### PR TITLE
Clarifying dynamic sieve size/memory requirement

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,7 @@ At a technical level, an implementation is considered faithful if it complies wi
 
 * It uses no external dependencies to calculate the actual sieve.
 * It uses a class to encapsulate the sieve, or an equivalent feature in your language. This class must contain the full state of the sieve. Each iteration should re-create a new instance of this class.
+* The sieve size and corresponding prime candidate memory buffer (or language equivalent) are set/allocated dynamically at runtime. The size of the memory buffer must correspond to the size of the sieve.
 * It conforms to the base [rules](#Rules).
 
 All other implementations are considered unfaithful. Note that they still need to conform to the base [rules](#Rules). 


### PR DESCRIPTION
This aims to clarify the requirements regarding faithful implementations, in the sense that sieve and memory buffer size must be set at runtime. The need for this clarification is illustrated by PRs #255, #256 and #266.