### PR TITLE
Marking PrimeZig/solution_3 unfaithful

### DIFF
--- a/PrimeZig/solution_3/README.md
+++ b/PrimeZig/solution_3/README.md
@@ -2,7 +2,7 @@
 
 ![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
 ![Algorithm](https://img.shields.io/badge/Algorithm-wheel-yellowgreen)
-![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
+![Faithfulness](https://img.shields.io/badge/Faithful-no-green)
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
 ![Parallelism](https://img.shields.io/badge/Parallel-yes-green)
 ![Bit count](https://img.shields.io/badge/Bits-1-green)

--- a/PrimeZig/solution_3/src/main.zig
+++ b/PrimeZig/solution_3/src/main.zig
@@ -145,7 +145,7 @@ fn printResults(backing: []const u8, passes: usize, elapsed_ns: u64, threads: us
     const stdout = std.io.getStdOut().writer();
     const algo = if (wheel) "wheel" else "base";
 
-    try stdout.print("{s};{};{d:.5};{};faithful=yes,algorithm={s},bits={}\n", .{
+    try stdout.print("{s};{};{d:.5};{};faithful=no,algorithm={s},bits={}\n", .{
         backing, passes, elapsed, threads, algo, bits
     });
 }


### PR DESCRIPTION
The implementations in PrimeZig/solution_3 need to be marked unfaithful, for two reasons:

- The prime sieve objects are not recreated from scratch for every sieve run, but reset
- The memory for the sieve objects is effectively statically allocated at compile time. This also violates the "from scratch" principle. #274 has been opened to clarify the contributing guidelines on this point

The reason this PR is necessary is simply that I missed this in my review of #241.