### PR TITLE
Remove unnecessary unique_ptr from PrimeCPP_PAR.cpp

### DIFF
--- a/PrimeCPP/solution_2/PrimeCPP_PAR.cpp
+++ b/PrimeCPP/solution_2/PrimeCPP_PAR.cpp
@@ -11,7 +11,6 @@
 #include <cmath>
 #include <vector>
 #include <thread>
-#include <memory>
 
 using namespace std;
 using namespace std::chrono;
@@ -242,7 +241,7 @@ int main(int argc, char **argv)
 
     if (bOneshot)
     {
-        std::unique_ptr<prime_sieve>(new prime_sieve(llUpperLimit))->runSieve();
+        prime_sieve(llUpperLimit).runSieve();
     }
     else
     {
@@ -250,14 +249,12 @@ int main(int argc, char **argv)
         {
             vector<thread> threadPool;
             
-            // We create N threads and give them each the job of runing the 'runSieve' method on a sieve
-            // that we create on the heap, rather than the stack, due to their possible enormity.  By using
-            // a unique_ptr it will automatically free resources as soon as its torn down.
+            // We create N threads and give them each the job of runing the 'runSieve' method on a sieve.
 
             for (unsigned int i = 0; i < cThreads; i++)
                 threadPool.push_back(thread([llUpperLimit] 
                 { 
-                    std::unique_ptr<prime_sieve>(new prime_sieve(llUpperLimit))->runSieve(); 
+                    prime_sieve(llUpperLimit).runSieve(); 
                 }));
 
             // Now we wait for all of the threads to finish before we repeat


### PR DESCRIPTION
## Description
The prime_sieve can be stack allocated without a problem:
(1) The bulk of the sieve will still be heap allocated because vector<bool> does a heap allocation.
(2) The prime_sieve will be destructed at the same moment as the unique_ptr was destructed, after all, the unique_ptr was stack allocated just the same.
 
## Contributing requirements
* [Yes ] I read the contribution guidelines in CONTRIBUTING.md.
* [ N/A] I placed my solution in the correct solution folder.
* [ N/A] I added a README.md with the right badge(s).
* [ N/A] I added a Dockerfile that builds and runs my solution.
* [ Yes] I selected `drag-race` as the target branch.
* [ Yes] All code herein is licensed compatible with BSD-3.
