### PR TITLE
F# performance improvements ~75%

### DIFF
--- a/PrimeFSharp/solution_1/Program.fs
+++ b/PrimeFSharp/solution_1/Program.fs
@@ -79,7 +79,7 @@ let main _argv =
   if sieve.CountPrimes <> referenceResults.[sieveSize] then
     printfn "WARNING: result is incorrect!"
 
-  printfn $"rbergen;{ passCount };{ duration };1;algorithm=base,faithful=yes"
+  printfn $"rbergen;{ passCount };{ duration };1;algorithm=base,faithful=yes,bits=1"
 
   0
 

--- a/PrimeFSharp/solution_1/Program.fs
+++ b/PrimeFSharp/solution_1/Program.fs
@@ -79,7 +79,7 @@ let main _argv =
   if sieve.CountPrimes <> referenceResults.[sieveSize] then
     printfn "WARNING: result is incorrect!"
 
-  printfn $"rbergen;{ passCount };{ duration };1;algorithm=base,faithful=yes,bits=1"
+  printfn $"rbergen;{ passCount };{ duration };1;algorithm=base,faithful=yes"
 
   0
 

--- a/PrimeFSharp/solution_2/Program.fs
+++ b/PrimeFSharp/solution_2/Program.fs
@@ -55,7 +55,7 @@ let printResults showResults duration passes sieveSize bitArray =
     printfn $"Passes: %d{passes}, Time: %f{duration}, Avg: %f{duration / (float passes)}, Limit: %d{sieveSize}, Count: %d{countPrimes primes}, Valid: %b{isValid}\n"
 
     if isValid then
-        printfn $"dmannock_fsharp_port;%d{passes};%f{duration};1;algorithm=base,faithful=yes,bits=1"
+        printfn $"dmannock_fsharp_port;%d{passes};%f{duration};1;algorithm=base,faithful=yes"
     else
         printfn "ERROR: invalid results"
 

--- a/PrimeFSharp/solution_2/Program.fs
+++ b/PrimeFSharp/solution_2/Program.fs
@@ -12,7 +12,10 @@ let primeCounts = Map.ofList([
     100000000, 5761455
 ]) 
 
-let initPrimeSieve sieveSize = Array.init sieveSize (fun _ -> true)
+let inline initPrimeSieve sieveSize = 
+    let raw = GC.AllocateUninitializedArray(sieveSize, true).AsSpan()
+    raw.Fill(true)
+    raw
 
 let filterPrimes bitArray =
     [|3..2..Array.length bitArray|]
@@ -25,20 +28,20 @@ let validateResults primeCounts sieveSize primes =
     | Some expected -> expected = countPrimes primes
     | None -> false
 
-let runSieve sieveSize (bitArray: byref<bool[]>) =
+let runSieve sieveSize (bitArray: Span<bool>) =
     let mutable factor = 3
     let mutable num = 0
     let q = sieveSize |> float |> sqrt |> int
 
     while factor <= q do
         num <- factor
-        while not (Array.get bitArray num) && num < sieveSize do
+        while not (bitArray.Item num) && num < sieveSize do
             num <- num + 2
         factor <- num
 
         num <- factor * factor
         while num < sieveSize do
-            Array.set bitArray num false
+            bitArray.Item num <- false
             num <- num + factor * 2
 
         factor <- factor + 2
@@ -66,9 +69,9 @@ let main _ =
 
     while (DateTime.UtcNow - tStart).TotalSeconds < 5. do
         sieve <- initPrimeSieve sieveSize
-        runSieve sieveSize &sieve
+        runSieve sieveSize sieve
         passes <- passes + 1
 
     let duration = (DateTime.UtcNow - tStart).TotalSeconds
-    printResults false duration passes sieveSize sieve
+    printResults false duration passes sieveSize (sieve.ToArray())
     0 // return an integer exit code

--- a/PrimeFSharp/solution_2/README.md
+++ b/PrimeFSharp/solution_2/README.md
@@ -3,7 +3,7 @@
 ![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
 ![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
-![Bit count](https://img.shields.io/badge/unknown-yellowgreen)
+![Bit count](https://img.shields.io/badge/Bits-unknown-yellowgreen)
 
 Port of the original C++ prime number sieve to F#. Matching as closely as possible by using while loops. 
 

--- a/PrimeFSharp/solution_2/README.md
+++ b/PrimeFSharp/solution_2/README.md
@@ -3,7 +3,7 @@
 ![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
 ![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
-![Bit count](https://img.shields.io/badge/Bits-1-green)
+![Bit count](https://img.shields.io/badge/unknown-yellowgreen)
 
 Port of the original C++ prime number sieve to F#. Matching as closely as possible by using while loops. 
 

--- a/PrimeFSharp/solution_2/README.md
+++ b/PrimeFSharp/solution_2/README.md
@@ -18,7 +18,7 @@ A Dockerfile has been provided.
 
 ## Output
 ```
-dmannock_fsharp_port;5248;5.000992;1;algorithm=base,faithful=yes,bits=1
+dmannock_fsharp_port;9669;5.000318;1;algorithm=base,faithful=yes,bits=1
 ```
 
 ## Original Output
@@ -27,15 +27,25 @@ CPU Used: 3700x (4.3GHz boost)
 
 ### F# [Recursion](PrimeSieveFsharp_Recursion)
 ```
-Passes: 5585, Time: 5.000537, Avg: 0.000895, Limit: 1000000, Count: 78498, Valid: true
+Passes: 9839, Time: 5.000479, Avg: 0.000508, Limit: 1000000, Count: 78498, Valid: true
 ```
 
 ### F# [Port from C++](PrimeSieveFsharp_Port) (_this solution_)
 ```
-Passes: 5248, Time: 5.000992, Avg: 0.000953, Limit: 1000000, Count: 78498, Valid: true
+Passes: 9669, Time: 5.000318, Avg: 0.000517, Limit: 1000000, Count: 78498, Valid: true
 ```
 
-### C#
+### C# (raw bits)
+```
+Passes: 6201, Time: 5.00026 s, Per Loop: 0.806322 ms, Sieve Size: 1000000, Thread Count: 1, Primes Found: 78498, Valid: True
+```
+
+### C# (bool array)
+```
+Passes: 5106, Time: 5.00088 s, Per Loop: 0.979240 ms, Sieve Size: 1000000, Thread Count: 1, Primes Found: 78498, Valid
+```
+
+### C# (original)
 ```
 Passes: 3545, Time: 5.0012068, Avg: 0.0014107776586741892, Limit: 1000000, Count: 78498, Valid: True
 ```

--- a/PrimeFSharp/solution_3/Program.fs
+++ b/PrimeFSharp/solution_3/Program.fs
@@ -12,7 +12,10 @@ let primeCounts = Map.ofList([
     100000000, 5761455
 ]) 
 
-let initPrimeSieve sieveSize = Array.init sieveSize (fun _ -> true)
+let inline initPrimeSieve sieveSize = 
+    let raw = GC.AllocateUninitializedArray(sieveSize, true)
+    raw.AsSpan().Fill(true)
+    raw
 
 let filterPrimes bitArray =
     [|3..2..Array.length bitArray|]
@@ -25,7 +28,7 @@ let validateResults primeCounts sieveSize primes =
     | Some expected -> expected = countPrimes primes
     | None -> false
 
-let runSieve sieveSize (bitArray: bool[]) =
+let inline runSieve sieveSize (bitArray: bool[]) =
     let q = sieveSize |> float |> sqrt |> int
 
     let rec findNext num =
@@ -33,12 +36,11 @@ let runSieve sieveSize (bitArray: bool[]) =
         then num
         else findNext (num + 2)
 
-    let eliminate factor =
+    let inline eliminate factor =
         let rec loop num =
             if num < sieveSize then
                 Array.set bitArray num false
                 loop (num + factor * 2)
-            else ()
         loop (factor * factor)
       
     let rec run factor =
@@ -46,7 +48,6 @@ let runSieve sieveSize (bitArray: bool[]) =
             let factor = findNext factor
             eliminate factor
             run (factor +  2)
-        else ()
     run 3
 
 let printResults showResults duration passes sieveSize bitArray =

--- a/PrimeFSharp/solution_3/Program.fs
+++ b/PrimeFSharp/solution_3/Program.fs
@@ -59,7 +59,7 @@ let printResults showResults duration passes sieveSize bitArray =
     printfn $"Passes: %d{passes}, Time: %f{duration}, Avg: %f{duration / (float passes)}, Limit: %d{sieveSize}, Count: %d{countPrimes primes}, Valid: %b{isValid}\n"
 
     if isValid then
-        printfn $"dmannock_fsharp_recursion;%d{passes};%f{duration};1;algorithm=base,faithful=yes,bits=1"
+        printfn $"dmannock_fsharp_recursion;%d{passes};%f{duration};1;algorithm=base,faithful=yes"
     else
         printfn "ERROR: invalid results"
 

--- a/PrimeFSharp/solution_3/README.md
+++ b/PrimeFSharp/solution_3/README.md
@@ -18,7 +18,7 @@ A Dockerfile has been provided.
 
 ## Output
 ```
-dmannock_fsharp_recursion;5585;5.000537;1;algorithm=base,faithful=yes,bits=1
+dmannock_fsharp_recursion;9839;5.000479;1;algorithm=base,faithful=yes,bits=1
 ```
 
 ## Original Output
@@ -27,15 +27,25 @@ CPU Used: 3700x (4.3GHz boost)
 
 ### F# [Recursion](PrimeSieveFsharp_Recursion) (_this solution_)
 ```
-Passes: 5585, Time: 5.000537, Avg: 0.000895, Limit: 1000000, Count: 78498, Valid: true
+Passes: 9839, Time: 5.000479, Avg: 0.000508, Limit: 1000000, Count: 78498, Valid: true
 ```
 
 ### F# [Port from C++](PrimeSieveFsharp_Port)
 ```
-Passes: 5248, Time: 5.000992, Avg: 0.000953, Limit: 1000000, Count: 78498, Valid: true
+Passes: 9669, Time: 5.000318, Avg: 0.000517, Limit: 1000000, Count: 78498, Valid: true
 ```
 
-### C#
+### C# (raw bits)
+```
+Passes: 6201, Time: 5.00026 s, Per Loop: 0.806322 ms, Sieve Size: 1000000, Thread Count: 1, Primes Found: 78498, Valid: True
+```
+
+### C# (bool array)
+```
+Passes: 5106, Time: 5.00088 s, Per Loop: 0.979240 ms, Sieve Size: 1000000, Thread Count: 1, Primes Found: 78498, Valid
+```
+
+### C# (original)
 ```
 Passes: 3545, Time: 5.0012068, Avg: 0.0014107776586741892, Limit: 1000000, Count: 78498, Valid: True
 ```

--- a/PrimeFSharp/solution_3/README.md
+++ b/PrimeFSharp/solution_3/README.md
@@ -3,7 +3,7 @@
 ![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
 ![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
-![Bit count](https://img.shields.io/badge/unknown-yellowgreen)
+![Bit count](https://img.shields.io/badge/Bits-unknown-yellowgreen)
 
 Port of the original C++ prime number sieve to F# using recursion. 
 

--- a/PrimeFSharp/solution_3/README.md
+++ b/PrimeFSharp/solution_3/README.md
@@ -3,7 +3,7 @@
 ![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
 ![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
-![Bit count](https://img.shields.io/badge/Bits-1-green)
+![Bit count](https://img.shields.io/badge/unknown-yellowgreen)
 
 Port of the original C++ prime number sieve to F# using recursion. 
 


### PR DESCRIPTION
## Description
Performance improvements to my previous F# solutions 2 & 3. Gives ~75% boost from changes involving sieve init, inlining & spans.

Test results updated in the readme files.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

* [X] I read the contribution guidelines in CONTRIBUTING.md.
* [X] I placed my solution in the correct solution folder.
* [X] I added a README.md with the right badge(s).
* [X] I added a Dockerfile that builds and runs my solution.
* [X] I selected `drag-race` as the target branch.
* [X] All code herein is licensed compatible with BSD-3.
