### PR TITLE
C# bitsperprime consistency

### DIFF
--- a/PrimeCSharp/solution_1/Benchmarks/PrimeSieve - And.cs
+++ b/PrimeCSharp/solution_1/Benchmarks/PrimeSieve - And.cs
@@ -9,7 +9,7 @@ namespace PrimeCSharp
     {
         public string QuickName => "bench+and";
         public string Name => "Benchmark BitArray 'and'";
-
+        public int? BitsPerPrime => 1;
         public int SieveSize { get; }
 
         private readonly BitArray bitArray;

--- a/PrimeCSharp/solution_1/Benchmarks/PrimeSieve - Mod.cs
+++ b/PrimeCSharp/solution_1/Benchmarks/PrimeSieve - Mod.cs
@@ -9,7 +9,7 @@ namespace PrimeCSharp
     {
         public string QuickName => "bench+mod";
         public string Name => "Benchmark BitArray 'mod'";
-
+        public int? BitsPerPrime => 1;
         public int SieveSize { get; }
         private readonly BitArray bitArray;
 

--- a/PrimeCSharp/solution_1/Benchmarks/PrimeSieve - US And.cs
+++ b/PrimeCSharp/solution_1/Benchmarks/PrimeSieve - US And.cs
@@ -9,7 +9,7 @@ namespace PrimeCSharp
     {
         public string QuickName => "bench+uint+and";
         public string Name => "Benchmark BitArray unsigned 'and'";
-
+        public int? BitsPerPrime => 1;
         public int SieveSize { get; }
         private readonly BitArray bitArray;
 

--- a/PrimeCSharp/solution_1/Benchmarks/PrimeSieve - US Mod.cs
+++ b/PrimeCSharp/solution_1/Benchmarks/PrimeSieve - US Mod.cs
@@ -9,7 +9,7 @@ namespace PrimeCSharp
     {
         public string QuickName => "bench+uint+mod";
         public string Name => "Benchmark BitArray Unsigned 'mod'";
-
+        public int? BitsPerPrime => 1;
         public int SieveSize { get; }
         private readonly BitArray bitArray;
 

--- a/PrimeCSharp/solution_1/Sieves/PrimeSieveOriginal.cs
+++ b/PrimeCSharp/solution_1/Sieves/PrimeSieveOriginal.cs
@@ -9,7 +9,7 @@ namespace PrimeCSharp.Sieves
         public string QuickName => "original";
         public string Name => "Original";
         public bool IsBaseAlgorithm => true;
-
+        public int? BitsPerPrime => 1;
         public int SieveSize { get; }
         private readonly BitArray bitArray;
 


### PR DESCRIPTION
## Description
Added missing bitsperprime on some implementations using BitArray so they are consistent. As mentioned in PR #283.


## Contributing requirements

* [X] I read the contribution guidelines in CONTRIBUTING.md.
* [X] I placed my solution in the correct solution folder.
* [X] I added a README.md with the right badge(s).
* [X] I added a Dockerfile that builds and runs my solution.
* [X] I selected `drag-race` as the target branch.
* [X] All code herein is licensed compatible with BSD-3.
