### PR TITLE
Octave: vectorize inner loop (500x faster)

### DIFF
--- a/PrimeOctave/solution_1/run_sieve.m
+++ b/PrimeOctave/solution_1/run_sieve.m
@@ -27,11 +27,8 @@ function count=run_sieve(limit)
     endif
   endfunction
 
-  function clear_bit(index)
-    % Mark a number as non-prime
-    if(rem(index,2)==1)
-      raw_bits((index+1)/2) = 0;
-    endif
+  function clear_bits(range)
+    raw_bits((range + 1) / 2) = 0;
   endfunction
 
   factor = 3;
@@ -47,9 +44,8 @@ function count=run_sieve(limit)
 
     % Mark all odd multiples of 'factor' as non-prime
     % Even multiples are already known to be non-prime
-    for num=factor*3:factor*2:limit
-      clear_bit(num);
-    endfor
+
+    clear_bits(factor*3:factor*2:limit);
     
     % Increment 'factor' to the next prime candidate
     factor += 2;


### PR DESCRIPTION
## Description
In Octave/Matlab/Numpy it is usual to write simple loops in vectorized form because this allows the interpreter to optimize many calculations more effectively.

Making this simple change to the loop marking off the non-primes makes the code about 500x faster on my machine.

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
