### PR TITLE
Julia: Move solution_2 script code into function

### DIFF
--- a/PrimeJulia/solution_2/Primes.jl
+++ b/PrimeJulia/solution_2/Primes.jl
@@ -36,13 +36,12 @@ function Base.iterate(r::Iterators.Reverse{Primes}, i=length(r.itr.data))
     (2i-1, i-1)
 end
 
-# the following block executes only if this file is the main script
-if abspath(PROGRAM_FILE) == @__FILE__
-    local limit = something(map(s -> tryparse(Int, s), ARGS)..., 1_000_000)
+function main()
+    limit = something(map(s -> tryparse(Int, s), ARGS)..., 1_000_000)
 
-    local passes = 0
-    local start = time()
-    local primes, duration
+    passes = 0
+    start = time()
+    local primes
     while (duration = time()-start) < 5
         primes = Primes(limit)
         passes += 1
@@ -51,4 +50,9 @@ if abspath(PROGRAM_FILE) == @__FILE__
     println(stderr, join(length(primes) > 10 ? [first(primes, 5)..., '…', last(primes, 5)...] : primes, ", "))
     println(stderr, "Passes: $passes, Time: $duration, Avg: $(duration/passes), Limit: $limit, Count: $(length(primes))")
     println("epithet-jl;$passes;$duration;1;algorithm=base,faithful=yes,bits=1")
+end
+
+# the following block executes only if this file is the main script
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
 end


### PR DESCRIPTION
## Description
This PR moves the code inside the `if abspath(PROGRAM_FILE) == @__FILE__` block into a separate function.
This follows the Julia "spirit" of sorts wherein you organize code into separate functions.

This cleans up some of the `local` variable declarations in the script code and also seems to give some small improvements:

Original:
```
> julia .\Primes_original.jl
2, 3, 5, 7, 11, …, 999953, 999959, 999961, 999979, 999983
Passes: 6739, Time: 5.0, Avg: 0.0007419498441905327, Limit: 1000000, Count: 78498
epithet-jl;6739;5.0;1;algorithm=base,faithful=yes,bits=1

> julia .\Primes_original.jl
2, 3, 5, 7, 11, …, 999953, 999959, 999961, 999979, 999983
Passes: 6785, Time: 5.0, Avg: 0.0007369196757553427, Limit: 1000000, Count: 78498
epithet-jl;6785;5.0;1;algorithm=base,faithful=yes,bits=1

> julia .\Primes_original.jl
2, 3, 5, 7, 11, …, 999953, 999959, 999961, 999979, 999983
Passes: 6730, Time: 5.0, Avg: 0.0007429420505200594, Limit: 1000000, Count: 78498
```
Edited:
```
> julia .\Primes.jl
2, 3, 5, 7, 11, …, 999953, 999959, 999961, 999979, 999983
Passes: 6775, Time: 5.0, Avg: 0.0007380073800738007, Limit: 1000000, Count: 78498
epithet-jl;6775;5.0;1;algorithm=base,faithful=yes,bits=1

> julia .\Primes.jl
2, 3, 5, 7, 11, …, 999953, 999959, 999961, 999979, 999983
Passes: 6850, Time: 5.0, Avg: 0.00072992700729927, Limit: 1000000, Count: 78498
epithet-jl;6850;5.0;1;algorithm=base,faithful=yes,bits=1

> julia .\Primes.jl
2, 3, 5, 7, 11, …, 999953, 999959, 999961, 999979, 999983
Passes: 6886, Time: 5.0, Avg: 0.0007261109497531223, Limit: 1000000, Count: 78498
epithet-jl;6886;5.0;1;algorithm=base,faithful=yes,bits=1
```

This might be because the original `local` declarations aren't actually doing anything when run in the global scope, and so the variables are still global and suffer from the performance issues detailed in Julia's [Performance Tips](https://docs.julialang.org/en/v1/manual/performance-tips/) page. Placing them into a function should alleviate that.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

* [X] I read the contribution guidelines in CONTRIBUTING.md.
* [X] I placed my solution in the correct solution folder.
* [X] I added a README.md with the right badge(s).
* [X] I added a Dockerfile that builds and runs my solution.
* [X] I selected `drag-race` as the target branch.
* [X] All code herein is licensed compatible with BSD-3.
