### PR TITLE
Support for multiple output formatters

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -318,3 +318,19 @@ found 0 vulnerabilities
 │   1   │ crystal        │ 1        │ marghidanu │  4232  │ 5.00019  │    1    │   base    │   yes    │ 1    │   846.36716   │
 └───────┴────────────────┴──────────┴────────────┴────────┴──────────┴─────────┴───────────┴──────────┴──────┴───────────────┘
 ```
+
+## Output formats
+
+The benchmark suite supports multiple output formats; if no formatter is specified, it will default to the `table` format. 
+Here are the supported values:
+
+* table
+* csv
+* json (this also includes the machine information data)
+
+The output format can be controlled via the `FORMATTER` variable like this:
+
+```
+make FORMATTER=json
+make one SOLUTION=PrimeCrystal/solution_1 FORMATTER=csv
+```

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ SHELL := /bin/bash
 SOLUTIONS  := $(shell find Prime* -type f -name Dockerfile -exec dirname {} \; | sed -e 's|^./||' | sort)
 OUTPUT_DIR := $(shell mktemp -d)
 ARCH_FILE  := ${shell case $$(uname -m) in x86_64) echo arch-amd64 ;; aarch64) echo arch-arm64 ;; esac}
+FORMATTER  := "table"
 
 .PHONY: all
 all: report
@@ -27,7 +28,7 @@ benchmark: check-docker-works $(SOLUTIONS)
 .PHONY: report
 report: check-node-works benchmark
 	@cd tools/; \
-	npm ci && npm start -- report -d "$(OUTPUT_DIR)"
+	npm ci && npm start -- report -d "$(OUTPUT_DIR)" -f "$(FORMATTER)"
 
 .PHONY: one
 one: check-env
@@ -36,7 +37,7 @@ one: check-env
 		OUTPUT="$(OUTPUT_DIR)/$${NAME}.out"; \
 		echo "[*] Running $${NAME}" && docker run --rm $$(docker build -q $$SOLUTION) | tee "$${OUTPUT}"; \
 		cd tools/; \
-		npm ci && npm start -- report -d "$(OUTPUT_DIR)" \
+		npm ci && npm start -- report -d "$(OUTPUT_DIR)" -f "$(FORMATTER)" \
 	else \
 		echo "Not specified!"; \
 	fi

--- a/tools/src/commands/report.ts
+++ b/tools/src/commands/report.ts
@@ -6,14 +6,13 @@ import { Command } from 'commander';
 
 import { Result } from '../models';
 import ReportService from '../services/report';
-import ResultService from '../services/result';
+import FormatterFactory from '../formatter_factory';
 
 const reportService = new ReportService();
-const resultService = new ResultService();
 
 export const command = new Command('report')
   .requiredOption('-d, --directory <directory>', 'Results directory')
-  .option('--json', 'Output JSON report')
+  .option('-f, --formatter <type>', 'Output formatter', 'table')
   .action(async (args) => {
     const directory = path.resolve(args.directory as string);
 
@@ -82,22 +81,7 @@ export const command = new Command('report')
       return;
     }
 
-    if (args.json) {
-      const report = await reportService.createReport(results);
-      console.log(JSON.stringify(report, undefined, 4));
-
-      return;
-    }
-
-    const singleThreadedResults = results.filter((value) => value.threads === 1);
-    if (singleThreadedResults.length > 0) {
-      console.log('');
-      resultService.printResults('Single-threaded', singleThreadedResults);
-    }
-
-    const multiThreadedResults = results.filter((result) => result.threads > 1);
-    if (multiThreadedResults.length > 0) {
-      console.log('');
-      resultService.printResults('Multi-threaded', multiThreadedResults);
-    }
+    const report = await reportService.createReport(results);
+    const formatter = FormatterFactory.getFormatter(args.formatter);
+    console.log(formatter.render(report));
   });

--- a/tools/src/formatter.ts
+++ b/tools/src/formatter.ts
@@ -1,0 +1,5 @@
+import { Report } from './models';
+
+export interface IFormatter {
+  render(report: Report): string;
+}

--- a/tools/src/formatter_factory.ts
+++ b/tools/src/formatter_factory.ts
@@ -1,0 +1,19 @@
+import { IFormatter } from './formatter';
+import { JSONFormatter } from './formatters/json';
+import { TableFormatter } from './formatters/table';
+import { CsvFormatter } from './formatters/text';
+
+export default class FormatterFactory {
+  static getFormatter(type: string): IFormatter {
+    switch (type.toLocaleLowerCase()) {
+      case 'json':
+        return new JSONFormatter();
+      case 'table':
+        return new TableFormatter();
+      case 'csv':
+        return new CsvFormatter();
+      default:
+        return new TableFormatter();
+    }
+  }
+}

--- a/tools/src/formatters/json.ts
+++ b/tools/src/formatters/json.ts
@@ -1,0 +1,8 @@
+import { Report } from '../models';
+import { IFormatter } from '../formatter';
+
+export class JSONFormatter implements IFormatter {
+  render(report: Report): string {
+    return JSON.stringify(report, undefined, 4);
+  }
+}

--- a/tools/src/formatters/table.ts
+++ b/tools/src/formatters/table.ts
@@ -1,9 +1,26 @@
-import { Result } from '../models';
-
 import { Table } from 'console-table-printer';
+import { Report, Result } from '../models';
+import { IFormatter } from '../formatter';
 
-export default class ResultService {
-  public printResults(title: string, data: Result[]): void {
+export class TableFormatter implements IFormatter {
+  render(report: Report): string {
+    const results = report.results;
+    const output = new Array<string>();
+
+    const singleThreadedResults = results.filter(
+      (value) => value.threads === 1
+    );
+    if (singleThreadedResults.length > 0)
+      output.push(this.printResults('Single-threaded', singleThreadedResults));
+
+    const multiThreadedResults = results.filter((result) => result.threads > 1);
+    if (multiThreadedResults.length > 0)
+      output.push(this.printResults('Multi-threaded', multiThreadedResults));
+
+    return output.join('\n');
+  }
+
+  private printResults(title: string, data: Result[]): string {
     const table = new Table({
       title,
       columns: [
@@ -51,6 +68,6 @@ export default class ResultService {
         })
     );
 
-    table.printTable();
+    return table.render();
   }
 }

--- a/tools/src/formatters/text.ts
+++ b/tools/src/formatters/text.ts
@@ -1,0 +1,46 @@
+import { Report } from '../models';
+import { IFormatter } from '../formatter';
+
+export class CsvFormatter implements IFormatter {
+  render(report: Report): string {
+    const results = report.results
+      .map((value) => {
+        return {
+          ...value,
+          passesPerSecond: value.passes / value.duration / value.threads
+        };
+      })
+      .sort((a, b) => b.passesPerSecond - a.passesPerSecond);
+
+    const csv = [
+      [
+        'Index',
+        'Implementation',
+        'Solution',
+        'Label',
+        'Passes',
+        'Duration',
+        'Threads',
+        'Algorithm',
+        'Faithful',
+        'Bits',
+        'PassesPerSecond'
+      ],
+      ...results.map((value, index) => [
+        index + 1,
+        value.implementation,
+        value.solution,
+        value.label,
+        value.passes,
+        value.duration.toFixed(5),
+        value.threads,
+        value.tags['algorithm'],
+        value.tags['faithful'],
+        value.tags['bits'],
+        value.passesPerSecond.toFixed(5)
+      ])
+    ];
+
+    return csv.map((value) => value.join(',')).join('\n');
+  }
+}


### PR DESCRIPTION
At the moment, all results are displayed in a text table. To make it more friendly towards other tools (like Excel & friends), the benchmark output can now be exported as CSV or JSON. The Makefile has also been modified to support the FORMAT variable; below is an example:

```
make one SOLUTION=PrimeCrystal/solution_1 FORMATTER=json
make one SOLUTION=PrimeCrystal/solution_1 FORMATTER=csv
make one SOLUTION=PrimeCrystal/solution_1 FORMATTER=table
```

If the variable is omitted, it will default to the `table` output formatter.
