### PR TITLE
Sped up the octave implementation

### DIFF
--- a/PrimeOctave/solution_1/run_sieve.m
+++ b/PrimeOctave/solution_1/run_sieve.m
@@ -10,33 +10,14 @@ function count=run_sieve(limit)
   % Only store information about odd numbers, as all even numbers are
   % automatically prime
   % rbergen: wrapped 2 in int32() to fix idivide integer input error in Octave 6.2.0
-  raw_bits = ones(1,idivide(limit,int32(2)));
+  raw_bits = true(1,idivide(limit,int32(2)));
   
-  % Check if 'index' has been eliminated as non-prime yet. Returns 1 if
-  % it has not yet been eliminated (still considered a prime candidate)
-  function bit = get_bit(index)
-    if rem(index,2) == 0
-      % If multiple of 2, automatically return false and warn the user 
-      % that he is checking even numbers unnecessarily
-      'checking even bits!'
-      bit = 0;
-      return
-    else
-      bit = raw_bits((index+1)/2);
-      return
-    endif
-  endfunction
-
-  function clear_bits(range)
-    raw_bits((range + 1) / 2) = 0;
-  endfunction
-
   factor = 3;
   q = sqrt(limit);
   while(factor<=q)
     % Find the next prime (look for the first bit in raw_bits that is still set
     for num=factor:2:limit
-      if get_bit(num)
+      if raw_bits((num+1)/2)
         factor = num;
         break
       endif
@@ -44,8 +25,7 @@ function count=run_sieve(limit)
 
     % Mark all odd multiples of 'factor' as non-prime
     % Even multiples are already known to be non-prime
-
-    clear_bits(factor*3:factor*2:limit);
+	raw_bits((factor*3+1)/2:factor:end) = false;
     
     % Increment 'factor' to the next prime candidate
     factor += 2;


### PR DESCRIPTION
## Description

The old implementation first created a vector of indices and then performed a sum and divide by two on that vector to compute the indices in the `raw_bits` vector. This was taking a lot of time. By avoiding a call into the function `clear_bits` and computing the indices in the original vector directly, I obtained a significant speedup. 
I replaced the raw_bits vector by a logical vector, as it seems more appropriate to use that here.
I also removed the get_bit function because it was performing a check that was unneeded.

Before this change, I obtained around 400 Passes. The new implementation has around 1500 Passes.

## Contributing requirements

* [ x ] I read the contribution guidelines in CONTRIBUTING.md.
* [ x ] I placed my solution in the correct solution folder.
* [ existed already ] I added a README.md with the right badge(s).
* [ existed already ] I added a Dockerfile that builds and runs my solution.
* [ x ] I selected `drag-race` as the target branch.
* [ x ] All code herein is licensed compatible with BSD-3.
