### PR TITLE
Update PrimePas.dpr

### DIFF
--- a/PrimeDelphi/solution_1/PrimePas.dpr
+++ b/PrimeDelphi/solution_1/PrimePas.dpr
@@ -17,8 +17,8 @@ type
 		FBitArray: array of ByteBool; //ByteBool: 4644. WordBool: 4232. LongBool: 3673
 		FMyDict: TDictionary<Integer, Integer>;
 
-		function GetBit(Index: Integer): Boolean;
-		procedure ClearBit(Index: Integer);
+		function GetBit(Index: Integer): Boolean; inline;
+		procedure ClearBit(Index: Integer); inline;
 		procedure InitializeBits;
 	public
 		constructor Create(Size: Integer);


### PR DESCRIPTION
As the GetBit and And Clearbit methods are trivial implementations, you can include the "inline" compiler hint to tell the compiler that there is no need to create a new method (ie consequently stack operations) for these.  Removing the function overhead doubles performance at least.

## Description
<!--
Delphi - Inlining the GetBit and ClearBit methods doubles performance
-->

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

* [ ] I read the contribution guidelines in CONTRIBUTING.md.
* [ ] I placed my solution in the correct solution folder.
* [ ] I added a README.md with the right badge(s).
* [ ] I added a Dockerfile that builds and runs my solution.
* [ ] I selected `drag-race` as the target branch.
* [ ] All code herein is licensed compatible with BSD-3.
