### PR TITLE
Optimized Bash implementation

### DIFF
--- a/PrimeBash/solution_1/Dockerfile
+++ b/PrimeBash/solution_1/Dockerfile
@@ -1,8 +1,8 @@
-FROM ubuntu:20.04
-
-RUN apt-get update
+# bash (with coreutils) in alpine seems to be less optimized than ubuntu
+# bash 5.1 seems to have much better performance than 5.0 shipped in 20.04
+FROM ubuntu:21.04
 
 WORKDIR /opt/app
-COPY PrimeBash.sh .
-
-ENTRYPOINT [ "./PrimeBash.sh" ]
+COPY *.sh ./
+ 
+ENTRYPOINT [ "./run.sh" ]

--- a/PrimeBash/solution_1/PrimeBashInline.sh
+++ b/PrimeBash/solution_1/PrimeBashInline.sh
@@ -60,23 +60,18 @@ function getBit {
 	(( $1 & 1 && !bitArray[\$1] ))
 }
 
-function clearBit {
-	# Mark as composite
-	bitArray[$1]=1
-}
-
 function runSieve {
 	local factor num q
 	sqrt q "$sieveSize"
 	for ((factor=3; factor <= q; factor+=2)); do
 		for ((num=factor; num < sieveSize; num+=2)); do
-			if getBit "$num"; then
+			if (( !bitArray[\$num] )); then
 				factor=$num
 				break
 			fi
 		done
 		for ((num=factor**2; num < sieveSize; num+=factor*2)); do
-			clearBit "$num"
+			bitArray[$num]=1
 		done
 	done
 }
@@ -127,7 +122,7 @@ function printResults {
 		"$count" "$valid"
 
 	# rbergen: added drag-race format output
-	printf "\nbash;%s;%s;1;algorithm=base,faithful=no\n" "$passes" "$dur_str"
+	printf "\nbash_inline;%s;%s;1;algorithm=base,faithful=no\n" "$passes" "$dur_str"
 }
 
 function main {

--- a/PrimeBash/solution_1/PrimeBashPacked.sh
+++ b/PrimeBash/solution_1/PrimeBashPacked.sh
@@ -1,0 +1,162 @@
+#! /bin/bash
+#
+# A simple prime sieve based on https://github.com/davepl/Primes
+# Written in bash.
+#
+# Tyler Hart (nitepone) <admin@night.horse>
+
+# rbergen -- changed number for 10 from 1 to 4
+readonly -A primeCounts=(
+	[10]=4
+	[100]=25
+	[1000]=168
+	[10000]=1229
+	[100000]=9592
+	[1000000]=78498
+	[10000000]=664579
+	[100000000]=576145
+)
+
+declare sieveSize=0
+declare -A bitArray=()
+# rbergen: changed runtime to drag-race default
+readonly RUNTIME_SEC=5
+
+function sqrt {
+	local -n i=$1 # Output
+	i=1
+	while ((i**2<=$2)); do
+		((++i))
+	done
+	((--i))
+}
+
+function initGlobals {
+	sieveSize=$1
+}
+
+function emptyBitArray {
+	bitArray=()
+}
+
+function validateResults {
+	local result=$1
+	(( primeCounts[\$sieveSize] == result ))
+}
+
+function countPrimes {
+	local i count=$((sieveSize >= 2))
+	for ((i=3; i < sieveSize; i++)); do
+		if getBit "$i"; then
+			((++count))
+		fi
+	done
+	echo "$count"
+}
+
+function getBit {
+	local index=$1 bit
+	(( index & 1 && !(bit=1<<(index>>1&63), index>>=7, bitArray[\$index] & bit) ))
+}
+
+function clearBit {
+	local index=$1 bit
+	(( index & 1 && (bit=1<<(index>>1&63), index>>=7, bitArray[\$index] |= bit) ))
+}
+
+function runSieve {
+	local factor num q
+	sqrt q "$sieveSize"
+	for ((factor=3; factor <= q; factor+=2)); do
+		for ((num=factor; num < sieveSize; num+=2)); do
+			if getBit "$num"; then
+				factor=$num
+				break
+			fi
+		done
+		for ((num=factor**2; num < sieveSize; num+=factor*2)); do
+			clearBit "$num"
+		done
+	done
+}
+
+function printResults {
+	local showresults dur_nano avg_dur_nano dur_str avg_dur_str passes count valid
+	showresults="$1"
+	dur_nano="$2"
+	passes="$3"
+	# create duration strings from nanosecond duration time
+	avg_dur_nano=$((dur_nano/passes))
+	dur_str="$(printf "%d.%09d"\
+		"$((dur_nano/1000000000))"\
+		"$((dur_nano%1000000000))"\
+	)"
+	avg_dur_str="$(printf "%d.%09d"\
+		"$((avg_dur_nano/1000000000))"\
+		"$((avg_dur_nano%1000000000))"\
+	)"
+	# create validity string
+	if validateResults "$(countPrimes)"; then
+		valid="True"
+	else
+		valid="False"
+	fi
+
+	if ((showresults)); then
+		printf "2, "
+	fi
+
+	count=$((sieveSize >= 2))
+	for ((num=3; num<sieveSize; num+=2)); do
+		if getBit "$num"; then
+			if ((showresults)); then
+				printf "%s, " "$num"
+			fi
+			((count++))
+		fi
+	done
+
+	if ((count != $(countPrimes))); then
+		echo "Internal: Print Results Counted Incorrectly..." >&2
+		exit 1
+	fi
+	printf "\n"
+	printf "Passes: %s, Time: %s, Avg: %s, Limit: %s, Count: %s, Valid: %s\n" \
+		"$passes" "$dur_str" "$avg_dur_str" "$sieveSize" \
+		"$count" "$valid"
+
+	# rbergen: added drag-race format output
+	printf "\nbash_packed;%s;%s;1;algorithm=base,faithful=no\n" "$passes" "$dur_str"
+}
+
+function main {
+	export LC_ALL=C
+	local passes=0 sleepPid tStart tRun
+
+	# Keep /dev/null handle open so we don't pay for opening it later
+	exec 3>/dev/null
+
+	initGlobals "1000000"
+
+	# Spawning subshells is expensive so run a background task which we can
+	# probe for liveness to determine when time is up.
+	local sleepPid
+	sleep "$RUNTIME_SEC" &
+	sleepPid=$!
+
+	# we are working in nanoseconds (10^9)
+	tStart=$(date +%s%N)
+
+	while kill -0 "$sleepPid" 2>&3; do
+		emptyBitArray
+		runSieve
+		((++passes))
+	done
+
+	# calculate real runtime
+	tRun=$(($(date +%s%N) - tStart))
+
+	printResults "0" "$tRun" "$passes"
+}
+
+main

--- a/PrimeBash/solution_1/README.md
+++ b/PrimeBash/solution_1/README.md
@@ -5,4 +5,11 @@
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
 ![Bit count](https://img.shields.io/badge/Bits-unknown-yellowgreen)
 
-Modified by rbergen as indicated in the source code.
+Modified by rbergen as indicated in the source code. Optimizations by Braden "Blzut3" Obrzut.
+
+Contains multiple implemenations as follows:
+
+1. An optimized base implementation written with natural code.
+2. A variation of the base implementation where the bit accessing functions are inlined.
+
+All implementations take advantage of bash arithmetic interpreting an empty string (i.e. uninitialized array index) as 0. The performance of bash in math heavy scripts seems to largely be determined by minimizing the number of variable accesses/writes and function calls. Of course avoiding the expensive operation of processing forking by eliminating subshells is also important.

--- a/PrimeBash/solution_1/README.md
+++ b/PrimeBash/solution_1/README.md
@@ -11,5 +11,8 @@ Contains multiple implemenations as follows:
 
 1. An optimized base implementation written with natural code.
 2. A variation of the base implementation where the bit accessing functions are inlined.
+3. Version using 64-bit bit packing. Although 64-bit arithmetic is used, Bash still stores base-10 strings.
 
 All implementations take advantage of bash arithmetic interpreting an empty string (i.e. uninitialized array index) as 0. The performance of bash in math heavy scripts seems to largely be determined by minimizing the number of variable accesses/writes and function calls. Of course avoiding the expensive operation of processing forking by eliminating subshells is also important.
+
+The bit-packed version could also take advantage of the inlining optimization, but that variant is not included here since the cost of doing the manipulations required to bit-pack easily outweigh the space savings. This implementation is included just to show it can be done.

--- a/PrimeBash/solution_1/run.sh
+++ b/PrimeBash/solution_1/run.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd "${0%/*}"
+
+exec find . -name '*.sh' -and -not -name run.sh -exec {} \;


### PR DESCRIPTION
## Description
I'm not entirely sure if using properties of uninitialized values is considered legal, but if so these changes do a little more than double performance of solution_1 on my machine (~12 seconds to ~5 seconds).  Solution_2 included here uses the same trick as PowerShell's solution_2 but only takes the run time for me from ~5 seconds to ~3 seconds.

As an aside I did try bitpacking to avoid the initialization slowness, but it seems that Bash's performance in mathematical code is basically a function of the number of variable accesses that are being done.  Doing the math, and creating the local variables required, to bit pack basically costs as much as it saves vs not bit packing.

I did try implementing a faster sqrt algorithm but once again the complexity of doing a smarter algorithm seemed to be outweighed by overheads on executing commands and variable access.  Plus it would only matter for smaller sieveSizes which the simple algorithm doesn't take long with anyway.  So I got rid of the subshell and called it a day.

Oh I saw a note somewhere that the reason Ubuntu was used for the container instead of Alpine was because the script wasn't exiting on Alpine.  This was likely due to the lack of coreutils for the date command, but even fixing that I found Alpine's Bash to be about half the speed of Ubuntu's.  Not sure why, but have to assume libc differences?

In summary the changes are:
- Invert meaning of 0 and 1 to avoid need for slow initialization. (Uninitialized values act as 0 for the purposes of this script.)
- Reduce complexity of get and clear functions for significant performance improvement.
- Use associative arrays for bitArray as they're actually faster in Bash (possibly due to avoiding the expression evaluator on the index)
- Upgrade to Bash 5.1 (Ubuntu 21.04) for improved performance. Note, Bash 5.1 in Alpine is about half the speed.
- Use a different method of limiting the runtime of the script which doesn't require spawning a process each loop.
- Removed the need for a subshell for the sqrt call.
- Set LC_ALL to C to avoid localization costs.
- Fixed typo on printing of times (9 digits instead of 8).
- Wrapped main in a function so that some of the parsing is done ahead of time instead of line by line.
- Added solution 2 which does the same inlining as PowerShell's solution 2 (albeit Bash's function call overhead isn't anywhere near as bad)

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
