### PR TITLE
Moved to solution 4, added loop count

### DIFF
--- a/PrimeGo/solution_4/Dockerfile
+++ b/PrimeGo/solution_4/Dockerfile
@@ -1,0 +1,9 @@
+FROM golang:1.16-alpine3.13
+
+WORKDIR /opt/app
+
+COPY main.go .
+
+RUN go build main.go
+
+ENTRYPOINT [ "./main" ]

--- a/PrimeGo/solution_4/README.md
+++ b/PrimeGo/solution_4/README.md
@@ -1,0 +1,30 @@
+# Go Prime Sieve solution by Richard Masci (rmasci)
+
+The reason I am highlighting this is show how easy it is to write concurrent in Go as concurrency, and Go was designed to be concurrent -- it wasn't added in later. Today computers don't scale like they did when most of these languages were written, where you could wait a few months and you had a faster processor and more RAM. Today, it's more about the number of cores.
+
+I took parts of solution 1 and solution 2 (Mostly from 2) to get this program. Without much work I am able to spawn 100 go routines to run at the same time, this is the first 'for' loop in the main function.  The second 'for' loop waits for 1 of the 100 go routines to finish, if it finishes with a 'true', it launches another go routine in it's place, and hopefully there will always be more than one running at the same time.
+
+## Run instructions
+1. Install Go
+2. go build -o sol3 main.go
+   You can also use `go run main.go`
+3. ./sol3
+
+## Output
+
+```
+[rmasci@mbpro ~/Primes/PrimeGo/solution_3] $ go run main.go
+rmasci;39480;5.02;1;algorithm=base,faithful=true
+```
+
+You can set the number of go routines to launch using -g -- experiment with this as if you use too many, it will slow down, too few will also slow it down. 100 is the default 
+
+Each go routine launches the Sieve 'loops' number of times, default is 7, You can also set the number of loops each go routine runs using -l. Again each system is going to be different, more is not better here. 
+
+On my system, 10th gen i7 1.6ghz 100 go routines , with a loop count of 10 gave me 39480.
+
+Even with one routine, and one loop it is twice as fast as the other solutions.
+```
+[rmasci@mbpro ~/go/Primes/PrimeGo/solution_3] $ go run main.go -r 1 -l 1
+rmasci;14007;5.00;1;algorithm=base,faithful=true
+```

--- a/PrimeGo/solution_4/go.mod
+++ b/PrimeGo/solution_4/go.mod
@@ -1,0 +1,5 @@
+module github.com/rmasci/Primes/PrimeGo/solution_3
+
+go 1.16
+
+require github.com/spf13/pflag v1.0.5

--- a/PrimeGo/solution_4/go.sum
+++ b/PrimeGo/solution_4/go.sum
@@ -1,0 +1,2 @@
+github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=

--- a/PrimeGo/solution_4/main.go
+++ b/PrimeGo/solution_4/main.go
@@ -1,0 +1,108 @@
+package main
+
+import (
+	"fmt"
+	"math"
+	"math/bits"
+	"os"
+	"time"
+
+	"github.com/spf13/pflag"
+)
+
+// I found that more is not better. Sometimes fewer go routines, each routine running a loop of sieves gave better performance. You can adjust the number of go routines and the number of loops each go routine runs.
+
+var primeCounts = map[uint64]uint64{
+	10:        4,
+	100:       25,
+	1000:      168,
+	10000:     1229,
+	100000:    9592,
+	1000000:   78498,
+	10000000:  664579,
+	100000000: 5761455,
+}
+
+type Sieve struct {
+	bits []uint8
+	size uint64
+}
+
+var loops int
+
+func (s Sieve) RunSieve(doneprime chan<- bool) {
+	var factor, start, step uint64
+	end := (s.size + 1) / 2
+	q := uint64(math.Sqrt(float64(s.size)) / 2)
+	for i := 1; i <= loops; i++ {
+		for factor = 1; factor <= q; factor++ {
+			if (s.bits[factor/8] & bits.RotateLeft8(1, int(factor))) != 0 {
+				continue
+			}
+
+			start = 2 * (factor*factor + factor)
+			step = factor*2 + 1
+
+			for ; start < end; start += step {
+				s.bits[start/8] |= bits.RotateLeft8(1, int(start))
+			}
+		}
+	}
+	doneprime <- true
+}
+
+// Validate Results comes from the solution 1
+func (s Sieve) ValidateResults() bool {
+	_, ok := primeCounts[s.size]
+	if !ok {
+		return false
+	} else {
+		return true
+	}
+}
+
+func main() {
+	var (
+		limit      uint64
+		duration   time.Duration
+		sieve      Sieve
+		help       bool
+		goRoutines int
+	)
+	pflag.Uint64VarP(&limit, "limit", "L", 1000000, "limit")
+	pflag.DurationVarP(&duration, "time", "t", 5*time.Second, "duration")
+	pflag.IntVarP(&goRoutines, "routines", "r", 100, "Go routintes to launch")
+	pflag.IntVarP(&loops, "loops", "l", 10, "Number of loops inside each go routine")
+	pflag.BoolVarP(&help, "help", "h", false, "Help")
+	pflag.Parse()
+	if help {
+		fmt.Println("Please see README.md for more information. You can set the number of go routines to launch. Even if you launch 1 (go run main.go -g 1) the program runs faster. Default is 1000.")
+		pflag.PrintDefaults()
+		os.Exit(1)
+	}
+	stop := make(chan struct{})
+	doneprime := make(chan bool)
+	passes := 0
+	start := time.Now()
+	time.AfterFunc(duration, func() { stop <- struct{}{} })
+	sieve = Sieve{make([]uint8, (limit+15)/16), limit}
+	for i := 0; i <= goRoutines; i++ {
+		go sieve.RunSieve(doneprime)
+	}
+	for {
+		select {
+		case <-stop:
+			ts := time.Since(start).Seconds()
+			fmt.Printf("rmasci;%d;%.2f;1;algorithm=base,faithful=%v\n", passes, ts, sieve.ValidateResults())
+			os.Exit(0)
+		default:
+			isDone := <-doneprime
+			if isDone {
+				// if isDone, then the routine ran the Sieve 'loops' (default is 10) number of times.
+				passes = passes + loops
+				sieve = Sieve{make([]uint8, (limit+15)/16), limit}
+				go sieve.RunSieve(doneprime)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description
<!--
Looked at the new solution 3, the one I created on my system runs a bit faster.  It launches x number of go routines, and in each of those go routines, it loops x number of times. On each system the number of go routines / loops is different, and each system needs a bit of a tweak in order to get max performance. On my system which is a 10th Gen i7, 6 cores, the score is 39480. With one loop, one go routine the score is 14007. 

Another difference is that this doesn't just launch x number of go routines, it continually launches them when one is finished. 

I did not test if it would run in Docker, looking at the dockerfile it should.
-->

## Contributing requirements
<!--
Conforms to the PR
-->

* [x ] I read the contribution guidelines in CONTRIBUTING.md.
* [ x] I placed my solution in the correct solution folder.
* [ x] I added a README.md with the right badge(s).
* [ x] I added a Dockerfile that builds and runs my solution.
* [ x] I selected `drag-race` as the target branch.
* [ x] All code herein is licensed compatible with BSD-3.
