### PR TITLE
Make prime_sieve type-stable

### DIFF
--- a/PrimeJulia/solution_1/PrimeSieveJulia.jl
+++ b/PrimeJulia/solution_1/PrimeSieveJulia.jl
@@ -9,7 +9,7 @@ const primeCounts = Dict( 10 => 4,
 
 struct prime_sieve
 	sieveSize::Int
-	rawbits::BitArray
+	rawbits::BitVector
 
 	prime_sieve(limit::Int) = new(  limit, trues( floor(Int,(limit+1)/2) )  )
 end


### PR DESCRIPTION
## Description
`BitArray` is an abstract type because dimensionality is not defined. Change it to `BitVector` for type stability.
This gives a speedup by a factor of 5 on my machine (350 passes before compared to 1500 passes after this change).
See https://docs.julialang.org/en/v1/manual/performance-tips/#man-performance-abstract-container for background info.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

* [ ] I read the contribution guidelines in CONTRIBUTING.md.
* [ ] I placed my solution in the correct solution folder.
* [ ] I added a README.md with the right badge(s).
* [ ] I added a Dockerfile that builds and runs my solution.
* [ ] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
