### PR TITLE
Clarifies that class must be used if available

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,7 @@ If you choose to include badges in your `README.md`, then:
 At a technical level, an implementation is considered faithful if it complies with the following:
 
 * It uses no external dependencies to calculate the actual sieve.
-* It uses a class to encapsulate the sieve, or an equivalent feature in your language. This class must contain the full state of the sieve. Each iteration should re-create a new instance of this class.
+* It uses a class to encapsulate the sieve, or a (closest) equivalent feature in your language if a class construct is not available. This class must contain the full state of the sieve. Each iteration should re-create a new instance of this class from scratch.
 * The sieve size and corresponding prime candidate memory buffer (or language equivalent) are set/allocated dynamically at runtime. The size of the memory buffer must correspond to the size of the sieve.
 * It conforms to the base [rules](#Rules).
 


### PR DESCRIPTION
Clarifies the contributing guidlelines on the points that:
- a class is the (only) allowed construct if a language provides one
- if it isn't but alternatives are, the one closest to the class concept must be used
- a class instance needs to be created _from scratch_ for every sieve run