### PR TITLE
PHP - remove the even number check

### DIFF
--- a/PrimePHP/solution_1/PrimePHP.php
+++ b/PrimePHP/solution_1/PrimePHP.php
@@ -126,3 +126,4 @@ function validateResult($sieveSize): ?int
 {
     return PrimeSieve::$primeCounts[$sieveSize];
 }
+?>

--- a/PrimePHP/solution_1/PrimePHP.php
+++ b/PrimePHP/solution_1/PrimePHP.php
@@ -35,17 +35,12 @@ class PrimeSieve
 
     private function getBit(int $index): bool
     {
-        if ($index % 2 !== 0) {
             return $this->rawbits[(int)$index / 2];
-        }
-        return false;
     }
 
     private function clearBit(int $index): void
     {
-        if ($index % 2 !== 0) {
             $this->rawbits[(int)$index / 2] = false;
-        }
     }
 
     public function runSieve()
@@ -54,7 +49,7 @@ class PrimeSieve
         $q = sqrt($this->sieveSize);
 
         while ($factor < $q) {
-            for ($i = $factor; $i <= $this->sieveSize; $i++) {
+            for ($i = $factor; $i <= $this->sieveSize; $i += 2) {
                 if ($this->getBit($i)) {
                     $factor = $i;
                     break;


### PR DESCRIPTION
## Description
<!--
-->
Watched the video "EW: What is the FASTEST Computer Language - 45 Tested: Round Two! (E02)" today and I see what he means about the even checks in both gitBit and clearBit methods. added += 2 to skip even numbers in the first for loop and factor is already increased by += 2 so there should be no need to check for even numbers anymore. The second for appears to always be odd and is not needed. This is about 16% faster performance on my older machine.

I added a closing ?> to the end of the file though perhaps that was left off with intent -- I don't know.

Also if I have messed up any formalities here, please let me know. I haven't worked much with git.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->
Didn't add a few of these as I am only doing a pull request.

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [ ] I placed my solution in the correct solution folder.
* [ ] I added a README.md with the right badge(s).
* [ ] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
