### PR TITLE
Use JIT optimizations and SplFixedArray instead of raw arrays

### DIFF
--- a/PrimePHP/solution_2/Dockerfile
+++ b/PrimePHP/solution_2/Dockerfile
@@ -2,6 +2,8 @@ FROM php:8.0-cli-alpine3.13
 
 WORKDIR /opt/app
 
+RUN docker-php-ext-install opcache
+
 COPY *.php .
 
-ENTRYPOINT [ "php", "-dopcache.enable_cli=1", "-dopcache.enable=1", "-dopcache.jit_buffer_size=100M", "-dopcache.jit=1255", "-dxdebug.mode=off", "PrimePHP.php" ]
+ENTRYPOINT [ "php", "-dopcache.enable_cli=1", "PrimePHP.php" ]

--- a/PrimePHP/solution_2/Dockerfile
+++ b/PrimePHP/solution_2/Dockerfile
@@ -1,0 +1,7 @@
+FROM php:8.0-cli-alpine3.13
+
+WORKDIR /opt/app
+
+COPY *.php .
+
+ENTRYPOINT [ "php", "-dopcache.enable_cli=1", "-dopcache.enable=1", "-dopcache.jit_buffer_size=100M", "-dopcache.jit=1255", "-dxdebug.mode=off", "PrimePHP.php" ]

--- a/PrimePHP/solution_2/PrimePHP.php
+++ b/PrimePHP/solution_2/PrimePHP.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 final class PrimeSieve
 {
     private int $sieveSize;
+    private int $rawBitsSize;
 
     /** @var SplFixedArray<bool> */
     private SplFixedArray $rawBits;
@@ -30,44 +31,54 @@ final class PrimeSieve
         return self::$resultsDictionary[$this->sieveSize] === $count;
     }
 
-    public function __construct(int $n)
+    public function __construct(int $sieveSize)
     {
-        // Creates the whole list of elements with 'null' as value
-        $this->rawBits = new SplFixedArray($n);
-        $this->sieveSize = $n;
+        $this->sieveSize = $sieveSize;
+        $this->rawBitsSize = (int)(($this->sieveSize + 1) / 2);
     }
 
     public function runSieve(): void
     {
         $factor = 3;
-        $q = \sqrt($this->sieveSize);
+        $sieveSize = $this->sieveSize;
+        $rawBitsSize = $this->rawBitsSize;
+        $q = (int) \sqrt($sieveSize);
+        $rawBits = new SplFixedArray($rawBitsSize);
 
         while ($factor < $q) {
-            for ($num = $factor; $num <= $this->sieveSize; $num += 2) {
+            for ($num = $factor; $num <= $sieveSize; $num += 2) {
                 // Invert the checks
-                if (null === $this->rawBits[$num]) {
+                if (null === $rawBits[$num / 2]) {
                     $factor = $num;
 
                     break;
                 }
             }
 
-            for ($num = $factor * $factor; $num <= $this->sieveSize; $num += $factor * 2) {
-                // Iinvert value asignment to keep main functionality intact with inverted checks
-                $this->rawBits[$num] = true;
+            $start = ($factor ** 2) / 2;
+
+            for ($num = $start; $num <= $rawBitsSize; $num += $factor) {
+                // Invert value asignment to keep main functionality intact with inverted checks
+                $rawBits[$num] = true;
             }
 
             $factor += 2;
         }
+
+        $this->rawBits = $rawBits;
     }
 
     public function printResults(bool $showResults, float $duration, int $passes): void
     {
         if ($showResults) {
             echo '2, ';
-        }
 
-        if ($showResults) {
+            for ($num = 3; $num < $this->sieveSize; $num += 2) {
+                if (($num & 1) === 1 && null === $this->rawBits[$num / 2]) {
+                    echo $num, ", ";
+                }
+            }
+
             echo "\n";
         }
 
@@ -92,9 +103,9 @@ final class PrimeSieve
     {
         $count = (int) ($this->sieveSize >= 2);
 
-        for ($num = 3; $num < $this->sieveSize; $num += 2) {
+        for ($num = 3; $num < $this->sieveSize; $num++) {
             // Invert the checks
-            if (null === $this->rawBits[$num]) {
+            if (($num & 1) === 1 && null === $this->rawBits[$num / 2]) {
                 ++$count;
             }
         }

--- a/PrimePHP/solution_2/PrimePHP.php
+++ b/PrimePHP/solution_2/PrimePHP.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+final class PrimeSieve
+{
+    private int $sieveSize;
+
+    /** @var SplFixedArray<bool> */
+    private SplFixedArray $rawBits;
+
+    /** @var array<int, int> */
+    private static $resultsDictionary = [
+        10 => 4,                 // Historical data for validating our results - the number of primes
+        100 => 25,               // to be found under some limit, such as 168 primes under 1000
+        1000 => 168,
+        10000 => 1229,
+        100000 => 9592,
+        1000000 => 78498,
+        10000000 => 664579,
+        100000000 => 5761455,
+    ];
+
+    private function validateResults(int $count): bool
+    {
+        if (!\array_key_exists($this->sieveSize, self::$resultsDictionary)) {
+            return false;
+        }
+
+        return self::$resultsDictionary[$this->sieveSize] === $count;
+    }
+
+    public function __construct(int $n)
+    {
+        // Creates the whole list of elements with 'null' as value
+        $this->rawBits = new SplFixedArray($n);
+        $this->sieveSize = $n;
+    }
+
+    public function runSieve(): void
+    {
+        $factor = 3;
+        $q = \sqrt($this->sieveSize);
+
+        while ($factor < $q) {
+            for ($num = $factor; $num <= $this->sieveSize; $num += 2) {
+                // Invert the checks
+                if (null === $this->rawBits[$num]) {
+                    $factor = $num;
+
+                    break;
+                }
+            }
+
+            for ($num = $factor * $factor; $num <= $this->sieveSize; $num += $factor * 2) {
+                // Iinvert value asignment to keep main functionality intact with inverted checks
+                $this->rawBits[$num] = true;
+            }
+
+            $factor += 2;
+        }
+    }
+
+    public function printResults(bool $showResults, float $duration, int $passes): void
+    {
+        if ($showResults) {
+            echo '2, ';
+        }
+
+        if ($showResults) {
+            echo "\n";
+        }
+
+        $count = $this->countPrimes();
+
+        \printf(
+            "Passes: %d, Time: %lf, Avg: %lf, Limit: %ld, Count: %d, Valid: %d\n",
+            $passes,
+            $duration,
+            $duration / $passes,
+            $this->sieveSize,
+            $count,
+            $this->validateResults($count)
+        );
+
+        // Following 2 lines added by rbergen to conform to drag race output format
+        echo "\n";
+        \printf("HugoSantiagoBecerraAdan;%d;%f;1;algorithm=base,faithful=yes\n", $passes, $duration);
+    }
+
+    public function countPrimes(): int
+    {
+        $count = (int) ($this->sieveSize >= 2);
+
+        for ($num = 3; $num < $this->sieveSize; $num += 2) {
+            // Invert the checks
+            if (null === $this->rawBits[$num]) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+}
+
+$sieveSize = 1000000;                  // Set sieve size
+$runTime = 5;                          // The amount of seconds the script should be running for
+$printResults = false;                 // Print the prime numbers that are found
+
+$passes = 0;
+$tStart = \microtime(true);
+
+while (true) {
+    $sieve = new PrimeSieve($sieveSize);
+    $sieve->runSieve();
+
+    ++$passes;
+
+    $duration = \microtime(true) - $tStart;
+
+    if ($duration >= $runTime) {
+        $sieve->printResults($printResults, $duration, $passes);
+
+        break;
+    }
+}

--- a/PrimePHP/solution_2/README.md
+++ b/PrimePHP/solution_2/README.md
@@ -5,9 +5,9 @@
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
 ![Bit count](https://img.shields.io/badge/Bits-unknown-yellowgreen)
 
-Implementation for PHP8 JIT with a faithful aproach to the algorithm presented in PrimeCPP by Dave Plummer almost line by line.
+Implementation based on the algorithm presented in PrimeCPP by Dave Plummer.
 
-This solution provides an expected **performance improvement between x3 and x4** over Solution #1.
+This solution uses PHP JIT and `SplFixedArray` with a **performance improvement over x5** in the result passes over Solution #1 (see performance below).
 
 The main code difference in comparison with the solution #1 or the CPP version is the use of `SplFixedArray` instead of raw arrays and the inverted values of the list.
 
@@ -57,9 +57,9 @@ PHP 8.0.8 (cli) (built: Jul  1 2021 15:26:46) ( NTS )
 
 ```bash
 $ ./run.sh
-Passes: 128, Time: 5.011532, Avg: 0.039153, Limit: 1000000, Count: 78498, Valid: 1
+Passes: 200, Time: 5.010664, Avg: 0.025053, Limit: 1000000, Count: 78498, Valid: 1
 
-HugoSantiagoBecerraAdan;128;5.011532;1;algorithm=base,faithful=yes
+HugoSantiagoBecerraAdan;200;5.010664;1;algorithm=base,faithful=yes
 ```
 
 Compared to other PHP implementations:

--- a/PrimePHP/solution_2/README.md
+++ b/PrimePHP/solution_2/README.md
@@ -1,0 +1,73 @@
+# PHP8 JIT solution by HugoSantiagoBecerraAdan
+
+![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
+![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
+![Parallelism](https://img.shields.io/badge/Parallel-no-green)
+![Bit count](https://img.shields.io/badge/Bits-unknown-yellowgreen)
+
+Implementation for PHP8 JIT with a faithful aproach to the algorithm presented in PrimeCPP by Dave Plummer almost line by line.
+
+This solution provides an expected **performance improvement between x3 and x4** over Solution #1.
+
+The main code difference in comparison with the solution #1 or the CPP version is the use of `SplFixedArray` instead of raw arrays and the inverted values of the list.
+
+A big performance penalty happens when initializing the elements of the list to `true`. Even calling the function `array_fill` it takes a significant amount of time. Using `SplFixedArray` instead of raw arrays provides a faster aproach in comparison when handling large lists with fixed number of elements.
+
+In order to improve more the performance, the elements of the list object are not initialized with `true` value, so they keep the default value of `null` and all validation works in inverted form.
+
+```php
+// Creates the whole list of elements with 'null' as value
+$this->rawBits = new SplFixedArray($this->sieveSize);
+```
+
+The validation and asignments are inverted to keep the functionality intact.
+
+```php
+// Inverted validation
+if (null === $this->rawBits[$num]) {
+```
+
+```php
+// Inverted value asignment
+$this->rawBits[$num] = true;
+```
+
+## Run instructions
+
+`./run.sh`, requires PHP 8.0 or above.
+
+Install PHP (CLI - Command Line Interface)
+
+> PHP8 is provided with Ubuntu and installable using `sudo apt install php-cli`
+
+How to verify installed PHP version:
+
+```bash
+$ php -v
+PHP 8.0.8 (cli) (built: Jul  1 2021 15:26:46) ( NTS )
+```
+
+## Output
+
+* **OS**: GNU/Linux (Kubuntu 20.04) 5.4.0-77-generic 64 bits
+* **CPU**: 8 × Intel® Core™ i7-8550U CPU @ 1.80GHz
+* **RAM**: 16 GiB
+
+### Native performance
+
+```bash
+$ ./run.sh
+Passes: 128, Time: 5.011532, Avg: 0.039153, Limit: 1000000, Count: 78498, Valid: 1
+
+HugoSantiagoBecerraAdan;128;5.011532;1;algorithm=base,faithful=yes
+```
+
+Compared to other PHP implementations:
+
+*Solution 1 (with corrected time limit of 5 sec.)*
+
+> Solution 1 uses a limit of **10 sec.** for execution time instead of 5 like the other implementations, so results must be inaccurate for comparisons.
+
+     Passes: 37, Time: 5117ms, Avg: 138ms, Limit: 1000000, Count: 78498, Valid: True
+
+     DennisdeBest;37;5.117794;1;algorithm=base,faithful=yes

--- a/PrimePHP/solution_2/run.sh
+++ b/PrimePHP/solution_2/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+php -dopcache.enable_cli=1 -dopcache.enable=1 -dopcache.jit_buffer_size=100M -dopcache.jit=1255 PrimePHP.php


### PR DESCRIPTION
## Description
Implementation for PHP8 using JIT and `SplFixedArray`

`SplFixedArray` provides a faster aproach to handle large lists with a fixed number of elements in comparison to raw arrays.

In order to improve more the performance, the elements of the list are not initialized with `true` value. They have the default value of `null` and all validation works in inverted form to keep the functionality intact.

This is an inverted validation:

```php
// Inverted validation
if (null === $this->rawBits[$num]) {
```

instead of:

```php
// Regular validation
if ($this->rawBits[$num]) {
```

This is an inverted asignment:

```php
// Inverted value asignment
$this->rawBits[$num] = true;
```

instead of:

```php
// Regular value asignment
$this->rawBits[$num] = false;
```

The Primes passes increase about 20% when compare to same code implementation but using raw array and `array_fill`.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
