### PR TITLE
PowerShell: Fix Solution 2 Sieve Calculation

### DIFF
--- a/PrimePowerShell/solution_2/PrimePowerShell.ps1
+++ b/PrimePowerShell/solution_2/PrimePowerShell.ps1
@@ -96,7 +96,7 @@ param(
 
 # Known results for validating the output.
 $KnowResults = @{
-    10        = 1;
+    10        = 4;
     100       = 25;
     1000      = 168;
     10000     = 1229;
@@ -109,7 +109,7 @@ $KnowResults = @{
 class Sieve {
     Sieve([int]$Size) {
         $this.SieveSize = $Size
-        $this.BitArray = (New-Object -TypeName System.Collections.BitArray -ArgumentList ([int] (($Size + 1) / 2)), $true)
+        $this.BitArray = (New-Object -TypeName System.Collections.BitArray -ArgumentList ([int] (($Size / 2) + ($Size % 2))), $true)
     }
     [int]$SieveSize
     [System.Collections.BitArray]$BitArray
@@ -185,19 +185,17 @@ function Invoke-Sieve {
     $factor = 3
     $q = [int] [System.Math]::Sqrt($Sieve.SieveSize)
 
-    while ($factor -lt $q) {
-        for ($i = $factor; $i -le $Sieve.SieveSize; ++$i) {
+    while ($factor -le $q) {
+        for ($i = $factor; $i -lt $Sieve.SieveSize; ++$i) {
             if (($i -band 1) -or $Sieve.BitArray[$i -shr 1]) {
                 $factor = $i
                 break;
             }
         }
-        
+
         $step = 2 * $factor
-        for ($i = $factor * 3; $i -le $Sieve.SieveSize; $i += $step) {
-            if ($i -band 1) {
-                $Sieve.BitArray[$i -shr 1] = $false;
-            }
+        for ($i = $factor * $factor; $i -lt $Sieve.SieveSize; $i += $step) {
+            $Sieve.BitArray[$i -shr 1] = $false;
         }
 
         $factor += 2
@@ -231,8 +229,8 @@ function Write-Results {
     $retval = [System.Collections.Generic.List[int]]::New($Sieve.SieveSize)
     $retval.Add(2)
     
-    for ($i = 3; $i -le $Sieve.SieveSize; ++$i) {
-        if (($i -band 1) -or $Sieve.BitArray[$i -shr 1]) {
+    for ($i = 3; $i -le $Sieve.SieveSize; $i+=2) {
+        if ($Sieve.BitArray[$i -shr 1]) {
             ++$count
             $retval.Add($i)
         }


### PR DESCRIPTION
## Description
Fixes bugs in the Sieve Calculation and Sieve Output for PowerShell / Solution 2 by @crowbar27  https://github.com/PlummersSoftwareLLC/Primes/pull/293#issuecomment-880271602


Fixes
* Incorrect known result was set for Sieve 10
* Incorrect bit allocation for sieve bit array
* `Invoke-Sieve` exited an iteration too early for square root of sieve size
* `Write-Results` used wrong increment when generating output based on bit array

Optimizes
* Clearing sieve flags can start with factor squared
* Remove unnecessary condition when clearing sieve flag

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

* [X] I read the contribution guidelines in CONTRIBUTING.md.
* [X] I placed my solution in the correct solution folder.
* [X] I added a README.md with the right badge(s).
* [X] I added a Dockerfile that builds and runs my solution.
* [X] I selected `drag-race` as the target branch.
* [X] All code herein is licensed compatible with BSD-3.
