### PR TITLE
Add Julia solution_3 based on sieve_1of2.c

### DIFF
--- a/PrimeJulia/solution_3/Dockerfile
+++ b/PrimeJulia/solution_3/Dockerfile
@@ -1,0 +1,7 @@
+FROM julia:1.6-buster
+
+WORKDIR /opt/app
+
+COPY *.jl ./
+
+ENTRYPOINT [ "julia", "primes_1of2.jl" ]

--- a/PrimeJulia/solution_3/README.md
+++ b/PrimeJulia/solution_3/README.md
@@ -30,8 +30,11 @@ simplifies the set_bit operation slightly
 
 If you see any room for improvement in the code or have any
 suggestions, don't hesitate to open an issue, pull request (PR), 
-discussion, or the like. Don't forget to tag me at `@louie-github` so I
+Discussion, or the like. Don't forget to tag me at `@louie-github` so I
 can be notified if my personal input is either wanted or needed.
+I'm open to fixing stylistic issues or discussing cosmetic changes to
+the code, but for those, it might be best if you open a Discussion
+first before opening an issue or pull request.
 
 
 ## Run instructions

--- a/PrimeJulia/solution_3/README.md
+++ b/PrimeJulia/solution_3/README.md
@@ -1,0 +1,123 @@
+# Julia solution by louie-github
+![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
+![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
+![Bit count](https://img.shields.io/badge/Bits-1-green)
+![Parallelism](https://img.shields.io/badge/Parallel-no-green)
+
+This solution is a port of [PrimeC/solution_2/sieve_1of2.c](../../PrimeC/solution_2/sieve_1of2.c)
+by Daniel Spångberg, with a few small tweaks and Julia-specific
+optimizations.
+
+Instead of using Julia's native `BitVector` type, this solution
+manually implements a bit array using a `Vector{UInt}` where `UInt`
+maps to the native unsigned integer type (native word size).
+
+Manual bit shifting and bit masking is employed to both read and set
+bits in the bit array. Bitwise operations are used as much as possible
+over arithmetic operations since they are much faster and simpler to
+execute.
+
+For readability, these bitwise operations are wrapped in functions such
+as `_div2` and `_mod_uint_size`. This is not unlike what Julia itself
+does with its native `BitVector` type (see
+[bitarray.jl](https://github.com/JuliaLang/julia/blob/master/base/bitarray.jl)).
+
+This implementation only stores bits for the odd numbers above 3. It is
+also an "inverted" bit array, i.e., bits are set when the number is
+*not prime* and bits are unset when the number is *prime*. This
+simplifies the set_bit operation slightly
+(`arr[i] |= mask vs. arr[i] &= ~mask`).
+
+
+## Run instructions
+
+### Running locally
+
+To build and run the solution locally, run the following command:
+```
+julia primes_1of2.jl
+```
+
+Optionally, you can specify a sieve size as an additional command line argument:
+```
+julia primes_1of2.jl 1000
+```
+
+You can also specify the duration to run the benchmark for after the
+sieve size:
+```
+julia primes_1of2.jl 1000000 10
+```
+
+### Running in Docker
+
+If you want to run this solution in a Docker container, follow the steps below.
+
+1. Build or update the Docker image. You can skip this step if you have
+   already built the `primejulia-3` image.
+
+```
+docker build --pull -t primejulia-3 .
+```
+
+2. Run the `primejulia-3` image as a container.
+```
+docker run -it --rm primejulia-3
+```
+You can also pass in a sieve size and/or a duration as additional
+arguments similar to when you run the solution locally:
+```
+docker run -it --rm primejulia-3 1000
+docker run -it --rm primejulia-3 1000000 10
+```
+
+3. If you want to remove the built Docker image, run:
+```
+docker image rm primejulia-3
+```
+
+This solution's [Dockerfile](Dockerfile) uses the `1.6-buster` image
+to provide maximum support for different architectures, most
+importantly ARM64 and x86_64. This also helps avoid any possible issues
+caused by Julia's [Tier 3 support for musl](https://julialang.org/downloads/#currently_supported_platforms),
+including Alpine Linux.
+
+
+## Validating results
+
+The validation code has been moved to a separate file:
+[validate.jl](validate.jl).
+
+Since 32-bit systems cannot represent the final element of the results
+dictionary (10^10 or 10000000000) in a single `UInt32`, this number is
+skipped when running validate.jl on 32 bit systems.
+
+To validate the results given by [primes_1of2.jl](primes_1of2.jl), run:
+```
+julia validate.jl
+```
+Note that this may take a few minutes to complete.
+
+If you want to verify that primes_1of2.jl does not go out-of-bounds
+when accessing memory since it uses `@inbounds` quite liberally, run
+either primes_1of2.jl or validate.jl with `julia --check-bounds=yes`.
+```
+julia --check-bounds=yes primes_1of2.jl
+julia --check-bounds=yes validate.jl
+```
+Note that this will make the code run a fair bit slower.
+
+
+## Output
+
+This is the output from running the solution on a machine with an Intel
+Core i5-9300H CPU and 24 GB of RAM running Windows 10 Home:
+```
+PS D:\Office Files\Programming\Primes> julia primes_1of2.jl
+Settings: sieve_size = 1000000 | duration = 5
+Number of trues: 78498
+primes_main.jl: Passes: 8549 | Elapsed: 5.0 | Passes per second: 1709.8 | Average pass duration: 0.0005848637267516669
+louie-github_port_1of2;8549;5.0;1;algorithm=base,faithful=yes,bits=1
+```
+On said machine, the number of passes usually ranges between 8300
+and 8600.

--- a/PrimeJulia/solution_3/README.md
+++ b/PrimeJulia/solution_3/README.md
@@ -28,6 +28,11 @@ also an "inverted" bit array, i.e., bits are set when the number is
 simplifies the set_bit operation slightly
 (`arr[i] |= mask vs. arr[i] &= ~mask`).
 
+If you see any room for improvement in the code or have any
+suggestions, don't hesitate to open an issue, pull request (PR), 
+discussion, or the like. Don't forget to tag me at `@louie-github` so I
+can be notified if my personal input is either wanted or needed.
+
 
 ## Run instructions
 

--- a/PrimeJulia/solution_3/primes_1of2.jl
+++ b/PrimeJulia/solution_3/primes_1of2.jl
@@ -1,0 +1,195 @@
+# Solution based on PrimeC/solution_2/sieve_1of2.c by Daniel Spångberg
+# 
+# While UInts are used as much as possible in the main code for
+# consistency, speed reasons, and to mimic sieve_1of2.c, most of the
+# defined functions accept any subtype of Integer so it's easier to
+# test them in the REPL, and also if we ever need to change `UInt` to
+# another type like `Int` for benchmarking purposes.
+# Julia compiles specialized code for each specific type anyway, so
+# we shouldn't see any significant slowdowns by doing this.
+# If you want to use purely UInts, you can simply replace all function
+# signatures containing `::Integer` to `::UInt` as well as patch the
+# count_primes and get_found_primes functions to use UInts.
+
+# This is basically a log2(sizeof(UInt)).
+if UInt == UInt16
+    const _div_uint_size_shift = 4
+elseif UInt == UInt32
+    const _div_uint_size_shift = 5
+elseif UInt == UInt64
+    const _div_uint_size_shift = 6
+elseif UInt == UInt128
+    const _div_uint_size_shift = 7
+else
+    error("Unknown UInt type ($UInt)")
+end
+const _uint_bit_length = sizeof(UInt) * 8
+
+# Functions like the ones defined below are also used in Julia Base
+# to speed up things such as Julia's native BitArray type.
+@inline _mul2(i::Integer) = i << 1
+@inline _div2(i::Integer) = i >> 1
+# Map factor to index (3 => 1, 5 => 2, 7 => 3, ...) and vice versa.
+@inline _map_to_index(i::Integer) = _div2(i - 1)
+@inline _map_to_factor(i::Integer) = _mul2(i) + 1
+# This function also takes inspiration from Base._mod64 (bitarray.jl).
+@inline _mod_uint_size(i::Integer) = i & (_uint_bit_length - 1)
+@inline _div_uint_size(i::Integer) = i >> _div_uint_size_shift
+# These functions are similar to Base.get_chunk_id (bitarray.jl).
+# This is definitely a bit more complicated due to one-based indexing.
+@inline _get_chunk_index(i::Integer) = _div_uint_size(i - 1) + 1
+@inline _get_bit_index_mask(i::Integer) = UInt(1) << _mod_uint_size(i - 1)
+
+
+struct PrimeSieve
+    sieve_size::UInt
+    is_not_prime::Vector{UInt}
+end
+
+# This is more accurate than _div_uint_size(_div2(i)) + 1
+@inline _get_num_uints(i::Integer) = _div_uint_size(
+    # We only store odd numbers starting from 3
+    _div2(
+        # Subtract 2 from i to account for the fact that the first
+        # index maps to 3, not 1.
+        i - 2 + (2 * _uint_bit_length - 1)
+    )
+)
+
+function PrimeSieve(sieve_size::UInt)
+    return PrimeSieve(sieve_size, zeros(UInt, _get_num_uints(sieve_size)))
+end
+
+# The main() function uses the UInt constructor; this is mostly useful
+# for testing in the REPL.
+PrimeSieve(sieve_size::Int) = PrimeSieve(UInt(sieve_size))
+
+@inline function unsafe_get_bit_at_index(arr::Vector{UInt}, index::Integer)
+    return @inbounds arr[_get_chunk_index(index)] & _get_bit_index_mask(index)
+end
+
+# This is used in unsafe_find_next_factor_index since we bitrotate the
+# bitmask there instead of calling _get_bit_index_mask each time.
+@inline function unsafe_get_bit_at_index_with_bitmask(arr::Vector{UInt}, index::Integer, bitmask::Integer)
+    return @inbounds arr[_get_chunk_index(index)] & bitmask
+end
+
+@inline function unsafe_set_bit_at_index!(arr::Vector{UInt}, index::Integer)
+    @inbounds arr[_get_chunk_index(index)] |= _get_bit_index_mask(index)
+end
+
+function unsafe_find_next_factor_index(arr::Vector{UInt}, start_index::Integer, max_index::Integer)
+    # Bit rotating the mask might be slower on platforms without a
+    # native bit rotate instruction. Requires at least Julia 1.5.
+    bitmask = _get_bit_index_mask(start_index)
+    for index in start_index:max_index
+        if unsafe_get_bit_at_index_with_bitmask(arr, index, bitmask) == 0
+            return index
+        end
+        bitmask = bitrotate(bitmask, 1)
+    end
+    # Unsafe: you need to check this in the caller or make sure it
+    # never happens
+    return max_index + 1
+end
+
+function clear_factors!(arr::Vector{UInt}, factor_index::Integer, max_index::Integer)
+    factor = _map_to_factor(factor_index)
+    # Since the for loop carries some memory dependencies (no two
+    # iterations should access the same UInt at the same time), we can
+    # only use `@simd` and not `@simd ivdep`.
+    @simd for index in _div2(factor * factor):factor:max_index
+        unsafe_set_bit_at_index!(arr, index)
+    end
+end
+
+function run_sieve!(sieve::PrimeSieve)
+    is_not_prime = sieve.is_not_prime
+    sieve_size = sieve.sieve_size
+    max_bits_index = _map_to_index(sieve_size)
+    max_factor_index = _map_to_index(@fastmath unsafe_trunc(UInt, sqrt(sieve_size)))
+    factor_index = UInt(1) # 1 => 3, 2 => 5, 3 => 7, ...
+    while factor_index <= max_factor_index
+        factor_index = unsafe_find_next_factor_index(is_not_prime, factor_index, max_bits_index)
+        clear_factors!(is_not_prime, factor_index, max_bits_index)
+        factor_index += 1
+    end
+    return is_not_prime
+end
+
+# These functions aren't optimized, but they aren't being benchmarked,
+# so it's fine.
+function count_primes(sieve::PrimeSieve)
+    arr = sieve.is_not_prime
+    max_bits_index = _map_to_index(sieve.sieve_size)
+    # Since we start clearing factors at 3, we include 2 in the count
+    # beforehand.
+    count = 1
+    for i in 1:max_bits_index
+        if unsafe_get_bit_at_index(arr, i) == 0
+            count += 1
+        end
+    end
+    return count
+end
+
+function get_found_primes(sieve::PrimeSieve)
+    arr = sieve.is_not_prime
+    sieve_size = sieve.sieve_size
+    max_bits_index = _map_to_index(sieve_size)
+    output = [2]
+    # Int(sieve_size) may overflow if sieve_size is too large (most
+    # likely only a problem for 32-bit systems)
+    for (index, number) in zip(1:max_bits_index, 3:2:Int(sieve_size))
+        if unsafe_get_bit_at_index(arr, index) == 0
+            push!(output, number)
+        end
+    end
+    return output
+end
+
+function main_benchmark(sieve_size::Integer, duration::Integer)
+    println(stderr, "Settings: sieve_size = $sieve_size | duration = $duration")
+    start_time = time()
+    elapsed = 0
+    passes = 0
+    # Ensure precompilation before we run the main benchmark.
+    sieve_instance = PrimeSieve(sieve_size)
+    run_sieve!(sieve_instance)
+    while elapsed < duration
+        run_sieve!(PrimeSieve(sieve_size))
+        passes += 1
+        elapsed = time() - start_time
+    end
+    println(stderr, "Number of trues: ", count_primes(sieve_instance))
+    println(
+        stderr,
+        "primes_main.jl: ",
+        join(
+            [
+                "Passes: $passes",
+                "Elapsed: $elapsed",
+                "Passes per second: $(passes / elapsed)",
+                "Average pass duration: $(elapsed / passes)",
+            ],
+            " | ",
+        )
+    )
+    println("louie-github_port_1of2;$passes;$elapsed;1;algorithm=base,faithful=yes,bits=1")
+end
+
+function main(args::Vector{String}=ARGS)
+    args_sieve_size = length(args) >= 1 ? tryparse(Int, args[1]) : nothing
+    args_duration = length(args) >= 2 ? tryparse(Int, args[2]) : nothing
+    # Techincally, we could just keep sieve_size as an Int since we
+    # have an Int constructor for PrimeSieve, but let's just use UInt
+    # to be consistent.
+    sieve_size = isnothing(args_sieve_size) ? UInt(1_000_000) : UInt(args_sieve_size)
+    duration = isnothing(args_duration) ? 5 : args_duration
+    main_benchmark(sieve_size, duration)
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    precompile(main_benchmark, (UInt, Int))
+    main()
+end

--- a/PrimeJulia/solution_3/primes_1of2.jl
+++ b/PrimeJulia/solution_3/primes_1of2.jl
@@ -107,7 +107,7 @@ function run_sieve!(sieve::PrimeSieve)
     is_not_prime = sieve.is_not_prime
     sieve_size = sieve.sieve_size
     max_bits_index = _map_to_index(sieve_size)
-    max_factor_index = _map_to_index(@fastmath unsafe_trunc(UInt, sqrt(sieve_size)))
+    max_factor_index = _map_to_index(unsafe_trunc(UInt, sqrt(sieve_size)))
     factor_index = UInt(1) # 1 => 3, 2 => 5, 3 => 7, ...
     while factor_index <= max_factor_index
         factor_index = unsafe_find_next_factor_index(is_not_prime, factor_index, max_bits_index)

--- a/PrimeJulia/solution_3/validate.jl
+++ b/PrimeJulia/solution_3/validate.jl
@@ -1,0 +1,42 @@
+include("primes_1of2.jl")
+
+# Taken from PrimeCPP/solution_1/PrimeCPP.cpp
+const resultsDictionary = Dict(
+    10 => 4,
+    100 => 25,
+    1000 => 168,
+    10000 => 1229,
+    100000 => 9592,
+    1000000 => 78498,
+    10000000 => 664579,
+    100000000 => 5761455,
+    1000000000 => 50847534
+)
+
+# UInt16 can't even handle 1 million
+if UInt == UInt16
+    error("UInt is detected as UInt16. Cannot run tests.")
+# 32-bit systems cannot represent 10^10 or 10_000_000_000
+elseif UInt == UInt32
+    @warn "Skipping test 10000000000 => 455052511 since machine is 32-bit."
+else
+    push!(resultsDictionary, 10000000000 => 455052511)
+end
+
+function validate_results()
+    output = Bool[]
+    for (sieve_size, expected_result) in resultsDictionary
+        print("$sieve_size => $expected_result: ")
+        s = PrimeSieve(sieve_size)
+        run_sieve!(s)
+        result = count_primes(s) == expected_result
+        println(result)
+        push!(output, result)
+    end
+    return all(output)
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    const is_valid = validate_results()
+    println("All tests return true: $is_valid")
+end


### PR DESCRIPTION
## Description
<!--
Add your description yere.
-->
This new Julia implementation is a port of [PrimeC/solution_2/sieve_1of2.c](https://github.com/PlummersSoftwareLLC/Primes/blob/drag-race/PrimeC/solution_2/sieve_1of2.c) by Daniel Spångberg. It runs quite a bit faster than [PrimeJulia/solution_2](https://github.com/PlummersSoftwareLLC/Primes/tree/drag-race/PrimeJulia/solution_2) on my machine:
```
PS D:\Office Files\Programming\PrimesFork\PrimeJulia> julia .\solution_2\Primes.jl
2, 3, 5, 7, 11, …, 999953, 999959, 999961, 999979, 999983
Passes: 6837, Time: 5.0, Avg: 0.0007313149041977475, Limit: 1000000, Count: 78498
epithet-jl;6837;5.0;1;algorithm=base,faithful=yes,bits=1
```
```
PS D:\Office Files\Programming\PrimesFork\PrimeJulia> julia .\solution_3\primes_1of2.jl
Settings: sieve_size = 1000000 | duration = 5
Number of trues: 78498
primes_main.jl: Passes: 8723 | Elapsed: 5.0 | Passes per second: 1744.6 | Average pass duration: 0.0005731972945087699
louie-github_port_1of2;8723;5.0;1;algorithm=base,faithful=yes,bits=1
```

This implementation's biggest differences are that it uses bitwise operations as much as possible to avoid the overhead of arithmetic operations like `div`, and that it manually implements a bit array using `Vector{UInt}` rather than using Julia's native `BitArray` or `BitVector` type. This is very similar to how `sieve_1of2.c` does it.

You could describe this as being as low-level as you can get with Julia to squeeze the most out of its performance.

This implementation is different enough that I don't think it could easily be considered an "improvement" to any of the existing solutions, so I decided to separate it into its own solution.

On another note, this solution uses the `julia:1.6-buster` Docker image instead of `julia:1.6-alpine3.13` for two reasons:
1. Compatibility with ARM64 as well as x86_64 and other architectures
2. Issues that may arise when using `musl` as Julia only has ["Tier 3" support](https://julialang.org/downloads/#currently_supported_platforms) (builds may not be available, tests may fail, considered experimental) for builds linked to musl (e.g. Alpine Linux) rather than glibc.

I appreciate any and all feedback!

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

* [X] I read the contribution guidelines in CONTRIBUTING.md.
* [X] I placed my solution in the correct solution folder.
* [X] I added a README.md with the right badge(s).
* [X] I added a Dockerfile that builds and runs my solution.
* [X] I selected `drag-race` as the target branch.
* [X] All code herein is licensed compatible with BSD-3.
