### PR TITLE
Fixes Go/solution_1 faithfulness issue

### DIFF
--- a/PrimeGo/solution_1/main.go
+++ b/PrimeGo/solution_1/main.go
@@ -97,8 +97,8 @@ func main() {
 	passes := 0
 	startClock := time.Now()
 
-	initBitArray := make([]bool, 1e6)
 	for {
+		initBitArray := make([]bool, 1e6)
 		for i := range initBitArray {
 			initBitArray[i] = true
 		}


### PR DESCRIPTION
Makes Go/solution_1 actually faithful by pulling the creation of the bit array into the timed loop. It's part of the sieve container, so it needs to be recreated with every iteration as per the guidelines.