### PR TITLE
Set runtime to 5 seconds

### DIFF
--- a/PrimeAssemblyScript/solution_1/src/index.ts
+++ b/PrimeAssemblyScript/solution_1/src/index.ts
@@ -5,7 +5,7 @@ export function bench(): void {
     let passes = 0;
     let sieve: PrimeSieve | null;
     const startTime = Date.now();
-    while (Date.now() - startTime < 10000) {
+    while (Date.now() - startTime < 5000) {
         sieve = new PrimeSieve(1000000);
         sieve.runSieve();
         ++passes;

--- a/PrimeCSharp/solution_2/PrimeCS.cs
+++ b/PrimeCSharp/solution_2/PrimeCS.cs
@@ -132,7 +132,7 @@ namespace PrimeSieveCS
             var passes = 0;
             prime_sieve sieve = null;
 
-            while ((DateTime.UtcNow - tStart).TotalSeconds < 10)
+            while ((DateTime.UtcNow - tStart).TotalSeconds < 5)
             {
                 sieve = new prime_sieve(1000000);
                 sieve.runSieve();

--- a/PrimeDelphi/solution_1/PrimePas.dpr
+++ b/PrimeDelphi/solution_1/PrimePas.dpr
@@ -229,7 +229,7 @@ begin
 	passes := 0;
 
 	sieve := nil;
-	while TTimeSpan.Subtract(Now, dtStart).TotalSeconds < 10 do
+	while TTimeSpan.Subtract(Now, dtStart).TotalSeconds < 5 do
 	begin
 		if Assigned(sieve) then
 			sieve.Free;

--- a/PrimeHaxe/solution_1/src/Main.hx
+++ b/PrimeHaxe/solution_1/src/Main.hx
@@ -82,7 +82,7 @@ class Main {
         var tStart:Float = Sys.time();
         var passes:Int = 0;
         var sieve:PrimeSieve = null;
-        while (Sys.time() - tStart < 10) {
+        while (Sys.time() - tStart < 5) {
             sieve = new PrimeSieve(1000000);
             sieve.runSieve();
             passes += 1;

--- a/PrimeJava/solution_1/PrimeSieveJava.java
+++ b/PrimeJava/solution_1/PrimeSieveJava.java
@@ -119,7 +119,7 @@ public class PrimeSieveJava
 		int passes = 0;
 		PrimeSieveJava sieve = null;
 		
-		while ((System.currentTimeMillis() - start) < 10000)
+		while ((System.currentTimeMillis() - start) < 5000)
 		{
 			sieve = new PrimeSieveJava(1000000);
 			sieve.runSieve();

--- a/PrimePHP/solution_1/PrimePHP.php
+++ b/PrimePHP/solution_1/PrimePHP.php
@@ -90,7 +90,7 @@ $passes = 0;                            //Init passes
 $sieveSize = 1000000;                   //Set sieve size
 $printResults = false;                  //Print the prime numbers that are found
 $rawbitCount;                           //Init a rawbitCount to validate the result
-$runTime = 10;                          //The amount of seconds the script should be running for
+$runTime = 5;                           //The amount of seconds the script should be running for
 
 while (getTimeDiffInMs($tStart) < $runTime * 1000) {
     $sieve = new PrimeSieve($sieveSize);

--- a/PrimePython/solution_1/PrimePY.py
+++ b/PrimePython/solution_1/PrimePY.py
@@ -124,7 +124,7 @@ class prime_sieve(object):
 tStart = timeit.default_timer()                         # Record our starting time
 passes = 0                                              # We're going to count how many passes we make in fixed window of time
 
-while (timeit.default_timer() - tStart < 10):           # Run until more than 10 seconds have elapsed
+while (timeit.default_timer() - tStart < 5):           # Run until more than 10 seconds have elapsed
     sieve = prime_sieve(1000000)                        #  Calc the primes up to a million
     sieve.runSieve()                                    #  Find the results
     passes = passes + 1                                 #  Count this pass

--- a/PrimeSwift/solution_1/Sources/PrimeSieveSwift/main.swift
+++ b/PrimeSwift/solution_1/Sources/PrimeSieveSwift/main.swift
@@ -122,7 +122,7 @@ let start = Date()
 var passes = 0
 var sieve: PrimeSieveSwift!
 
-while start.distance(to: Date()) < 10 {
+while start.distance(to: Date()) < 5 {
     sieve = PrimeSieveSwift(limit: 1_000_000)
     sieve.runSieve()
     passes += 1


### PR DESCRIPTION
This sets the runtime for all solutions to 5 seconds. Some solutions that were grandfathered when the 5 second rule came in effect are now still running for 10.

After this is merged, any runtime other than 5 seconds will be considered a bug and fixed as such.