### PR TITLE
Cl solution2 patch 2

### DIFF
--- a/PrimeLisp/solution_2/Dockerfile
+++ b/PrimeLisp/solution_2/Dockerfile
@@ -1,10 +1,3 @@
-# Build and run like this:
-#
-# $ cd PrimeLisp/solution_2
-# $ podman build -t lisp2 .
-# $ podman run --rm lisp2
-
-#FROM clfoundation/sbcl:2.1.6-slim-buster
 FROM daewok/sbcl:2.1.6-alpine3.13
 
 WORKDIR /opt/app

--- a/PrimeLisp/solution_2/Dockerfile
+++ b/PrimeLisp/solution_2/Dockerfile
@@ -1,6 +1,11 @@
-FROM alpine:3.13
+# Build and run like this:
+#
+# $ cd PrimeLisp/solution_2
+# $ podman build -t lisp2 .
+# $ podman run --rm lisp2
 
-RUN apk --update add --no-cache sbcl
+#FROM clfoundation/sbcl:2.1.6-slim-buster
+FROM daewok/sbcl:2.1.6-alpine3.13
 
 WORKDIR /opt/app
 

--- a/PrimeLisp/solution_2/PrimeSieve.lisp
+++ b/PrimeLisp/solution_2/PrimeSieve.lisp
@@ -4,39 +4,65 @@
 ;;;     sbcl --script PrimeSieve.lisp
 ;;;
 
+
 (declaim
-  (optimize (speed 3) (safety 0) (debug 0) (space 0))
-  (inline get-bit)
-  (inline clear-bit))
+  (optimize (speed 3) (safety 0) (debug 0) (space 0)))
 
 
-(defun get-bit (rawbits index)
-  (declare (simple-bit-vector rawbits))
-  (if (zerop (mod index 2))
-        0
-    (aref rawbits
-        (floor index 2))))
+(defparameter *list-to* 100
+  "list primes up to that number, set to nil to disable listing")
 
-(defun clear-bit (rawbits index)
-  (declare (simple-bit-vector rawbits))
-  (setf (aref rawbits (floor index 2)) 0))
 
-(defun run-sieve (sieve-size)
-  (declare (fixnum sieve-size))
+(defconstant +results+
+  '((         10 . 4        )
+    (        100 . 25       )
+    (       1000 . 168      )
+    (      10000 . 1229     )
+    (     100000 . 9592     )
+    (    1000000 . 78498    )
+    (   10000000 . 664579   )
+    (  100000000 . 5761455  )
+    ( 1000000000 . 50847534 )
+    (10000000000 . 455052511))
+  "Historical data for validating our results - the number of primes
+   to be found under some limit, such as 168 primes under 1000")
 
-  (let ((rawbits (make-array
-                   (floor (1+ sieve-size) 2)
-                   :element-type 'bit
-                   :initial-element 1))
-        (q (floor (sqrt sieve-size))))
-    (declare (fixnum q))
-    (do ((factor 3 (+ factor 2))) ((> factor q))
+
+(defclass sieve-state ()
+  ((maxints :initarg :maxints
+            :type fixnum
+            :accessor sieve-state-maxints)
+
+   (a       :initarg :a
+            :type simple-bit-vector
+            :accessor sieve-state-a)))
+
+
+(defun create-sieve (maxints)
+  (declare (fixnum maxints))
+  (make-instance 'sieve-state
+    :maxints maxints
+    :a (make-array (floor (1+ maxints) 2)
+         :element-type 'bit
+         :initial-element 0)))
+
+
+(defun run-sieve (sieve-state)
+  (declare (type sieve-state sieve-state))
+
+  (let* ((rawbits (sieve-state-a sieve-state))
+         (sieve-size (sieve-state-maxints sieve-state))
+         (q (floor (sqrt sieve-size))))
+    (declare (fixnum sieve-size q) (type simple-bit-vector rawbits))
+    (do ((factor 3))
+        ((> factor q))
       (declare (fixnum factor))
 
       (loop for num fixnum
             from factor
-            to sieve-size
-            until (when (= (get-bit rawbits num) 1)
+            to q
+            by 2
+            until (when (zerop (sbit rawbits (floor num 2)))
                     (setq factor num)
                     t))
 
@@ -44,23 +70,54 @@
             from (the fixnum (* factor factor))
             to sieve-size
             by (the fixnum (* factor 2))  do
-        (clear-bit rawbits num)))
-    rawbits))
+        (setf (sbit rawbits (floor num 2)) 1))
 
-(defun count-primes (rawbits)
-  (reduce #'+ rawbits))
+      (incf factor 2))
+    sieve-state))
+
+
+(defun count-primes (sieve-state)
+  (reduce #'+ (sieve-state-a sieve-state) :key (lambda (n) (- 1 n))))
+
+
+(defun list-primes (result)
+  (princ "2, " *error-output*)
+  (let ((bits (sieve-state-a result)))
+    (loop for i
+          from 3
+          to (min *list-to* (sieve-state-maxints result))
+          by 2 do
+      (when (zerop (sbit bits (floor i 2)))
+        (format *error-output* "~d, " i))))
+  (when (< *list-to* (sieve-state-maxints result))
+    (princ "..." *error-output*))
+  (terpri *error-output*))
+
+
+(defun validate (sieve-state)
+  (let ((hist (cdr (assoc (sieve-state-maxints sieve-state) +results+ :test #'=))))
+    (if (and hist (= (count-primes sieve-state) hist)) "yes" "no")))
+
+
+;(require :sb-sprof) (sb-sprof:with-profiling (:max-samples 1000 :report :flat :loop nil)
 
 (let* ((passes 0)
        (start (get-internal-real-time))
        (end (+ start (* internal-time-units-per-second 5)))
        result)
+  (declare (fixnum passes))
 
   (do () ((>= (get-internal-real-time) end))
-    (setq result (run-sieve 1000000))
+    (setq result (create-sieve 1000000))
+    (run-sieve result)
     (incf passes))
 
   (let* ((duration  (/ (- (get-internal-real-time) start) internal-time-units-per-second))
          (avg (/ duration passes)))
-    (format *error-output* "Passes: ~d  Time: ~f Avg: ~f ms Count: ~d~%" passes duration (* 1000 avg)  (count-primes result))
+    (when *list-to* (list-primes result))
+    (format *error-output* "Algorithm: base  Passes: ~d  Time: ~f  Avg: ~f ms  Count: ~d  Valid: ~A~%"
+            passes duration (* 1000 avg) (count-primes result) (validate result))
 
-    (format t "mayerrobert-cl;~d;~f;1;algorithm=base,faithful=no,bits=1~%" passes duration)))
+    (format t "mayerrobert-cl;~d;~f;1;algorithm=base,faithful=yes,bits=1~%" passes duration)))
+
+;) (disassemble 'run-sieve)

--- a/PrimeLisp/solution_2/PrimeSieve.lisp
+++ b/PrimeLisp/solution_2/PrimeSieve.lisp
@@ -99,8 +99,6 @@
     (if (and hist (= (count-primes sieve-state) hist)) "yes" "no")))
 
 
-;(require :sb-sprof) (sb-sprof:with-profiling (:max-samples 1000 :report :flat :loop nil)
-
 (let* ((passes 0)
        (start (get-internal-real-time))
        (end (+ start (* internal-time-units-per-second 5)))
@@ -119,5 +117,3 @@
             passes duration (* 1000 avg) (count-primes result) (validate result))
 
     (format t "mayerrobert-cl;~d;~f;1;algorithm=base,faithful=yes,bits=1~%" passes duration)))
-
-;) (disassemble 'run-sieve)

--- a/PrimeLisp/solution_2/PrimeSieveWheel.lisp
+++ b/PrimeLisp/solution_2/PrimeSieveWheel.lisp
@@ -1,25 +1,45 @@
 ;;;; Common Lisp port of PrimeC/solution_2/sieve_5760of30030_only_write_read_bits.c by Daniel Spangberg
 ;;;
-;;; approx. 2.6x speedup over solution_2, approx. 325x speedup over solution_1
-;;;
 ;;; run as:
 ;;;     sbcl --script PrimeSieveWheel.lisp
 ;;;
-;;;
-;;; I have no idea how this works I just stole the algorithm.
-;;;
-;;; For Common Lisp bit ops see https://lispcookbook.github.io/cl-cookbook/numbers.html#bit-wise-operation
-;;;
-;;; (compile-file "PrimeSieveWheel.lisp") will show lots of info during the compilation
-;;; regarding inefficient code that can't be optimized.
 
 
 (declaim
   (optimize (speed 3) (safety 0) (debug 0)))
 
-(defconstant +bits-per-word+ 32)
-(defconstant +MASK+ #x1F)
-(defconstant +SHIFT+ -5)
+
+(defparameter *list-to* 100
+  "list primes up to that number, set to nil to disable listing")
+
+
+(defconstant +results+
+  '((         10 . 4        )
+    (        100 . 25       )
+    (       1000 . 168      )
+    (      10000 . 1229     )
+    (     100000 . 9592     )
+    (    1000000 . 78498    )
+    (   10000000 . 664579   )
+    (  100000000 . 5761455  )
+    ( 1000000000 . 50847534 )
+    (10000000000 . 455052511))
+  "Historical data for validating our results - the number of primes
+   to be found under some limit, such as 168 primes under 1000")
+
+
+#+64-bit (defconstant +bits-per-word+ 64)
+#-64-bit (defconstant +bits-per-word+ 32)
+
+(defconstant +MASK+ (1- +bits-per-word+))
+(defconstant +SHIFT+ (- (logcount +MASK+)))
+
+(deftype nonneg-fixnum ()
+  `(integer 0 ,most-positive-fixnum))
+
+(deftype sieve-element-type ()
+  `(unsigned-byte ,+bits-per-word+))
+
 
 (defconstant +steps+ #(
  8 1 2 3 1 3 2 1 2 3 3 1 3 2 1 3 2 3 4 2 1 2 1 2 7 
@@ -258,7 +278,7 @@
 
 (defstruct sieve-state
   (maxints -1 :type fixnum :read-only t)
-  (a nil :type simple-array))
+  (a nil :type simple-array :read-only t))
 
 
 (defun create-sieve (maxints)
@@ -266,8 +286,8 @@
   (make-sieve-state
     :maxints maxints
     :a (make-array
-         (1+ (floor maxints +bits-per-word+))
-         :element-type '(unsigned-byte 32)
+         (1+ (floor (floor maxints +bits-per-word+) 2))
+         :element-type 'sieve-element-type
          :initial-element 0)))
 
 
@@ -278,39 +298,45 @@
          (maxintsh (ash maxints -1))
          (a (sieve-state-a sieve-state))
          (q (1+ (isqrt maxints)))
-         (step 1)
-         (inc (aref steps step))
+         
          (factorh (ash 17 -1))
          (qh (ash q -1)))
-    (declare (fixnum maxints maxintsh q step inc factorh qh)
-             (simple-vector a))
-    (do () ((> factorh qh))
+    (declare (fixnum maxints maxintsh q factorh qh)
+             (type (simple-array sieve-element-type 1) a))
+    (do* ((step 1 (if (>= step 5759) 0 (1+ step)))
+          (inc (aref steps step) (aref steps step)))
+         ((> factorh qh))
+      (declare (fixnum step inc))
 
-      (if (not (zerop (logand (aref a (ash factorh +SHIFT+))
-                              (ash 1 (logand factorh +MASK+)))))
-            (progn
-              (incf factorh inc)
-              (when (= (incf step) 5760) (setq step 0))
-              (setq inc (aref steps step)))
+      (when (zerop (logand (aref a (ash factorh +SHIFT+))
+                           (ash 1 (logand factorh +MASK+))))
 
-        (let* ((istep step)
-               (ninc (aref steps istep))
-               (factor (1+ (ash factorh 1))))
-          (declare (fixnum istep ninc factor))
+;      (when (zerop (multiple-value-bind (q r) (floor factorh +bits-per-word+)
+;                     (declare (type nonneg-fixnum q) (type (integer 0 64) r))
+;                     (logand (aref a q) r)))
 
-          (do ((i (ash (the fixnum (* factor factor)) -1)))
-              ((> i maxintsh))
-            (declare (fixnum i))
-            (setf (aref a (ash i +SHIFT+))
-                  (logior (the (unsigned-byte 32) (aref a (ash i +SHIFT+)))
-                          (the (unsigned-byte 32) (ash 1 (logand i +MASK+)))))
-            (incf i (the fixnum (* factor ninc)))
-            (when (= (incf istep) 5760) (setq istep 0))
-            (setq ninc (aref steps istep)))
+;      (unless (multiple-value-bind (q r) (floor factorh +bits-per-word+)
+;                (declare (type nonneg-fixnum q) (type (integer 0 64) r))
+;                (logbitp r (aref a q)))
 
-          (incf factorh inc)
-          (if (= (incf step) 5760) (setq step 0))
-          (setq inc (aref steps step)))))))
+        (do* ((istep step (if (>= istep 5759) 0 (1+ istep)))
+              (ninc (aref steps istep) (aref steps istep))
+              (factor (1+ (ash factorh 1)))
+              (i (ash (the fixnum (* factor factor)) -1)))
+             ((>= i maxintsh))
+          (declare (fixnum istep ninc factor i))
+
+          (setf #1=(aref a (ash i +SHIFT+))
+                (logior #1# (ash 1 (logand i +MASK+))))
+
+;          (multiple-value-bind (q r) (floor i +bits-per-word+)
+;            (declare (type nonneg-fixnum q) (type (integer 0 64) r))
+;            (setf #1=(aref a q)
+;                 (logior #1# (expt 2 r))))
+
+          (incf i (the fixnum (* factor ninc)))))
+
+      (incf factorh inc))))
 
 
 (defun count-primes (sieve-state)
@@ -321,19 +347,30 @@
          (factor 17)
          (step 1)
          (inc (ash (aref +steps+ step) 1)))
-    (declare (fixnum maxints ncount factor inc) (simple-vector a))
+    (declare (fixnum maxints ncount factor inc) (type (simple-array sieve-element-type 1) a))
+    (when *list-to* (princ "2, 3, 5, 7, 11, 13, " *error-output*))
     (do () ((> factor maxints))
-      (when (zerop (logand (aref a (the (unsigned-byte 32) (ash factor (+ -1 +SHIFT+))))
-                           (ash 1 (the (unsigned-byte 32) (logand (ash factor -1) +MASK+)))))
-        (incf ncount))
+      (when (zerop (logand (aref a (ash factor (+ -1 +SHIFT+)))
+                           (ash 1 (logand (ash factor -1) +MASK+))))
+        (incf ncount)
+        (when (and *list-to* (<= factor *list-to*))
+          (format *error-output* "~d, " factor)))
       (incf factor inc)
-      (when (= (incf step) 5760) (setq step 0))
+      (setq step (if (>= step 5759) 0 (1+ step)))
       (setq inc (ash (the fixnum (aref +steps+ step)) 1)))
+    (when *list-to*
+      (when (< *list-to* (sieve-state-maxints sieve-state))
+        (princ "..." *error-output*))
+      (terpri *error-output*))
     ncount))
 
 
-;(disassemble 'run-sieve)
+(defun validate (sieve-state)
+  (let ((hist (cdr (assoc (sieve-state-maxints sieve-state) +results+ :test #'=))))
+    (if (and hist (= (count-primes sieve-state) hist)) "yes" "no")))
 
+
+;(require :sb-sprof) (sb-sprof:with-profiling (:max-samples 1000 :report :flat :loop nil)
 
 (let* ((passes 0)
        (start (get-internal-real-time))
@@ -348,6 +385,9 @@
 
   (let* ((duration  (/ (- (get-internal-real-time) start) internal-time-units-per-second))
          (avg (/ duration passes)))
-    (format *error-output* "Passes: ~d  Time: ~f Avg: ~f ms Count: ~d~%" passes duration (* 1000 avg)  (count-primes result))
+    (format *error-output* "Algorithm: wheel  Passes: ~d  Time: ~f Avg: ~f ms Count: ~d  Valid: ~A~%"
+            passes duration (* 1000 avg) (count-primes result) (let ((*list-to* nil)) (validate result)))
 
     (format t "mayerrobert-cl-wheel;~d;~f;1;algorithm=wheel,faithful=no,bits=1~%" passes duration)))
+
+;) (disassemble 'run-sieve)

--- a/PrimeLisp/solution_2/PrimeSieveWheel.lisp
+++ b/PrimeLisp/solution_2/PrimeSieveWheel.lisp
@@ -311,14 +311,6 @@
       (when (zerop (logand (aref a (ash factorh +SHIFT+))
                            (ash 1 (logand factorh +MASK+))))
 
-;      (when (zerop (multiple-value-bind (q r) (floor factorh +bits-per-word+)
-;                     (declare (type nonneg-fixnum q) (type (integer 0 64) r))
-;                     (logand (aref a q) r)))
-
-;      (unless (multiple-value-bind (q r) (floor factorh +bits-per-word+)
-;                (declare (type nonneg-fixnum q) (type (integer 0 64) r))
-;                (logbitp r (aref a q)))
-
         (do* ((istep step (if (>= istep 5759) 0 (1+ istep)))
               (ninc (aref steps istep) (aref steps istep))
               (factor (1+ (ash factorh 1)))
@@ -328,12 +320,6 @@
 
           (setf #1=(aref a (ash i +SHIFT+))
                 (logior #1# (ash 1 (logand i +MASK+))))
-
-;          (multiple-value-bind (q r) (floor i +bits-per-word+)
-;            (declare (type nonneg-fixnum q) (type (integer 0 64) r))
-;            (setf #1=(aref a q)
-;                 (logior #1# (expt 2 r))))
-
           (incf i (the fixnum (* factor ninc)))))
 
       (incf factorh inc))))
@@ -370,8 +356,6 @@
     (if (and hist (= (count-primes sieve-state) hist)) "yes" "no")))
 
 
-;(require :sb-sprof) (sb-sprof:with-profiling (:max-samples 1000 :report :flat :loop nil)
-
 (let* ((passes 0)
        (start (get-internal-real-time))
        (end (+ start (* internal-time-units-per-second 5)))
@@ -389,5 +373,3 @@
             passes duration (* 1000 avg) (count-primes result) (let ((*list-to* nil)) (validate result)))
 
     (format t "mayerrobert-cl-wheel;~d;~f;1;algorithm=wheel,faithful=no,bits=1~%" passes duration)))
-
-;) (disassemble 'run-sieve)

--- a/PrimeLisp/solution_2/PrimeSieveWheelOpt.lisp
+++ b/PrimeLisp/solution_2/PrimeSieveWheelOpt.lisp
@@ -3,9 +3,6 @@
 ;;; run as:
 ;;;     sbcl --script PrimeSieveWheelOpt.lisp
 ;;;
-;;; Algorithm is _wheel_, see PrimeC/solution_2/README.md for a better explanation than I would be able to give.
-;;; I have no idea how the wheel algorithm works, I just stole the algorithm.
-;;;
 ;;; For Common Lisp bit ops see https://lispcookbook.github.io/cl-cookbook/numbers.html#bit-wise-operation,
 ;;; although most of the shifts were replaced by "normal" Lisp functions,
 ;;; e.g. x>>n -> (floor x m), a&b -> (mod a b), 1<<x -> (expt 2 x),
@@ -332,13 +329,6 @@
     (setf #1=(aref a q)
          (logior #1# (expt 2 r)))) 0)
 
-;(defun set-nth-bit (a n)
-;  (declare (type sieve-array-type a)
-;           (type nonneg-fixnum n))
-;  (multiple-value-bind (q r) (floor n +bits-per-word+)
-;    (declare (nonneg-fixnum q) (nonneg-fixnum r))
-;    (setf (ldb (byte 1 r) (aref a q)) 1)) 0)
-
 
 (defun run-sieve (sieve-state steps)
   (declare (sieve-state sieve-state) (simple-vector steps))
@@ -396,8 +386,6 @@
     (if (and hist (= (count-primes sieve-state) hist)) "yes" "no")))
 
 
-;(require :sb-sprof) (sb-sprof:with-profiling (:max-samples 1000 :report :flat :loop nil)
-
 (let* ((passes 0)
        (start (get-internal-real-time))
        (end (+ start (* internal-time-units-per-second 5)))
@@ -415,5 +403,3 @@
             passes duration (* 1000 avg) (count-primes result) (let ((*list-to* nil)) (validate result)))
 
     (format t "mayerrobert-cl-wheel-opt;~d;~f;1;algorithm=wheel,faithful=no,bits=1~%" passes duration)))
-
-;) (disassemble 'run-sieve)

--- a/PrimeLisp/solution_2/PrimeSieveWheelOpt.lisp
+++ b/PrimeLisp/solution_2/PrimeSieveWheelOpt.lisp
@@ -1,0 +1,419 @@
+;;;; Common Lisp port of PrimeC/solution_2/sieve_5760of30030_only_write_read_bits.c by Daniel Spangberg
+;;;
+;;; run as:
+;;;     sbcl --script PrimeSieveWheelOpt.lisp
+;;;
+;;; Algorithm is _wheel_, see PrimeC/solution_2/README.md for a better explanation than I would be able to give.
+;;; I have no idea how the wheel algorithm works, I just stole the algorithm.
+;;;
+;;; For Common Lisp bit ops see https://lispcookbook.github.io/cl-cookbook/numbers.html#bit-wise-operation,
+;;; although most of the shifts were replaced by "normal" Lisp functions,
+;;; e.g. x>>n -> (floor x m), a&b -> (mod a b), 1<<x -> (expt 2 x),
+;;; because sbcl optimizes these rather efficiently.
+;;; Only logior remains.
+;;;
+
+
+(declaim
+  (optimize (speed 3) (safety 0) (debug 0))
+
+  (inline nth-bit-set-p)
+  (inline set-nth-bit))
+
+
+(defparameter *list-to* 100
+  "list primes up to that number, set to nil to disable listing")
+
+
+(defconstant +results+
+  '((         10 . 4        )
+    (        100 . 25       )
+    (       1000 . 168      )
+    (      10000 . 1229     )
+    (     100000 . 9592     )
+    (    1000000 . 78498    )
+    (   10000000 . 664579   )
+    (  100000000 . 5761455  )
+    ( 1000000000 . 50847534 )
+    (10000000000 . 455052511))
+  "Historical data for validating our results - the number of primes
+   to be found under some limit, such as 168 primes under 1000")
+
+
+; Should match machine register size for efficient code.
+; Too small hurts a litle, too big hurts a lot
+; because sbcl will be forced to use bignums
+#+64-bit (defconstant +bits-per-word+ 64)
+#-64-bit (defconstant +bits-per-word+ 32)
+
+; Apparently some Lisps have non-negative-fixnum, sbcl doesn't.
+; Also it's not in the ANSI CL specs.
+(deftype nonneg-fixnum ()
+  `(integer 0 ,most-positive-fixnum))
+
+(deftype sieve-bitpos-type ()
+  `(integer 0 ,(1- +bits-per-word+)))
+
+(deftype sieve-element-type ()
+  `(unsigned-byte ,+bits-per-word+))
+
+(deftype sieve-array-type ()
+  `(simple-array sieve-element-type 1))
+
+
+(defconstant +steps+ #(
+ 8 1 2 3 1 3 2 1 2 3 3 1 3 2 1 3 2 3 4 2 1 2 1 2 7 
+ 2 3 1 5 1 3 3 2 3 3 1 5 1 2 1 6 6 2 1 2 3 1 5 3 3 
+ 3 1 3 2 1 3 2 7 2 1 2 3 4 3 5 1 2 3 1 3 3 3 2 3 1 
+ 3 2 4 5 1 5 1 2 1 2 3 4 2 1 2 6 4 2 1 3 2 3 6 1 2 
+ 1 6 3 2 3 3 3 1 3 5 1 2 3 1 3 3 2 1 5 1 5 1 2 3 3 
+ 1 3 3 2 3 4 3 2 1 3 2 3 4 2 1 3 2 4 3 2 4 2 3 4 5 
+ 1 5 1 3 2 1 2 1 5 1 5 1 2 1 2 7 2 1 2 3 3 1 3 2 4 
+ 5 4 2 1 2 3 4 3 2 3 3 3 1 3 3 2 1 2 3 1 5 1 2 1 5 
+ 1 5 1 3 2 4 3 2 1 2 3 3 4 2 1 3 5 4 2 1 3 2 4 5 3 
+ 1 2 4 3 3 2 1 2 3 1 3 2 3 1 5 6 1 2 1 2 3 1 3 2 1 
+ 2 6 1 3 3 5 3 4 2 1 2 1 2 4 3 6 2 3 1 6 2 1 2 3 4 
+ 2 1 2 1 6 5 1 2 1 2 3 1 5 1 2 3 4 3 2 1 3 2 3 4 2 
+ 3 1 2 4 3 2 3 1 2 3 1 3 3 2 3 3 4 3 2 1 5 1 5 1 2 
+ 1 5 1 3 2 1 5 3 1 3 2 1 3 2 3 4 3 2 1 6 5 3 1 2 3 
+ 1 6 2 1 2 4 3 2 1 2 1 5 1 5 3 1 2 3 1 3 2 1 5 3 1 
+ 3 2 6 3 4 3 2 1 2 4 3 2 3 1 2 3 4 3 3 2 3 1 3 2 1 
+ 2 1 5 6 1 2 6 1 3 2 1 2 3 3 1 6 3 2 9 1 2 1 2 4 3 
+ 2 3 1 2 4 3 3 2 1 2 3 1 3 2 1 2 6 1 6 3 2 3 1 3 2 
+ 3 3 3 1 3 2 1 3 2 3 4 2 1 2 1 2 7 2 3 1 5 1 3 3 2 
+ 1 5 1 5 1 2 7 5 1 2 1 2 3 1 3 5 3 3 1 5 1 3 2 3 4 
+ 2 1 2 3 4 3 5 1 2 3 1 3 3 2 1 2 3 1 3 2 1 3 5 1 5 
+ 3 1 2 3 4 2 1 2 6 1 3 2 1 3 2 3 6 1 2 1 2 4 3 2 3 
+ 1 5 1 3 5 3 3 1 3 2 1 2 1 5 1 6 2 3 3 1 6 2 3 3 1 
+ 3 2 1 3 2 7 2 1 3 2 4 3 2 3 1 2 3 4 3 3 5 1 3 2 3 
+ 1 5 1 5 1 2 1 2 4 3 2 1 2 3 3 4 2 4 2 3 4 2 1 2 1 
+ 6 3 2 3 3 3 1 3 3 2 1 2 3 1 3 3 2 1 5 1 5 1 3 2 3 
+ 1 3 2 1 2 3 7 2 1 3 5 4 2 1 2 1 2 4 5 4 2 4 3 5 1 
+ 2 3 1 3 2 3 1 5 1 5 1 2 1 2 3 4 2 1 2 3 3 1 3 3 3 
+ 5 4 2 1 2 3 4 3 2 4 2 3 1 3 3 2 1 2 3 6 1 2 1 5 1 
+ 5 1 2 1 2 4 5 1 2 3 4 3 2 1 3 2 3 4 2 4 2 4 3 2 3 
+ 1 2 3 1 3 3 2 3 3 1 3 3 2 1 5 6 1 2 1 2 3 1 3 2 1 
+ 8 1 3 2 1 5 3 4 2 1 2 1 6 3 5 1 2 3 1 6 2 1 2 4 3 
+ 2 1 2 1 6 5 3 1 2 3 1 3 2 1 2 3 3 1 3 2 1 5 3 4 5 
+ 1 2 4 3 2 3 1 2 3 1 3 3 3 2 3 4 2 1 2 1 5 6 1 2 1 
+ 5 1 3 2 1 2 3 3 1 5 1 3 2 7 3 2 1 2 4 5 3 1 2 3 1 
+ 3 3 2 1 2 4 3 2 1 2 6 1 6 2 1 2 3 1 3 2 1 5 3 1 3 
+ 2 4 2 3 4 2 1 2 1 2 7 2 3 1 5 4 3 2 1 2 3 1 5 1 2 
+ 1 6 5 1 2 3 3 1 3 2 3 3 3 1 3 3 3 2 3 6 1 2 3 4 3 
+ 5 1 2 4 3 3 2 1 2 3 1 3 2 1 3 5 1 5 1 3 2 3 4 2 3 
+ 6 1 3 2 1 3 2 3 6 1 2 1 2 7 2 3 1 2 3 1 3 5 1 5 1 
+ 3 2 1 2 6 1 5 1 2 3 3 1 3 3 2 3 3 1 5 1 3 2 3 4 2 
+ 1 3 2 4 3 2 3 1 2 3 4 3 2 1 5 1 3 2 1 3 5 1 5 3 1 
+ 2 4 3 2 1 2 3 3 1 3 2 4 2 3 4 2 1 2 1 2 4 3 2 3 6 
+ 1 3 3 2 3 3 1 3 2 1 2 1 5 1 6 3 2 3 1 5 1 2 3 3 4 
+ 2 1 3 9 2 1 2 1 2 4 5 3 1 2 4 3 3 3 2 3 1 3 2 3 1 
+ 5 1 5 1 2 1 2 3 1 3 2 1 2 3 3 4 3 3 2 3 4 2 1 2 1 
+ 6 3 2 6 3 1 3 3 2 1 2 3 4 3 2 1 5 1 5 1 2 1 2 3 1 
+ 5 1 2 3 4 3 2 1 3 2 3 4 2 3 1 2 4 3 2 4 2 3 1 3 5 
+ 3 3 1 3 3 2 1 5 1 5 1 2 1 2 3 4 2 1 5 3 1 3 2 1 3 
+ 5 4 2 1 2 7 3 2 3 1 2 3 1 6 2 1 2 4 5 1 2 1 5 1 5 
+ 3 1 2 4 3 2 1 2 3 3 1 3 2 1 5 3 4 3 3 2 4 3 2 3 1 
+ 2 3 1 3 3 3 2 3 1 3 2 1 2 1 5 6 1 2 1 5 1 3 2 1 2 
+ 6 1 5 1 5 7 2 1 2 1 2 4 3 5 1 2 3 1 6 2 1 2 3 1 3 
+ 2 1 2 7 6 2 1 2 3 1 3 2 1 2 3 3 1 3 2 1 3 2 3 4 2 
+ 3 1 2 7 2 3 1 5 1 3 3 2 1 2 3 6 1 2 1 6 5 1 2 1 5 
+ 1 3 2 3 3 3 1 3 2 1 3 2 3 4 3 2 3 4 8 1 2 3 1 3 3 
+ 2 1 2 4 3 2 1 3 5 1 5 1 2 1 2 3 4 2 1 8 1 3 2 4 2 
+ 3 6 1 2 1 2 4 3 2 3 1 2 3 4 5 1 2 3 1 3 2 1 2 1 5 
+ 1 5 1 2 3 3 1 3 3 2 3 3 1 3 3 3 2 3 6 1 3 2 4 3 2 
+ 3 1 2 7 3 2 1 5 1 3 2 1 2 1 5 1 5 1 3 2 4 3 2 3 3 
+ 3 1 3 2 4 2 3 4 2 1 2 1 2 7 2 3 3 3 1 3 3 2 1 5 1 
+ 3 2 1 2 6 1 5 1 3 2 3 1 3 3 2 3 3 6 1 3 5 4 2 1 2 
+ 1 2 4 5 3 1 2 4 3 3 2 1 2 3 1 3 2 4 5 1 5 3 1 2 3 
+ 1 3 2 1 2 3 3 1 3 3 3 2 3 4 2 1 2 1 2 4 3 2 4 5 1 
+ 3 3 2 3 3 4 2 1 2 1 5 1 6 2 1 2 3 1 5 1 2 3 4 3 2 
+ 1 3 2 7 2 3 1 2 4 3 2 3 1 2 3 1 3 3 5 3 1 3 5 1 5 
+ 1 5 1 2 1 2 3 1 3 2 1 5 3 4 2 1 3 2 3 4 2 1 2 1 6 
+ 3 2 3 3 3 1 6 2 1 2 4 3 3 2 1 5 1 5 3 1 2 3 1 3 2 
+ 1 2 3 4 3 2 1 5 3 4 3 2 1 2 4 3 2 4 2 3 1 3 6 2 3 
+ 1 3 2 1 2 1 5 6 1 2 1 5 4 2 1 2 3 3 1 5 1 3 9 2 1 
+ 2 3 4 3 2 3 1 2 3 1 3 3 2 1 2 3 1 5 1 2 6 1 6 2 1 
+ 2 4 3 2 1 2 3 3 1 3 2 1 3 2 3 4 2 1 3 2 7 2 3 1 5 
+ 1 3 3 2 1 2 3 1 5 1 2 1 11 1 2 1 2 3 1 3 2 3 6 1 3 
+ 2 1 5 3 4 2 1 2 3 4 3 5 1 2 3 1 6 2 1 2 3 1 3 2 1 
+ 3 6 5 1 2 1 2 3 4 2 1 2 6 1 3 2 1 3 2 3 6 3 1 2 4 
+ 3 2 3 1 2 3 1 3 5 1 2 3 4 2 1 2 1 5 1 5 1 2 6 1 3 
+ 3 2 3 3 1 3 2 1 3 2 3 4 3 3 2 4 5 3 1 2 3 4 3 2 1 
+ 6 3 2 1 2 1 5 1 5 1 2 1 2 4 3 2 1 5 3 1 3 2 4 2 3 
+ 4 2 1 2 1 2 4 3 2 3 3 3 4 3 2 1 2 3 1 3 2 1 2 1 5 
+ 1 5 1 5 3 1 3 2 1 2 3 3 4 3 3 5 6 1 2 1 2 4 5 3 1 
+ 2 4 3 3 2 1 2 3 1 3 2 3 1 5 1 5 1 3 2 3 1 3 2 3 3 
+ 3 1 3 3 3 2 3 4 2 1 2 1 2 7 2 4 2 3 1 3 3 2 1 5 4 
+ 2 1 2 6 1 5 1 2 1 2 3 1 6 2 3 4 5 1 3 2 3 4 2 3 1 
+ 2 4 3 2 3 1 2 3 1 3 3 2 3 3 1 3 3 3 5 1 5 3 1 2 3 
+ 1 3 2 1 5 3 1 3 2 1 3 2 3 4 2 1 2 1 6 3 2 3 1 5 1 
+ 6 2 3 4 3 2 1 2 1 5 1 8 1 2 3 1 5 1 2 3 3 1 3 2 1 
+ 5 7 3 2 1 2 4 3 2 3 1 2 3 1 3 3 3 2 3 1 3 2 3 1 5 
+ 6 1 2 1 5 1 3 2 1 2 3 3 6 1 3 2 7 2 1 2 1 6 3 2 3 
+ 3 3 1 3 3 2 1 2 3 1 3 3 2 6 1 6 2 1 2 3 1 3 2 1 2 
+ 3 4 3 2 1 3 2 3 4 2 1 2 1 2 7 2 4 5 1 3 5 1 2 3 1 
+ 5 1 2 1 6 5 1 2 1 2 3 4 2 3 3 3 1 3 2 1 3 5 4 2 1 
+ 2 3 4 3 5 1 2 3 1 3 3 2 1 2 3 1 5 1 3 5 1 5 1 2 1 
+ 2 7 2 1 2 6 1 3 2 1 3 2 3 6 1 3 2 4 3 2 3 1 2 3 1 
+ 3 5 1 2 3 1 3 2 1 2 1 5 6 1 2 3 3 1 3 3 2 6 1 3 2 
+ 1 5 3 4 2 1 3 2 4 3 5 1 2 3 7 2 1 5 1 3 2 1 2 1 6 
+ 5 1 2 1 2 4 3 2 1 2 3 3 1 3 2 4 2 3 4 2 3 1 2 4 3 
+ 2 3 3 3 1 3 3 2 1 2 3 4 2 1 2 1 5 1 5 1 3 5 1 3 2 
+ 1 2 3 3 4 2 1 3 5 4 3 2 1 2 4 5 3 1 2 4 3 3 2 1 2 
+ 4 3 2 3 1 5 1 5 1 2 1 2 3 1 3 2 1 5 3 1 3 6 2 3 4 
+ 2 1 2 1 2 4 3 2 4 2 3 4 3 2 1 2 3 4 2 1 2 1 5 1 5 
+ 1 2 3 3 1 5 1 2 3 4 3 3 3 2 3 6 3 1 2 4 3 2 3 1 2 
+ 4 3 3 2 3 3 1 3 3 2 1 5 1 5 1 3 2 3 1 3 2 6 3 1 3 
+ 2 1 3 2 3 4 2 1 2 1 9 2 3 1 2 3 1 6 2 1 6 3 2 1 2 
+ 6 1 5 3 1 2 3 1 3 3 2 3 3 1 5 1 5 3 4 3 2 1 2 4 3 
+ 2 3 1 2 3 1 3 3 3 2 3 1 3 2 1 3 5 6 3 1 5 1 3 2 1 
+ 2 3 3 1 5 1 3 2 7 2 1 2 1 2 4 3 2 3 1 5 1 3 3 2 3 
+ 3 1 3 2 1 2 6 1 6 2 1 2 3 1 5 1 2 3 3 1 3 2 1 3 2 
+ 7 2 1 2 1 2 7 2 3 1 5 1 3 3 3 2 3 1 5 3 1 6 5 1 2 
+ 1 2 3 1 3 2 3 3 3 4 2 1 3 2 3 4 2 1 2 7 3 5 3 3 1 
+ 3 3 2 1 2 3 1 3 3 3 5 1 5 1 2 1 2 3 4 2 1 2 7 3 2 
+ 1 3 2 3 6 1 2 1 2 4 3 2 4 2 3 1 3 5 1 2 3 1 3 2 1 
+ 2 1 5 1 5 1 2 3 3 4 3 2 3 3 1 3 2 1 3 5 4 2 1 5 4 
+ 3 2 3 1 2 3 4 3 2 1 5 1 5 1 2 1 5 1 5 1 2 1 2 4 3 
+ 2 1 2 3 3 1 3 2 4 2 3 4 2 1 3 2 4 3 2 3 3 3 1 3 3 
+ 2 1 2 3 1 3 2 1 2 1 5 6 1 3 2 3 1 3 2 1 2 6 4 2 1 
+ 8 4 2 1 2 1 2 4 8 1 2 4 6 2 1 2 3 1 3 2 3 1 6 5 1 
+ 2 1 2 3 1 3 2 1 2 3 3 1 3 3 3 2 3 4 2 3 1 2 4 3 2 
+ 4 2 3 1 3 3 2 1 2 3 4 2 1 2 1 5 1 5 1 2 1 5 1 5 1 
+ 2 3 4 3 2 1 3 2 3 4 5 1 2 4 5 3 1 2 3 1 3 3 2 3 4 
+ 3 3 2 1 5 1 5 1 2 1 2 3 1 3 2 1 5 3 1 3 2 4 2 3 4 
+ 2 1 2 1 6 3 2 3 1 2 3 7 2 1 2 4 3 2 1 2 1 5 1 5 3 
+ 3 3 1 3 2 1 2 3 3 1 3 3 5 3 7 2 1 2 4 3 2 3 1 2 4 
+ 3 3 3 2 3 1 3 2 1 2 1 5 6 1 3 5 1 3 2 3 3 3 1 5 1 
+ 3 2 7 2 1 2 1 2 7 2 3 1 2 3 1 3 3 2 1 5 1 3 2 1 2 
+ 6 1 6 2 1 2 3 1 3 3 2 3 3 1 5 1 3 2 3 4 2 1 2 1 2 
+ 7 2 3 1 5 1 3 3 2 1 2 3 1 5 1 3 6 5 3 1 2 3 1 3 2 
+ 3 3 3 1 3 2 1 3 2 3 4 2 1 2 3 4 3 5 1 5 1 3 3 2 3 
+ 3 1 3 2 1 3 5 1 6 2 1 2 3 6 1 2 6 1 3 2 1 3 2 9 1 
+ 2 1 2 4 3 2 3 1 2 3 1 3 6 2 3 1 3 2 3 1 5 1 5 1 2 
+ 3 3 1 3 3 2 3 3 4 2 1 3 2 3 4 2 1 3 6 3 2 3 3 3 4 
+ 3 2 1 5 1 3 3 2 1 5 1 5 1 2 1 2 4 3 2 1 2 3 4 3 2 
+ 4 2 3 4 2 1 2 1 2 4 3 2 6 3 1 3 5 1 2 3 1 3 2 1 2 
+ 1 5 1 5 1 3 2 3 4 2 1 2 3 3 4 2 1 3 5 4 2 1 2 3 4 
+ 5 3 1 2 4 3 3 2 1 2 3 1 5 3 1 5 1 5 1 2 1 2 4 3 2 
+ 1 2 3 3 1 3 3 3 2 3 4 2 1 3 2 4 3 2 4 2 3 1 3 3 2 
+ 1 2 3 4 2 1 2 1 5 6 1 2 1 2 3 1 5 1 2 7 3 2 1 5 3 
+ 4 2 3 1 2 4 3 5 1 2 3 1 6 2 3 3 1 3 3 2 1 6 5 1 2 
+ 1 2 3 1 3 2 1 5 3 1 3 2 1 3 2 3 4 2 3 1 6 3 2 3 1 
+ 2 3 1 6 2 1 2 7 2 1 2 1 5 1 5 3 1 5 1 3 2 1 2 3 3 
+ 1 3 2 1 5 3 4 3 2 1 2 4 5 3 1 2 3 1 3 3 3 2 4 3 2 
+ 1 2 1 5 6 1 2 1 5 1 3 2 1 5 3 1 5 4 2 7 2 1 2 1 2 
+ 4 3 2 3 1 2 3 4 3 2 1 2 3 1 3 2 1 2 6 1 6 2 3 3 1 
+ 3 2 1 2 3 3 1 3 3 3 2 3 6 1 2 1 2 7 2 3 1 6 3 3 2 
+ 1 2 3 1 5 1 2 1 6 5 1 3 2 3 1 3 2 3 3 3 1 3 2 1 3 
+ 2 3 4 2 1 2 3 7 5 1 2 3 1 3 3 2 1 5 1 3 2 1 8 1 5 
+ 1 2 1 2 3 4 3 2 6 1 5 1 3 2 3 6 1 2 1 2 4 3 2 3 1 
+ 2 3 1 3 5 1 2 3 1 3 2 1 3 5 1 5 3 3 3 1 3 3 2 3 3 
+ 1 3 2 1 3 2 3 4 2 1 3 2 4 3 2 3 1 5 4 3 2 6 1 3 2 
+ 1 2 1 5 1 6 2 1 2 4 5 1 2 3 3 1 3 2 4 2 7 2 1 2 1 
+ 2 4 3 2 3 3 3 1 3 3 3 2 3 1 3 2 3 1 5 1 5 1 3 2 3 
+ 1 3 2 1 2 3 3 4 2 1 3 5 4 2 1 2 1 6 5 3 3 4 3 3 2 
+ 1 2 3 1 3 5 1 5 1 5 1 2 1 2 3 1 3 2 1 2 3 4 3 3 3 
+ 2 3 4 2 1 2 1 2 4 3 2 4 2 3 1 3 5 1 2 3 4 2 1 2 1 
+ 5 1 5 1 2 1 2 3 6 1 2 3 4 3 2 1 3 5 4 2 3 3 4 3 2 
+ 3 1 2 3 1 3 3 2 3 3 1 6 2 1 5 1 5 1 2 1 2 4 3 2 1 
+ 5 3 1 3 2 1 3 2 3 4 2 1 3 6 3 2 3 1 2 3 1 6 2 1 2 
+ 4 3 2 1 2 1 5 6 3 1 2 3 1 3 2 1 2 6 1 3 2 1 5 3 4 
+ 3 2 1 2 4 3 5 1 2 3 1 6 3 2 3 1 3 2 1 2 1 11 1 2 1 
+ 5 1 3 2 1 2 3 3 1 5 1 3 2 7 2 3 1 2 4 3 2 3 1 2 3 
+ 1 3 3 2 1 2 3 4 2 1 2 6 1 6 2 1 5 1 3 2 1 2 3 3 1 
+ 3 2 1 3 2 3 4 3 2 1 2 9 3 1 5 1 3 3 2 1 2 4 5 1 2 
+ 1 6 5 1 2 1 2 3 1 3 2 6 3 1 3 2 4 2 3 4 2 1 2 3 4 
+ 3 5 1 2 3 4 3 2 1 2 3 1 3 2 1 3 5 1 5 1 2 3 3 4 2 
+ 1 2 6 1 3 3 3 2 3 6 1 2 1 2 4 3 2 3 1 2 4 3 5 1 2 
+ 3 1 3 2 1 2 1 5 1 5 1 5 3 1 3 5 3 3 1 3 2 1 3 2 3 
+ 4 2 1 3 2 7 2 3 1 2 3 4 3 2 1 5 1 3 2 1 2 6 1 5 1 
+ 2 1 2 4 3 3 2 3 3 1 5 4 2 3 4 2 1 2 1 2 4 3 2 3 3 
+ 3 1 3 3 2 1 2 3 1 3 2 1 3 5 1 5 4 2 3 1 3 2 1 2 3 
+ 3 4 2 1 3 5 4 2 1 2 1 2 4 5 3 1 6 3 3 2 3 3 1 3 2 
+ 3 1 5 1 6 2 1 2 3 1 5 1 2 3 3 1 3 3 3 2 7 2 1 2 1 
+ 2 4 3 2 4 2 3 1 3 3 3 2 3 4 2 3 1 5 1 5 1 2 1 2 3 
+ 1 5 1 2 3 7 2 1 3 2 3 4 2 3 1 6 3 2 3 3 3 1 3 3 2 
+ 3 3 1 3 3 2 1 5 1 5 1 2 1 2 3 1 3 2 1 5 4 3 2 1 3 
+ 2 3 4 2 1 2 1 6 3 2 4 2 3 1 8 1 2 4 3 2 1 2 1 5 1 
+ 5 3 1 2 3 4 2 1 2 3 3 1 3 2 1 8 4 3 2 3 4 3 2 3 1 
+ 2 3 1 3 3 3 2 3 1 5 1 2 1 5 6 1 2 1 6 3 2 1 2 3 3 
+ 1 5 1 3 2 7 2 1 3 2 4 3 2 3 1 2 3 1 3 3 2 1 2 3 1 
+ 3 2 1 2 6 7 2 1 2 3 1 3 2 1 2 6 1 3 2 1 5 3 4 2 1 
+ 2 1 2 7 5 1 5 1 6 2 1 2 3 1 5 1 2 1 6 5 1 2 1 2 3 
+ 1 3 2 3 3 3 1 3 2 1 3 2 3 4 2 3 3 4 3 5 1 2 3 1 3 
+ 3 2 1 2 3 4 2 1 3 5 1 5 1 2 1 5 4 2 1 2 6 1 3 2 1 
+ 3 2 3 7 2 1 2 4 5 3 1 2 3 1 3 5 1 2 4 3 2 1 2 1 5 
+ 1 5 1 2 3 3 1 3 3 5 3 1 3 2 4 2 3 4 2 1 3 2 4 3 2 
+ 3 1 2 3 4 3 2 1 5 1 3 2 1 2 1 5 1 5 1 2 3 4 3 2 1 
+ 2 3 3 1 3 6 2 3 6 1 2 1 2 4 3 2 3 3 4 3 3 2 1 2 3 
+ 1 3 2 1 2 1 5 1 5 1 3 2 3 1 3 2 3 3 3 4 2 1 3 5 4 
+ 2 1 2 1 2 9 3 1 2 4 3 3 2 1 5 1 3 2 3 6 1 5 1 2 1 
+ 2 3 1 3 3 2 3 3 1 6 3 2 3 4 2 1 2 1 2 4 3 2 4 2 3 
+ 1 3 3 2 1 2 3 4 2 1 3 5 1 5 3 1 2 3 1 5 1 2 3 4 3 
+ 2 1 3 2 3 4 2 3 1 2 4 3 2 3 1 5 1 3 3 2 3 3 1 3 3 
+ 2 1 5 1 6 2 1 2 3 1 5 1 5 3 1 3 2 1 3 2 7 2 1 2 1 
+ 6 3 2 3 1 2 3 1 6 3 2 4 3 2 3 1 5 1 5 3 1 2 3 1 3 
+ 2 1 2 3 3 4 2 1 5 3 4 3 2 1 6 3 2 3 3 3 1 3 3 3 2 
+ 3 1 3 3 2 1 5 6 1 2 1 5 1 3 2 1 2 3 4 5 1 3 2 7 2 
+ 1 2 1 2 4 3 2 4 2 3 1 3 5 1 2 3 1 3 2 1 2 6 1 6 2 
+ 1 2 3 4 2 1 2 3 3 1 3 2 1 3 5 4 2 1 2 3 7 2 3 1 5 
+ 1 3 3 2 1 2 3 1 5 1 2 1 6 5 1 2 1 2 4 3 2 3 3 3 1 
+ 3 2 1 3 2 3 4 2 1 5 4 3 5 1 2 3 1 3 3 2 1 2 3 1 3 
+ 2 1 3 5 6 1 2 1 2 3 4 2 1 2 6 1 3 2 1 5 3 6 1 2 1 
+ 2 4 3 5 1 2 3 1 8 1 2 3 1 3 2 1 2 1 6 5 1 2 3 3 1 
+ 3 3 2 3 3 1 3 2 1 3 2 3 4 2 4 2 4 3 2 3 1 2 3 4 3 
+ 2 1 5 4 2 1 2 1 5 1 5 1 2 1 6 3 2 1 2 3 3 1 3 2 4 
+ 2 3 4 3 2 1 2 4 5 3 3 3 1 3 3 2 1 2 4 3 2 1 2 1 5 
+ 1 5 1 3 2 3 1 3 2 1 5 3 4 2 4 5 4 2 1 2 1 2 4 5 3 
+ 1 2 7 3 2 1 2 3 1 3 2 3 1 5 1 5 1 2 3 3 1 3 2 1 2 
+ 3 3 1 3 3 3 2 3 6 1 2 1 2 4 3 2 4 2 4 3 3 2 1 2 3 
+ 4 2 1 2 1 5 1 5 1 3 2 3 1 5 3 3 4 3 2 1 3 2 3 4 2 
+ 3 1 2 7 2 3 1 2 3 1 3 3 2 6 1 3 3 2 6 1 5 1 2 1 2 
+ 3 1 3 3 5 3 1 5 1 3 2 3 4 2 1 2 1 6 3 2 3 1 2 3 1 
+ 6 2 1 2 4 3 2 1 3 5 1 5 3 1 2 3 1 3 2 1 2 3 3 1 3 
+ 2 1 5 3 4 3 2 1 2 4 3 2 3 1 5 1 3 3 5 3 1 3 2 1 2 
+ 1 5 7 2 1 5 1 5 1 2 3 3 1 5 1 3 2 7 2 1 2 1 2 4 3 
+ 2 3 1 2 3 1 3 3 3 2 3 1 3 2 3 6 1 6 2 1 2 3 1 3 2 
+ 1 2 3 3 4 2 1 3 2 3 4 2 1 2 1 9 2 3 6 1 3 3 2 1 2 
+ 3 1 6 2 1 6 5 1 2 1 2 3 1 3 2 3 3 4 3 2 1 3 2 3 4 
+ 2 1 2 3 4 3 6 2 3 1 3 5 1 2 3 1 3 2 1 3 5 1 5 1 2 
+ 1 2 3 4 2 1 2 6 1 3 2 1 3 5 6 1 2 3 4 3 2 3 1 2 3 
+ 1 3 5 1 2 3 1 5 1 2 1 5 1 5 1 2 3 4 3 3 2 3 3 1 3 
+ 2 1 3 2 3 4 2 1 3 2 4 3 2 3 1 2 3 4 3 2 1 5 1 3 2 
+ 1 2 1 5 6 1 2 1 2 4 3 2 1 2 6 1 3 2 6 3 4 2 1 2 1 
+ 2 4 3 5 3 3 1 6 2 1 2 3 1 3 2 1 2 1 6 5 1 3 2 3 1 
+ 3 2 1 2 3 3 4 2 1 3 5 4 2 3 1 2 4 5 3 1 2 4 3 3 2 
+ 1 2 3 4 2 3 1 5 1 5 1 2 1 5 1 3 2 1 2 3 3 1 3 3 3 
+ 2 3 4 3 2 1 2 4 5 4 2 3 1 3 3 2 1 2 7 2 1 2 1 5 1 
+ 5 1 2 1 2 3 1 5 1 5 4 3 2 4 2 3 4 2 3 1 2 4 3 2 3 
+ 1 2 3 4 3 2 3 3 1 3 3 2 1 5 1 5 1 2 3 3 1 3 2 1 5 
+ 3 1 3 3 3 2 3 6 1 2 1 6 3 2 3 1 2 4 6 2 1 2 4 3 2 
+ 1 2 1 5 1 5 4 2 3 1 3 2 3 3 3 1 3 2 1 5 3 4 3 2 1 
+ 2 7 2 3 1 2 3 1 3 3 3 5 1 3 2 1 2 6 6 1 2 1 5 1 3 
+ 3 2 3 3 1 5 1 3 2 7 2 1 2 1 2 4 3 2 3 1 2 3 1 3 3 
+ 2 1 2 3 1 3 2 1 8 1
+))
+
+
+(defclass sieve-state ()
+  ((maxints :initarg :maxints
+            :type nonneg-fixnum
+            :accessor sieve-state-maxints)
+
+   (a       :initarg :a
+            :type simple-array
+            :accessor sieve-state-a)))
+
+
+(defun create-sieve (maxints)
+  (declare (nonneg-fixnum maxints))
+  (make-instance 'sieve-state
+    :maxints maxints
+    :a (make-array
+         (1+ (floor (floor maxints +bits-per-word+) 2))
+         :element-type 'sieve-element-type
+         :initial-element 0)))
+
+
+(defun nth-bit-set-p (a n)
+  (declare (type sieve-array-type a)
+           (type nonneg-fixnum n))
+  (multiple-value-bind (q r) (floor n +bits-per-word+)
+    (declare (nonneg-fixnum q) (type sieve-bitpos-type r))
+    (logbitp r (aref a q))))
+
+
+(defun set-nth-bit (a n)
+  (declare (type sieve-array-type a)
+           (type nonneg-fixnum n))
+  (multiple-value-bind (q r) (floor n +bits-per-word+)
+    (declare (nonneg-fixnum q) (type sieve-bitpos-type r))
+    (setf #1=(aref a q)
+         (logior #1# (expt 2 r)))) 0)
+
+;(defun set-nth-bit (a n)
+;  (declare (type sieve-array-type a)
+;           (type nonneg-fixnum n))
+;  (multiple-value-bind (q r) (floor n +bits-per-word+)
+;    (declare (nonneg-fixnum q) (nonneg-fixnum r))
+;    (setf (ldb (byte 1 r) (aref a q)) 1)) 0)
+
+
+(defun run-sieve (sieve-state steps)
+  (declare (sieve-state sieve-state) (simple-vector steps))
+
+  (do* ((maxints (sieve-state-maxints sieve-state))
+        (maxintsh (floor maxints 2))
+        (a (sieve-state-a sieve-state))
+        (q (1+ (isqrt maxints)))
+        (step 1  (if (>= step 5759) 0 (1+ step)))
+        (inc (aref steps step) (aref steps step))
+        (factorh (floor 17 2))
+        (qh (floor q 2)))
+       ((> factorh qh) sieve-state)
+    (declare (nonneg-fixnum maxints maxintsh q step inc factorh qh)
+             (type sieve-array-type a))
+    (unless (nth-bit-set-p a factorh)
+      (do* ((istep step (if (>= istep 5759) 0 (1+ istep)))
+            (ninc (aref steps istep) (aref steps istep))
+            (factor (1+ (the nonneg-fixnum (* factorh 2))))
+            (i (floor (the nonneg-fixnum (* factor factor)) 2)))
+           ((>= i maxintsh))
+        (declare (nonneg-fixnum istep ninc factor i))
+        (set-nth-bit a i)
+        (incf i (the nonneg-fixnum (* factor ninc)))))
+
+    (incf factorh inc)))
+
+
+(defun count-primes (sieve-state)
+  (declare (sieve-state sieve-state))
+  (when *list-to* (princ "2, 3, 5, 7, 11, 13, " *error-output*))
+  (do* ((maxints (sieve-state-maxints sieve-state))
+        (a (sieve-state-a sieve-state))
+        (ncount 6)
+        (factor 17)
+        (step 1  (if (>= step 5759) 0 (1+ step)))
+        (inc (* (aref +steps+ step) 2) (* (the nonneg-fixnum (aref +steps+ step)) 2)))
+       ((> factor maxints)
+        (when *list-to*
+          (when (< *list-to* (sieve-state-maxints sieve-state))
+            (princ "..." *error-output*))
+          (terpri *error-output*))
+        ncount)
+     (declare (nonneg-fixnum maxints ncount factor inc)
+              (type sieve-array-type a))
+     (unless (nth-bit-set-p a (floor factor 2))
+       (incf ncount)
+       (when (and *list-to* (<= factor *list-to*))
+         (format *error-output* "~d, " factor)))
+     (incf factor inc)))
+
+
+(defun validate (sieve-state)
+  (let ((hist (cdr (assoc (sieve-state-maxints sieve-state) +results+ :test #'=))))
+    (if (and hist (= (count-primes sieve-state) hist)) "yes" "no")))
+
+
+;(require :sb-sprof) (sb-sprof:with-profiling (:max-samples 1000 :report :flat :loop nil)
+
+(let* ((passes 0)
+       (start (get-internal-real-time))
+       (end (+ start (* internal-time-units-per-second 5)))
+       result)
+  (declare (nonneg-fixnum passes))
+
+  (do () ((>= (get-internal-real-time) end))
+    (setq result (create-sieve 1000000))
+    (run-sieve result +steps+)
+    (incf passes))
+
+  (let* ((duration  (/ (- (get-internal-real-time) start) internal-time-units-per-second))
+         (avg (/ duration passes)))
+    (format *error-output* "Algorithm: wheel optimized  Passes: ~d, Time: ~f, Avg: ~f ms, Count: ~d  Valid: ~A~%"
+            passes duration (* 1000 avg) (count-primes result) (let ((*list-to* nil)) (validate result)))
+
+    (format t "mayerrobert-cl-wheel-opt;~d;~f;1;algorithm=wheel,faithful=no,bits=1~%" passes duration)))
+
+;) (disassemble 'run-sieve)

--- a/PrimeLisp/solution_2/PrimeSievebitops.lisp
+++ b/PrimeLisp/solution_2/PrimeSievebitops.lisp
@@ -1,0 +1,165 @@
+;;;; based on sieve_1of2.c by  by Daniel Spangberg
+;;;
+;;; run as:
+;;;     sbcl --script PrimeSievebitops.lisp
+;;;
+
+
+(declaim
+  (optimize (speed 3) (safety 0) (debug 0) (space 0))
+
+  (inline nth-bit-set-p)
+  (inline set-nth-bit))
+
+
+(defparameter *list-to* 100
+  "list primes up to that number, set to nil to disable listing")
+
+
+(defconstant +results+
+  '((         10 . 4        )
+    (        100 . 25       )
+    (       1000 . 168      )
+    (      10000 . 1229     )
+    (     100000 . 9592     )
+    (    1000000 . 78498    )
+    (   10000000 . 664579   )
+    (  100000000 . 5761455  )
+    ( 1000000000 . 50847534 )
+    (10000000000 . 455052511))
+  "Historical data for validating our results - the number of primes
+   to be found under some limit, such as 168 primes under 1000")
+
+
+#+64-bit (defconstant +bits-per-word+ 64)
+#-64-bit (defconstant +bits-per-word+ 32)
+
+(deftype sieve-element-type ()
+  `(unsigned-byte ,+bits-per-word+))
+
+(deftype sieve-array-type ()
+  `(simple-array sieve-element-type 1))
+
+
+(defclass sieve-state ()
+  ((maxints :initarg :maxints
+            :type fixnum
+            :accessor sieve-state-maxints)
+
+   (a       :initarg :a
+            :type sieve-array-type
+            :accessor sieve-state-a)))
+
+
+(defun create-sieve (maxints)
+  (declare (fixnum maxints))
+  (make-instance 'sieve-state
+    :maxints maxints
+    :a (make-array (1+ (floor (floor maxints +bits-per-word+) 2))
+         :element-type 'sieve-element-type
+         :initial-element 0)))
+
+
+(defun nth-bit-set-p (a n)
+  (declare (sieve-array-type a)
+           (fixnum n))
+  (multiple-value-bind (q r) (floor n +bits-per-word+)
+    (declare (fixnum q r))
+    (logbitp r (aref a q))))
+
+(defun set-nth-bit (a n)
+  (declare (type sieve-array-type a)
+           (type fixnum n))
+  (multiple-value-bind (q r) (floor n +bits-per-word+)
+    (declare (fixnum q r))
+    (setf #1=(aref a q)
+         ;(logandc2 #1# (expt 2 r)))) 0) ; this would clear the bit
+         (logior #1# (expt 2 r)))) 0)
+
+
+(defun run-sieve (sieve-state)
+  (declare (type sieve-state sieve-state))
+
+  (let* ((rawbits (sieve-state-a sieve-state))
+         (sieve-size (sieve-state-maxints sieve-state))
+         (sieve-sizeh (floor sieve-size 2))
+         (q (floor (sqrt sieve-size)))
+         (qh (floor (1+ q) 2)))
+    (declare (fixnum sieve-size sieve-sizeh q qh) (type sieve-array-type rawbits))
+    (do ((factor 0)
+         (factorh 1))
+        ((> factorh qh))
+      (declare (fixnum factor factorh))
+
+      (loop for num of-type fixnum
+            from factorh
+            to qh
+            while (nth-bit-set-p rawbits num)
+            finally (setq factor (1+ (* num 2)))
+                    (setq factorh (1+ num)))
+
+      (loop for num of-type fixnum
+            from (floor (the fixnum (* factor factor)) 2)
+            to (1- sieve-sizeh)
+            by factor
+            do (set-nth-bit rawbits num)))
+    sieve-state))
+
+
+(defun count-primes (sieve-state)
+  (declare (sieve-state sieve-state))
+  (let ((max (sieve-state-maxints sieve-state))
+        (bits (sieve-state-a sieve-state))
+        (result 0))
+    (declare (fixnum result))
+    (loop for i fixnum
+          from 1
+          to max
+          by 2
+          do
+      (unless (nth-bit-set-p bits (floor i 2))
+        (incf result)))
+    result))
+
+
+(defun list-primes (result)
+  (princ "2, " *error-output*)
+  (let ((bits (sieve-state-a result)))
+    (loop for i
+          from 3
+          to (min *list-to* (sieve-state-maxints result))
+          by 2 do
+      (unless  (nth-bit-set-p bits (floor i 2))
+        (format *error-output* "~d, " i))))
+  (when (< *list-to* (sieve-state-maxints result))
+    (princ "..." *error-output*))
+  (terpri *error-output*))
+
+
+(defun validate (sieve-state)
+  (let ((hist (cdr (assoc (sieve-state-maxints sieve-state) +results+ :test #'=))))
+    (if (and hist (= (count-primes sieve-state) hist)) "yes" "no")))
+
+
+;(require :sb-sprof) (sb-sprof:with-profiling (:max-samples 1000 :report :flat :loop nil)
+
+(let* ((passes 0)
+       (start (get-internal-real-time))
+       (end (+ start (* internal-time-units-per-second 5)))
+       result)
+  (declare (fixnum passes))
+
+  (do () ((>= (get-internal-real-time) end))
+    (setq result (create-sieve 1000000))
+    (run-sieve result)
+    (incf passes))
+
+  (let* ((duration  (/ (- (get-internal-real-time) start) internal-time-units-per-second))
+         (avg (/ duration passes)))
+    (when *list-to* (list-primes result))
+    (format *error-output* "Algorithm: base w/ bitops  Passes: ~d  Time: ~f Avg: ~f ms Count: ~d  Valid: ~A~%"
+            passes duration (* 1000 avg) (count-primes result) (validate result))
+
+    (format t "mayerrobert-clb;~d;~f;1;algorithm=base,faithful=yes,bits=1~%" passes duration)))
+
+;) (disassemble 'run-sieve)

--- a/PrimeLisp/solution_2/PrimeSievebitops.lisp
+++ b/PrimeLisp/solution_2/PrimeSievebitops.lisp
@@ -73,7 +73,6 @@
   (multiple-value-bind (q r) (floor n +bits-per-word+)
     (declare (fixnum q r))
     (setf #1=(aref a q)
-         ;(logandc2 #1# (expt 2 r)))) 0) ; this would clear the bit
          (logior #1# (expt 2 r)))) 0)
 
 
@@ -141,8 +140,6 @@
     (if (and hist (= (count-primes sieve-state) hist)) "yes" "no")))
 
 
-;(require :sb-sprof) (sb-sprof:with-profiling (:max-samples 1000 :report :flat :loop nil)
-
 (let* ((passes 0)
        (start (get-internal-real-time))
        (end (+ start (* internal-time-units-per-second 5)))
@@ -161,5 +158,3 @@
             passes duration (* 1000 avg) (count-primes result) (validate result))
 
     (format t "mayerrobert-clb;~d;~f;1;algorithm=base,faithful=yes,bits=1~%" passes duration)))
-
-;) (disassemble 'run-sieve)

--- a/PrimeLisp/solution_2/README.md
+++ b/PrimeLisp/solution_2/README.md
@@ -2,6 +2,7 @@
 
 ![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
 ![Algorithm](https://img.shields.io/badge/Algorithm-wheel-yellowgreen)
+![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
 ![Faithfulness](https://img.shields.io/badge/Faithful-no-yellowgreen)
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
 ![Bit count](https://img.shields.io/badge/Bits-1-green)
@@ -10,18 +11,35 @@
 with lots of type declarations to allow sbcl's optimizer do it's thing.
 Algorithm is base.
 
+The state of the sieve is stored in a Lisp class.
+
 Uses a bit-vector (one-dimensional arrays are called vector in Lisp)
 for storage.
+
+`PrimeSievebitops.lisp` doesn't use a bit vector but a machine word array and some bit operations to get and set bits.
+The state of the sieve is stored in a Lisp class.
+
+For Common Lisp bit ops see https://lispcookbook.github.io/cl-cookbook/numbers.html#bit-wise-operation
+Also it uses inverted logic, i.e. 0 for primes.
 
 `PrimeSieveWheel.lisp` is a Common Lisp port of sieve_5760of30030_only_write_read_bits.c
 by Daniel Spangberg.
 
-The state of the sieve is stored in a Lisp struct (closest to a class in Lisp).
+The state of the sieve is stored in a Lisp struct.
 
 Algorithm is _wheel_, see PrimeC/solution_2/README.md for a better explanation than I would be able to give.
 
-PrimeSieveWheel.lisp stores bits in an array of `(unsigned-byte 32)`,
-much like Daniel's code uses an array of `uint32_t` when compiled without `-DCOMPILE_64_BIT`.
+PrimeSieveWheel.lisp stores bits in an array of `(unsigned-byte 64)`,
+much like Daniel's code uses an array of `uint64_t` when compiled with `-DCOMPILE_64_BIT`.
+
+`PrimeSieveWheelOpt.lisp` contains further performance improvements.
+I think the biggest improvement is using FLOOR vs AND+SHIFT
+because FLOOR does both in one step.
+
+The state of the sieve is stored in a Lisp class.
+
+Re: optimizations; (compile-file "PrimeSieveWheel.lisp") will show lots of info during the compilation
+regarding inefficient code that can't be optimized.
 
 ## Run instructions
 
@@ -29,25 +47,33 @@ First install "Steel Bank Common Lisp", see http://www.sbcl.org/platform-table.h
 Other Common Lisps should work as well ("Armed Bear Common Lisp" was lightly tested).
 
 Then
-`sbcl --script PrimeSieveWheel.lisp` will compile and run the program in one step,
-`sbcl --script PrimeSieveWheel.lisp 2>nul` (Windows) or
-`sbcl --script PrimeSieveWheel.lisp 2> /dev/null` (Unix)
+`sbcl --script PrimeSieveWheelOpt.lisp` will compile and run the program in one step,
+`sbcl --script PrimeSieveWheelOpt.lisp 2>nul` (Windows) or
+`sbcl --script PrimeSieveWheelOpt.lisp 2> /dev/null` (Unix)
 will do the same but only output the CSV result data.
 
-Or use `docker` or `podman` to build and run the provided dockerfile:
+Or use `run.cmd` (Windows) or `./run.sh` (Unix) to run all files.
+
+If you can't or won't install sbcl then use `docker` or `podman` to build and run the provided dockerfile:
 
     $ cd PrimeLisp/solution_2
     $ podman build -t lisp2 .
-    $ podman run lisp2
+    $ podman run --rm lisp2
 
 ## Output
 
 Using sbcl 2.0.0 on Windows 7, Pentium(R) Dual Core T4300 @ 2.10GHz I get
 
-    D:\projects\primes\PrimeLisp\solution_2>sbcl --script PrimeSieve.lisp
-    Passes: 1853  Time: 5.002 Avg: 2.6994064 ms Count: 78498
-    mayerrobert-cl;1853;5.002;1;algorithm=base,faithful=no,bits=1
-    
-    D:\projects\Primes\PrimeLisp\solution_2>sbcl --script PrimeSieveWheel.lisp
-    Passes: 4875  Time: 5.0 Avg: 1.0256411 ms Count: 78498
-    mayerrobert-cl-wheel;4875;5.0;1;algorithm=wheel,faithful=no,bits=1
+    D:\robert\projects\Primes\PrimeLisp\solution_2>run.cmd 2>nul
+    mayerrobert-cl;1852;5.002;1;algorithm=base,faithful=yes,bits=1
+    mayerrobert-clb;2195;5.002;1;algorithm=base,faithful=yes,bits=1
+    mayerrobert-cl-wheel;5369;5.0;1;algorithm=wheel,faithful=no,bits=1
+    mayerrobert-cl-wheel-opt;6005;5.0;1;algorithm=wheel,faithful=no,bits=1
+
+Using sbcl 2.1.6 on Windows 10/ WSL2/ debian 10.9, 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz I get
+
+    $ ./run.sh 2>/dev/null
+    mayerrobert-cl;3605;5.0;1;algorithm=base,faithful=yes,bits=1
+    mayerrobert-clb;5326;5.0;1;algorithm=base,faithful=yes,bits=1
+    mayerrobert-cl-wheel;15512;5.0;1;algorithm=wheel,faithful=no,bits=1
+    mayerrobert-cl-wheel-opt;16742;5.0;1;algorithm=wheel,faithful=no,bits=1

--- a/PrimeLisp/solution_2/run.cmd
+++ b/PrimeLisp/solution_2/run.cmd
@@ -1,0 +1,3 @@
+@echo off
+
+for %%i in (PrimeSieve*.lisp) do @sbcl --script %%i done

--- a/PrimeLisp/solution_2/run.sh
+++ b/PrimeLisp/solution_2/run.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-# run base
-sbcl --script PrimeSieve.lisp
-
-
-# run wheel
-sbcl --script PrimeSieveWheel.lisp
+for i in PrimeSieve*.lisp; do
+  sbcl --script $i
+done


### PR DESCRIPTION
## Description

Lots of changes to Common Lisp solution 2, also 2 of the solutions now are marked as faithful, as they are using bits and a class for the sieve state, waiting for feedback on that ;-)

Other changes:

- switched to an alpine docker image that already comes with a current sbcl Lisp compiler (2.1.6 is faster than the previously used 2.0.11)
- some fixes re: potential array access past the end
- validate results and print up to 100 (configurable)
- add a base algorithm with manual bit fiddling (bits are stored in a word array)
- no more hardcoded word sizes, now 32 vs 64 bits will be selected based on the predefined variable *features*
- some speedups

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
