### PR TITLE
Crystal fix

### DIFF
--- a/PrimeCrystal/solution_1/Dockerfile
+++ b/PrimeCrystal/solution_1/Dockerfile
@@ -1,8 +1,4 @@
-FROM alpine:3.13 AS build
-
-# hadolint ignore=DL3018
-RUN sed -i -e 's/v[[:digit:]]\..*\//edge\//g' /etc/apk/repositories \
-    && apk add --no-cache build-base crystal
+FROM crystallang/crystal:1.0.0-alpine AS build
 
 WORKDIR /opt/app
 COPY primes.cr .


### PR DESCRIPTION
Fix for the Crystal build. The new compiler (1.1.0) is failing, switched to the official image at version 1.0.0, for now only available on amd64.