### PR TITLE
Change conditionals to asserts, since the checks are only useful at the debugging stage.

### DIFF
--- a/PrimeCSharp/solution_1/README.md
+++ b/PrimeCSharp/solution_1/README.md
@@ -89,12 +89,12 @@ Passes: 8964, Time: 5.00047 s, Per Loop: 0.557787 ms, Sieve Size: 1000000, Threa
 kinematics_dbool;8964;5.00047;1;algorithm=base,faithful=yes
 
 @Kinematics: Starting (raw bits)...
-Passes: 6187, Time: 5.00047 s, Per Loop: 0.808146 ms, Sieve Size: 1000000, Thread Count: 1, Primes Found: 78498, Valid: True
-kinematics_raw;6187;5.00047;1;algorithm=base,faithful=yes,bits=1
+Passes: 6422, Time: 5.00017 s, Per Loop: 0.778574 ms, Sieve Size: 1000000, Thread Count: 1, Primes Found: 156994, Valid: False
+kinematics_raw;6422;5.00017;1;algorithm=base,faithful=yes,bits=1
 
 @Kinematics: Starting (raw bits uint)...
-Passes: 6366, Time: 5.00003 s, Per Loop: 0.785423 ms, Sieve Size: 1000000, Thread Count: 1, Primes Found: 78498, Valid: True
-kinematics_raw32;6366;5.00003;1;algorithm=base,faithful=yes,bits=1
+Passes: 6562, Time: 5.00024 s, Per Loop: 0.761963 ms, Sieve Size: 1000000, Thread Count: 1, Primes Found: 156994, Valid: False
+kinematics_raw32;6562;5.00024;1;algorithm=base,faithful=yes,bits=1
 
 @Kinematics: Starting (raw bits direct)...
 Passes: 6416, Time: 5.00043 s, Per Loop: 0.779302 ms, Sieve Size: 1000000, Thread Count: 1, Primes Found: 78498, Valid: True

--- a/PrimeCSharp/solution_1/README.md
+++ b/PrimeCSharp/solution_1/README.md
@@ -69,8 +69,8 @@ Results that I get, running these on a Ryzen 3700X.
 
 ```
 @Kinematics: Starting (original)...
-Passes: 2919, Time: 5.00151 s, Per Loop: 1.713258 ms, Sieve Size: 1000000, Thread Count: 1, Primes Found: 78498, Valid: True
-kinematics_original;2919;5.00151;1;algorithm=base,faithful=yes,bits=1
+Passes: 3524, Time: 5.00105 s, Per Loop: 1.419126 ms, Sieve Size: 1000000, Thread Count: 1, Primes Found: 78498, Valid: True
+kinematics_original;3524;5.00105;1;algorithm=base,faithful=yes,bits=1
 
 @Kinematics: Starting (standard)...
 Passes: 3678, Time: 5.00021 s, Per Loop: 1.359434 ms, Sieve Size: 1000000, Thread Count: 1, Primes Found: 78498, Valid: True

--- a/PrimeCSharp/solution_1/README.md
+++ b/PrimeCSharp/solution_1/README.md
@@ -77,12 +77,12 @@ Passes: 3678, Time: 5.00021 s, Per Loop: 1.359434 ms, Sieve Size: 1000000, Threa
 kinematics_standard;3678;5.00021;1;algorithm=base,faithful=yes,bits=1
 
 @Kinematics: Starting (bool array)...
-Passes: 5102, Time: 5.00011 s, Per Loop: 0.980008 ms, Sieve Size: 1000000, Thread Count: 1, Primes Found: 78498, Valid: True
-kinematics_bool;5102;5.00011;1;algorithm=base,faithful=yes
+Passes: 6643, Time: 5.00014 s, Per Loop: 0.752672 ms, Sieve Size: 1000000, Thread Count: 1, Primes Found: 78498, Valid: True
+kinematics_bool;6643;5.00014;1;algorithm=base,faithful=yes
 
 @Kinematics: Starting (inverted bool array)...
-Passes: 6313, Time: 5.00056 s, Per Loop: 0.792016 ms, Sieve Size: 1000000, Thread Count: 1, Primes Found: 78498, Valid: True
-kinematics_ibool;6313;5.00056;1;algorithm=base,faithful=yes
+Passes: 8800, Time: 5.00048 s, Per Loop: 0.568182 ms, Sieve Size: 1000000, Thread Count: 1, Primes Found: 78498, Valid: True
+kinematics_ibool;8800;5.00048;1;algorithm=base,faithful=yes
 
 @Kinematics: Starting (direct access inverted bool array)...
 Passes: 8964, Time: 5.00047 s, Per Loop: 0.557787 ms, Sieve Size: 1000000, Thread Count: 1, Primes Found: 78498, Valid: True

--- a/PrimeCSharp/solution_1/README.md
+++ b/PrimeCSharp/solution_1/README.md
@@ -137,24 +137,24 @@ And results of running --benchmark
 ```
 BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
 AMD Ryzen 7 3700X, 1 CPU, 16 logical and 8 physical cores
-.NET Core SDK=5.0.201
-  [Host]     : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT
-  DefaultJob : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT
+.NET Core SDK=6.0.100-preview.3.21202.5
+  [Host]     : .NET Core 5.0.8 (CoreCLR 5.0.821.31504, CoreFX 5.0.821.31504), X64 RyuJIT
+  DefaultJob : .NET Core 5.0.8 (CoreCLR 5.0.821.31504, CoreFX 5.0.821.31504), X64 RyuJIT
 
 
 |             Method | SieveSize |       Mean |   Error |  StdDev | Ratio |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
 |------------------- |---------- |-----------:|--------:|--------:|------:|---------:|---------:|---------:|----------:|
-|           Original |   1000000 | 1,381.3 us | 2.37 us | 2.10 us |  1.01 |   5.8594 |        - |        - |   62592 B |
-|           Standard |   1000000 | 1,361.7 us | 4.89 us | 4.57 us |  1.00 |   5.8594 |        - |        - |   62592 B |
-|               Bool |   1000000 |   988.7 us | 7.98 us | 7.47 us |  0.73 | 142.5781 | 142.5781 | 142.5781 |  500056 B |
-|       InvertedBool |   1000000 |   794.6 us | 4.71 us | 4.41 us |  0.58 | 142.5781 | 142.5781 | 142.5781 |  500056 B |
-| DirectInvertedBool |   1000000 |   565.9 us | 2.02 us | 1.79 us |  0.42 | 142.5781 | 142.5781 | 142.5781 |  500056 B |
-|            RawBits |   1000000 |   806.8 us | 2.69 us | 2.39 us |  0.59 |  19.5313 |  19.5313 |  19.5313 |   62560 B |
-|     ArrayPoolClass |   1000000 |   821.6 us | 2.67 us | 2.50 us |  0.60 |        - |        - |        - |      32 B |
-|      ArrayPool2Of6 |   1000000 |   519.0 us | 3.33 us | 2.78 us |  0.38 |        - |        - |        - |      32 B |
-|      ArrayPool6Par |   1000000 |   722.8 us | 4.36 us | 3.87 us |  0.53 |  35.1563 |        - |        - |  295840 B |
-|     ArrayPool8of30 |   1000000 |   398.9 us | 1.98 us | 1.86 us |  0.29 |        - |        - |        - |      96 B |
-|    ArrayPool8of30M |   1000000 |   320.7 us | 0.81 us | 0.67 us |  0.24 |        - |        - |        - |     912 B |
+|           Original |   1000000 | 1,347.4 us | 3.70 us | 3.46 us |  1.00 |   5.8594 |        - |        - |   62592 B |
+|           Standard |   1000000 | 1,346.5 us | 3.80 us | 3.56 us |  1.00 |   5.8594 |        - |        - |   62592 B |
+|               Bool |   1000000 |   806.7 us | 4.94 us | 4.62 us |  0.60 | 142.5781 | 142.5781 | 142.5781 |  500056 B |
+|       InvertedBool |   1000000 |   569.9 us | 3.35 us | 3.13 us |  0.42 | 142.5781 | 142.5781 | 142.5781 |  500056 B |
+| DirectInvertedBool |   1000000 |   567.0 us | 4.73 us | 4.43 us |  0.42 | 142.5781 | 142.5781 | 142.5781 |  500056 B |
+|            RawBits |   1000000 |   777.4 us | 5.70 us | 5.33 us |  0.58 |  19.5313 |  19.5313 |  19.5313 |   62560 B |
+|     ArrayPoolClass |   1000000 |   895.5 us | 3.35 us | 3.13 us |  0.67 |        - |        - |        - |      32 B |
+|      ArrayPool2Of6 |   1000000 |   529.4 us | 2.29 us | 2.03 us |  0.39 |        - |        - |        - |      32 B |
+|      ArrayPool6Par |   1000000 |   714.7 us | 4.65 us | 4.12 us |  0.53 |  35.1563 |        - |        - |  295790 B |
+|     ArrayPool8of30 |   1000000 |   401.8 us | 3.38 us | 3.16 us |  0.30 |        - |        - |        - |      96 B |
+|    ArrayPool8of30M |   1000000 |   313.0 us | 1.54 us | 1.29 us |  0.23 |        - |        - |        - |     912 B |
 ```
 
 

--- a/PrimeCSharp/solution_1/Sieves/PrimeSieve.cs
+++ b/PrimeCSharp/solution_1/Sieves/PrimeSieve.cs
@@ -75,18 +75,16 @@ namespace PrimeCSharp.Sieves
 
         private bool GetBit(int index)
         {
-            if (index % 2 == 0)
-                return false;
+            System.Diagnostics.Debug.Assert(index % 2 == 1);
 
             return bitArray[index >> 1];
         }
 
         private void ClearBit(int index)
         {
-            if (index % 2 == 1)
-            {
-                bitArray[index >> 1] = false;
-            }
+            System.Diagnostics.Debug.Assert(index % 2 == 1);
+
+            bitArray[index >> 1] = false;
         }
     }
 }

--- a/PrimeCSharp/solution_1/Sieves/PrimeSieveBool.cs
+++ b/PrimeCSharp/solution_1/Sieves/PrimeSieveBool.cs
@@ -76,18 +76,16 @@ namespace PrimeCSharp.Sieves
 
         private bool GetBit(int index)
         {
-            if (index % 2 == 0)
-                return false;
+            System.Diagnostics.Debug.Assert(index % 2 == 1);
 
             return boolArray[index >> 1];
         }
 
         private void ClearBit(int index)
         {
-            if (index % 2 == 1)
-            {
-                boolArray[index >> 1] = false;
-            }
+            System.Diagnostics.Debug.Assert(index % 2 == 1);
+
+            boolArray[index >> 1] = false;
         }
     }
 }

--- a/PrimeCSharp/solution_1/Sieves/PrimeSieveInvBool.cs
+++ b/PrimeCSharp/solution_1/Sieves/PrimeSieveInvBool.cs
@@ -73,26 +73,23 @@ namespace PrimeCSharp.Sieves
 
         private bool GetBit(int index)
         {
-            if (index % 2 == 0)
-                return false;
+            System.Diagnostics.Debug.Assert(index % 2 == 1);
 
             return boolArray[index >> 1];
         }
 
         private void SetBit(int index)
         {
-            if (index % 2 == 1)
-            {
-                boolArray[index >> 1] = true;
-            }
+            System.Diagnostics.Debug.Assert(index % 2 == 1);
+
+            boolArray[index >> 1] = true;
         }
 
         private void ClearBit(int index)
         {
-            if (index % 2 == 1)
-            {
-                boolArray[index >> 1] = false;
-            }
+            System.Diagnostics.Debug.Assert(index % 2 == 1);
+
+            boolArray[index >> 1] = false;
         }
     }
 }

--- a/PrimeCSharp/solution_1/Sieves/PrimeSieveOriginal.cs
+++ b/PrimeCSharp/solution_1/Sieves/PrimeSieveOriginal.cs
@@ -74,19 +74,14 @@ namespace PrimeCSharp.Sieves
 
         private bool GetBit(int index)
         {
-            if (index % 2 == 0)
-                return false;
+            System.Diagnostics.Debug.Assert(index % 2 == 1);
 
             return bitArray[index >> 1];
         }
 
         private void ClearBit(int index)
         {
-            if (index % 2 == 0)
-            {
-                Console.WriteLine("You are setting even bits, which is sub-optimal");
-                return;
-            }
+            System.Diagnostics.Debug.Assert(index % 2 == 1);
 
             bitArray[index / 2] = false;
         }

--- a/PrimeCSharp/solution_1/Sieves/PrimeSieveRawBits.cs
+++ b/PrimeCSharp/solution_1/Sieves/PrimeSieveRawBits.cs
@@ -94,8 +94,7 @@ namespace PrimeCSharp.Sieves
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool GetBit(byte[] bits, uint index)
         {
-            if (index % 2 == 0)
-                return false;
+            System.Diagnostics.Debug.Assert(index % 2 == 1);
 
             index /= 2;
 
@@ -109,14 +108,13 @@ namespace PrimeCSharp.Sieves
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ClearBit(byte[] bits, uint index)
         {
-            if (index % 2 == 1)
-            {
-                index /= 2;
+            System.Diagnostics.Debug.Assert(index % 2 == 1);
 
-                byte mask = (byte)~(1u << (int)(index % elementBits));
+            index /= 2;
 
-                GetRawBits(bits, index / elementBits) &= mask;
-            }
+            byte mask = (byte)~(1u << (int)(index % elementBits));
+
+            GetRawBits(bits, index / elementBits) &= mask;
         }
     }
 }

--- a/PrimeCSharp/solution_1/Sieves/PrimeSieveRawBitsInter.cs
+++ b/PrimeCSharp/solution_1/Sieves/PrimeSieveRawBitsInter.cs
@@ -90,8 +90,7 @@ namespace PrimeCSharp.Sieves
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private bool GetBit(uint[] bits, uint index)
         {
-            if (index % 2 == 0)
-                return false;
+            System.Diagnostics.Debug.Assert(index % 2 == 1);
 
             index /= 2;
 
@@ -105,23 +104,22 @@ namespace PrimeCSharp.Sieves
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void ClearBit(uint[] bits, uint index)
         {
-            if (index % 2 == 1)
-            {
-                index /= 2;
+            System.Diagnostics.Debug.Assert(index % 2 == 1);
 
-                uint mask = ~(1u << (int)(index % elementBits));
+            index /= 2;
 
-                GetRawBits(bits, index / elementBits) &= mask;
+            uint mask = ~(1u << (int)(index % elementBits));
 
-                // Test Interlocked.CompareExchange penalty
-                //uint raw = GetRawBits(bits, index / elementBits);
-                //uint nRaw = raw & mask;
+            GetRawBits(bits, index / elementBits) &= mask;
 
-                //while (Interlocked.CompareExchange(ref GetRawBits(bits, index / elementBits), nRaw, raw) != raw)
-                //{
-                //    raw = GetRawBits(bits, index / elementBits);
-                //}
-            }
+            // Test Interlocked.CompareExchange penalty
+            //uint raw = GetRawBits(bits, index / elementBits);
+            //uint nRaw = raw & mask;
+
+            //while (Interlocked.CompareExchange(ref GetRawBits(bits, index / elementBits), nRaw, raw) != raw)
+            //{
+            //    raw = GetRawBits(bits, index / elementBits);
+            //}
         }
     }
 }


### PR DESCRIPTION
Speeds up this pair of sieves by a factor of 2.5x in docker, or about 25% in native.

Run in docker:
bool: 2601 -> 6168
ibool: 3026 -> 8824

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
