### PR TITLE
Lua/solution_2 perfomance increase by using cdata

### DIFF
--- a/PrimeLua/solution_2/PrimeLua.lua
+++ b/PrimeLua/solution_2/PrimeLua.lua
@@ -1,21 +1,26 @@
-function get(primes, num)
-	return bit.band(
-		primes[bit.rshift(num, 6)],
-		bit.lshift(1, bit.band(bit.rshift(num, 1), 31))
+local ffi = require "ffi"
+local lshift, rshift, band, bor = bit.lshift, bit.rshift, bit.band, bit.bor
+local ceil, sqrt = math.ceil, math.sqrt
+local time = os.time
+
+local function get(primes, num)
+	return band(
+		primes[rshift(num, 6)],
+		lshift(1, band(rshift(num, 1), 31))
 	) == 0
 end
 
 local function ruleOut(primes, max)
-	local sqrtMax = math.ceil(math.sqrt(max))
+	local sqrtMax = ceil(sqrt(max))
 	local prime = 3
 	while prime <= sqrtMax do
 		local step = prime + prime
 		for num = prime^2, max, step do
-			primes[bit.rshift(num, 6)] = bit.bor(
-				primes[bit.rshift(num, 6)],
-				bit.band(
-					bit.lshift(1, bit.band(bit.rshift(num, 1), 31)),
-					-bit.band(num, 1)
+			primes[rshift(num, 6)] = bor(
+				primes[rshift(num, 6)],
+				band(
+					lshift(1, band(rshift(num, 1), 31)),
+					-band(num, 1)
 				)
 			)
 		end
@@ -26,29 +31,25 @@ local function ruleOut(primes, max)
 end
 
 local function getPrimes(max)
-	local buf = {max=max}
-	for i = 0, max/64 do
-		buf[i] = 0
-	end
-
+	local buf = ffi.new("int[?]", max/64)
 	ruleOut(buf, max)
 	return buf
 end
 
 local limit, passes = 1000000, 0
-local checkNum, realBuf = 78498, {}
+local checkNum, realBuf = 78498
 
 -- Lua doesn't have a call to get time more accurate than 1 second, so here I wait until the beginning of a second to give as accurate results as possible.
-local startTime, endTime = os.time()+1
-while os.time() ~= startTime do end
+local startTime, endTime = time()+1
+while time() ~= startTime do end
 repeat
 	realBuf = getPrimes(limit)
 	passes = passes + 1
-	endTime = os.time()
+	endTime = time()
 until endTime >= startTime+5
 
 local realNum = 0
-for i = 1, realBuf.max, 2 do
+for i = 1, limit, 2 do
 	if get(realBuf, i) then
 		realNum = realNum + 1
 	end


### PR DESCRIPTION
## Description
Using a cdata array (ffi.new) instead of a normal lua table more than doubles the speed
Local caching of library functions also helps performance
I'm completely new to github, so sorry if there's any mistakes :)


## Contributing requirements
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
