### PR TITLE
Marking Zig/solution_2 as unfaithful due to compile-time size fix

### DIFF
--- a/PrimeZig/solution_2/README.md
+++ b/PrimeZig/solution_2/README.md
@@ -1,3 +1,6 @@
 # Zig solution by ManDeJan
 
-![Category](https://img.shields.io/badge/Category-faithful-green)
+![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
+![Faithfulness](https://img.shields.io/badge/Faithful-no-yellowgreen)
+![Parallelism](https://img.shields.io/badge/Parallel-no-green)
+![Bit count](https://img.shields.io/badge/Bits-8-yellowgreen)

--- a/PrimeZig/solution_2/src/main.zig
+++ b/PrimeZig/solution_2/src/main.zig
@@ -78,7 +78,7 @@ fn runSieveBitTest(comptime size: comptime_int, run_for: comptime_int) anyerror!
 fn printResults(backing: []const u8, passes: usize, elapsed_ns: u64, bit_size: usize) !void {
     const elapsed = @intToFloat(f32, elapsed_ns) / @intToFloat(f32, time.ns_per_s);
     const stdout = std.io.getStdOut().writer();
-    try stdout.print("{s};{};{d:.5};1;faithful=yes,algorithm=base,bits={}\n", .{
+    try stdout.print("{s};{};{d:.5};1;faithful=no,algorithm=base,bits={}\n", .{
         backing, passes, elapsed, bit_size
     });
 }


### PR DESCRIPTION
As pointed out by [a comment](https://github.com/PlummersSoftwareLLC/Primes/discussions/445#discussioncomment-1033651) in discussion #445, the use of a combination of const and comptime in Zig/solution_2 boils down to the sieve (memory) size being set at compile time.
This goes against the rule that _The sieve size and corresponding prime candidate memory buffer (or language equivalent) are set/allocated dynamically at runtime._

As @ManDeJan has indicated that [they can change Zig/solution_2 to make it faithful](https://github.com/PlummersSoftwareLLC/Primes/discussions/445#discussioncomment-1042101), I'll hold on merging this PR for a few days to allow them to do so. 