### PR TITLE
Fixing undefined behaviour

### DIFF
--- a/PrimeCPP/solution_1/Dockerfile
+++ b/PrimeCPP/solution_1/Dockerfile
@@ -1,11 +1,11 @@
 FROM ubuntu:21.04 AS build
 
 RUN apt-get update -qq \
-    && apt-get install -y g++
+    && apt-get install -y clang
 
 COPY *.cpp /opt/app/
 WORKDIR /opt/app
-RUN g++ -Ofast -std=c++17 PrimeCPP.cpp -o PrimeCPP
+RUN clang++ -march=native -mtune=native -Ofast -std=c++17 PrimeCPP.cpp -o PrimeCPP
 
 FROM ubuntu:21.04
 COPY --from=build /opt/app/PrimeCPP /usr/local/bin

--- a/PrimeCPP/solution_1/PrimeCPP.cpp
+++ b/PrimeCPP/solution_1/PrimeCPP.cpp
@@ -56,7 +56,7 @@ public:
         while (n < arrSize) {
             array[index(n)] &= rolling_mask;
             n += skip;
-            rolling_mask = rol(rolling_mask, skip);
+            rolling_mask = rol(rolling_mask, roll_bits);
         }
     }
 };

--- a/PrimeCPP/solution_1/PrimeCPP.cpp
+++ b/PrimeCPP/solution_1/PrimeCPP.cpp
@@ -51,12 +51,9 @@ public:
     }
 
     void setFlagsFalse(size_t n, size_t skip) {
-        auto rolling_mask = ~uint32_t(1 << n % 32);
-        auto roll_bits = skip % 32;
-        while (n < arrSize) {
-            array[index(n)] &= rolling_mask;
-            n += skip;
-            rolling_mask = rol(rolling_mask, roll_bits);
+        const auto rolling_mask = ~uint32_t(1 << n % 32);
+        for (int c = 0; n < arrSize; ++c, n += skip) {
+            array[index(n)] &= rol(rolling_mask, (c * skip) % 32);
         }
     }
 };

--- a/PrimeCPP/solution_1/README.md
+++ b/PrimeCPP/solution_1/README.md
@@ -8,7 +8,7 @@
 
 ## Run instructions
 
-(Linux): g++ -Ofast -std=c++17 PrimeCPP.cpp -o Primes_g++ && ./Primes_g++
+(Linux): clang++ -Ofast -std=c++17 PrimeCPP.cpp -o Primes_clang++ && ./Primes_clang++
 
 ## Output
 

--- a/PrimeCPP/solution_1/run.sh
+++ b/PrimeCPP/solution_1/run.sh
@@ -3,7 +3,7 @@
 # g++ -Ofast  -std=c++17 PrimeCPP.cpp -oPrimes_g++.exe
 # clang -Ofast -std=c++17 -lc++ PrimeCPP.cpp -oPrimes_clang.exe
 
-g++ -Ofast -std=c++17 PrimeCPP.cpp -oPrimes_g++.exe
-cp Primes_g++.exe Primes.exe
+clang++ -march=native -mtune=native -Ofast -std=c++17 PrimeCPP.cpp -o Primes_clang++.exe
+cp Primes_clang++.exe Primes.exe
 
 ./Primes.exe

--- a/PrimeCPP/solution_2/Dockerfile
+++ b/PrimeCPP/solution_2/Dockerfile
@@ -1,11 +1,11 @@
 FROM ubuntu:21.04 AS build
 
 RUN apt-get update -qq \
-    && apt-get install -y g++
+    && apt-get install -y clang
 
 COPY *.cpp /opt/app/
 WORKDIR /opt/app
-RUN g++ -pthread -Ofast -std=c++17 PrimeCPP_PAR.cpp -oprimes_par
+RUN clang++ -march=native -mtune=native -pthread -Ofast -std=c++17 PrimeCPP_PAR.cpp -oprimes_par
 
 FROM ubuntu:21.04
 COPY --from=build /opt/app/primes_par /usr/local/bin

--- a/PrimeCPP/solution_2/PrimeCPP_PAR.cpp
+++ b/PrimeCPP/solution_2/PrimeCPP_PAR.cpp
@@ -61,7 +61,7 @@ public:
         while (n < arrSize) {
             array[index(n)] &= rolling_mask;
             n += skip;
-            rolling_mask = rol(rolling_mask, skip);
+            rolling_mask = rol(rolling_mask, roll_bits);
         }
     }
     
@@ -281,7 +281,7 @@ int main(int argc, char **argv)
     if (!bQuiet)
     {
         printf("Computing primes to %llu on %d thread%s for %d second%s.\n", 
-            llUpperLimit,
+            (unsigned long long)llUpperLimit,
             cThreads,
             cThreads == 1 ? "" : "s",
             cSeconds,

--- a/PrimeCPP/solution_2/PrimeCPP_PAR.cpp
+++ b/PrimeCPP/solution_2/PrimeCPP_PAR.cpp
@@ -56,12 +56,9 @@ public:
     }
 
     void setFlagsFalse(size_t n, size_t skip) {
-        auto rolling_mask = ~uint32_t(1 << n % 32);
-        auto roll_bits = skip % 32;
-        while (n < arrSize) {
-            array[index(n)] &= rolling_mask;
-            n += skip;
-            rolling_mask = rol(rolling_mask, roll_bits);
+        const auto rolling_mask = ~uint32_t(1 << n % 32);
+        for (int c = 0; n < arrSize; ++c, n += skip) {
+            array[index(n)] &= rol(rolling_mask, (c * skip) % 32);
         }
     }
     

--- a/PrimeCPP/solution_2/PrimeCPP_PAR.cpp
+++ b/PrimeCPP/solution_2/PrimeCPP_PAR.cpp
@@ -61,7 +61,7 @@ public:
         while (n < arrSize) {
             array[index(n)] &= rolling_mask;
             n += skip;
-            rolling_mask = rol(rolling_mask, skip);
+            rolling_mask = rol(rolling_mask, roll_bits);
         }
     }
     

--- a/PrimeCPP/solution_2/README.md
+++ b/PrimeCPP/solution_2/README.md
@@ -8,7 +8,7 @@
 
 ## Run instructions
 
-(Linux): clang++ -march=native -mtune=native -Ofast -pthread -std=c++17 PrimeCPP_PAR.cpp -o Primes_g && ./Primes_g
+(Linux): clang++ -march=native -mtune=native -Ofast -pthread -std=c++17 PrimeCPP_PAR.cpp -o Primes_clang++ && ./Primes_clang++
 
 ## Output
 

--- a/PrimeCPP/solution_2/README.md
+++ b/PrimeCPP/solution_2/README.md
@@ -8,7 +8,7 @@
 
 ## Run instructions
 
-(Linux): g++ -Ofast -std=c++17 PrimeCPP.cpp -o Primes_g && ./Primes_g
+(Linux): clang++ -march=native -mtune=native -Ofast -pthread -std=c++17 PrimeCPP_PAR.cpp -o Primes_g && ./Primes_g
 
 ## Output
 

--- a/PrimeCPP/solution_2/run.sh
+++ b/PrimeCPP/solution_2/run.sh
@@ -2,5 +2,5 @@
 # gcc -Ofast -std=c++17 PrimeCPP.cpp -lc++ -oPrimes_gcc.exe
 # clang -Ofast -std=c++17 -lc++ PrimeCPP.cpp -oPrimes_clang.exe
 
-g++ -pthread -Ofast -std=c++17 PrimeCPP_PAR.cpp -oprimes_par.exe
+clang++ -pthread -Ofast -std=c++17 PrimeCPP_PAR.cpp -oprimes_par.exe
 ./primes_par.exe

--- a/PrimeCPP/solution_2/run.sh
+++ b/PrimeCPP/solution_2/run.sh
@@ -2,5 +2,5 @@
 # gcc -Ofast -std=c++17 PrimeCPP.cpp -lc++ -oPrimes_gcc.exe
 # clang -Ofast -std=c++17 -lc++ PrimeCPP.cpp -oPrimes_clang.exe
 
-clang++ -pthread -Ofast -std=c++17 PrimeCPP_PAR.cpp -oprimes_par.exe
+clang++ -march=native -mtune=native -pthread -Ofast -std=c++17 PrimeCPP_PAR.cpp -oprimes_par.exe
 ./primes_par.exe


### PR DESCRIPTION
The CPP version are using a rolling mask which is rotated while settings numbers as not primes.

This mask is sometimes shifted by a value greater than 32. It mostly seems to works, but with some platforms and compilers or optimization settings, it gives wrong results. The right value which is modulo is unused in the code. This PR makes use of that value. 