### PR TITLE
	modified:   solution_1/PrimeREXX.rex

### DIFF
--- a/PrimeREXX/solution_1/PrimeREXX.rex
+++ b/PrimeREXX/solution_1/PrimeREXX.rex
@@ -1,149 +1,206 @@
 /* rexx */
-signal Main
-
-Sieve:
-count = 0
-do while time("E") <= 5
-  primes. = 1
-  do i = 3 to sqRt by 2
-    if primes.i then
-      do
-        incr = i + i; strt = i * i
-        do j = strt to maxVal by incr
-          primes.j = 0
-        end j
-      end
-  end i
-  count = count + 1
-end
-return
-
 /*
 ** Determine the prime numbers less than a number passed as a
-** program parameter (maxVal). The default maxVal is 1,000,000
-** Unlike many programming languages  with predefined data structure type,
+** program parameter (sieveSize). The default sieveSize is 1,000,000
+** Unlike many programming languages  with predefined data structure types,
 ** the stem variables used to store those odd numbers that are not prime
 ** use more memory.
 **
+** As noted in the original pull request, REXX is going to fall at or
+** very near the bottom of the drag-race. This is due to three
+** factors:
+**   o  The submitted REXX is not compiled.
+**   o  The code is therefore dependent upon the efficiency
+**      of the Regina REXX interpreter implementation.
+**   o  The possibility that there is performance to
+**      be gained somewhere in this implementation.
 */
-Main:
-parse arg maxVal printSw
-if maxVal = 0 | maxVal = 1 | maxVal = 2 | maxVal = 3 then
+parse arg sieveSize outputMode
+if sieveSize = 0 | sieveSize = 1 | sieveSize = 2 | sieveSize = 3 then
   do
-    printSw = maxVal
-    maxVal = 1000000
+    /* user did not supply the sieve size, use default 1,000,000 */
+    outputMode = sieveSize
+    sieveSize = 1000000
   end
-else if datatype(maxVal) \= "NUM" then
-  maxVal = 1000000
+else if datatype(sieveSize) \= "NUM" then
+  sieveSize = 1000000
 
-if datatype(printSw) \= "NUM" then
-  printSw = 0 /* no output except the iteration count*/
-printWidth = length(maxVal) + 1
+if datatype(outputMode) \= "NUM" then
+  outputMode = 0 /* no output except the iteration count*/
 
-/*
-** SquareRoot function uses Newton's approximation method. There is no square
-** root function in REXX.
-*/
-sqRt = SquareRoot(maxVal)
+sqRt = SquareRoot(sieveSize)
 
 /*
 ** Note:
 ** o  The final iteration of the do while time("E") <= 5 loop may finish
 **    outside the 5 second mark. So perhaps the final count is too high by
-**    1 iteration, especially as the maxVal gets larger.
-**
-**   Actual Sieve logic starts here, no comments in Sieve()
-***/
-t = time("R")
-call Sieve
-t = time("E") /* close enough for algorithm run time */
+**    1 iteration, especially as the sieveSize gets larger.
+*/
+iterations = Sieve(sieveSize, sqRt)
 
 /*
 ** Sieve iterations are complete, print the results
 */
-call lineout 'stdout',"joss_REXX;"count";"t";1;algorithm=base,bits=8,faithful=no"
+call lineout 'stdout',"joss_REXX;"iterations";"primes._FINAL_ELAPSED";1;algorithm=base,bits=8,faithful=no"
 select
-  when printSw = 1 then
-    call PrintDetail maxVal,printWidth
-  when printSw = 2 then
-    call PrintSummary maxVal
-  when printSw = 3 then
+  when outputMode = 1 then
+    call PrintDetail sieveSize,printWidth
+  when outputMode = 2 then
+    call PrintSummary sieveSize
+  when outputMode = 3 then
     do
-      call PrintSummary maxVal
-      call PrintDetail maxVal,printWidth
+      /* print summary last so you don't have to scroll to the top
+      ** of the detail output to see the summary
+      */
+      call PrintDetail sieveSize,printWidth
+      call PrintSummary sieveSize
     end
   otherwise
     nop
 end /* select*/
 return 0
 
+/*
+** Sieve:
+**  Use the REXX stem 'primes.' to keep track of which numbers from 
+**  3 to sieveSize are prime. Each iteration starts out with all 
+**  numbers assumed prime (primes. = 1 initialization). Then as
+**  the sieve eliminates multiples of the primes found, the 
+**  relevant primes. entry is set to 0.
+**  Notes:
+**    o    The primes. stem is global (via expose)
+**    o    1 and all even numbers could still be seen as prime
+**         because the primes. entries are not set to 0. This
+**         is handled by the PrintDetail() and PrintSummary()
+**         subroutines which bypass 1 and the evens when
+**         processing the primes. stem.
+**    o    Since REXX is interpreted at run time (no JIT compiles)
+**         a subroutine call starts at the top of the source and
+**         reads the source until the subroutine is found. This
+**         represents a minor performance loss (VERY minor). So
+**         the timer start (t = time("R")) was moved to this
+**         subroutine to bypass that loss and also allow for
+**         these comments.
+**    o    The code submitted to github.com/PlummersSoftwareLLC/Primes
+**         had the Sieve() subroutine near the top of the code
+**         to also remove the performance loss mentioned in
+**         the last bullet. By moving the timer start to
+**         the subroutine, the subroutine could be moved below
+**         the main and perhaps be more readable.
+**   There are no comments in Sieve() so the interpreter does not have
+**   to process them.
+*/
+Sieve: procedure expose primes.
+t = time("R")
+parse arg sieveSize, sqRt
+iterations = 0
+do while time("E") <= 5
+  primes. = 1
+  do i = 3 to sqRt by 2
+    if primes.i then
+      do
+        incr = i + i; strt = i * i
+        do j = strt to sieveSize by incr
+          primes.j = 0
+        end j
+      end
+  end i
+  iterations = iterations + 1
+end
+primes._FINAL_ELAPSED = time("E") 
+return iterations
 
+/*
+** PrintDetail:
+** Print all of the primes 2, 3 up to
+** sieve size. Note that 2 is assumed prime
+** the rest were calculated by Sieve.
+*/
 PrintDetail: procedure expose primes.
-parse arg maxVal,printWidth
+parse arg sieveSize
+printWidth = length(sieveSize) + 1
 line = right(2,printWidth)
-digitCount = 1
+/*
+** linePrimesCount keeps track of how many primes are
+** on a single line of output. Starts at 1 to
+** accomodate the first output line containing
+** "2".
+*/
+linePrimesCount = 1
 
-
-do i = 3 to maxVal by 2
-  if primes.i = 1 then
+do i = 3 to sieveSize by 2
+  if primes.i then
    do
      line = line||right(i,printWidth," ")
-     digitCount = digitCount + 1
-     if digitCount = 20 then
+     linePrimesCount = linePrimesCount + 1
+     if linePrimesCount = 20 then
        do
          call lineout 'stdout', line
          line = ""
-         digitCount = 0
+         linePrimesCount = 0
        end
    end
 end i
-if digitCount > 0 then
+if linePrimesCount > 0 then
   call lineout 'stdout', line
 return
 
-
+/*
+** PrintSummary:
+**   Print the count of primes less than powers of 10 up to 10,000,000
+**   If sieveSize was specified, print the primes <= Sievesize and
+**   stop.
+*/
 PrintSummary: procedure expose primes.
-parse arg maxVal
+parse arg sieveSize
 cnt = 1 /* accounts for 2 as prime */
-do i = 3 to maxVal by 2
+do i = 3 to sieveSize by 2
   if primes.i then
     cnt = cnt + 1
   select
-    when i = 99 & i <= maxVal then
+    when i = 99 & i <= sieveSize then
       call lineout 'stderr',cnt" primes less than 100"
-    when i = 999 & i <= maxVal then
+    when i = 999 & i <= sieveSize then
       call lineout 'stderr', cnt" primes less than 1,000"
-    when i = 9999 & i <= maxVal then
+    when i = 9999 & i <= sieveSize then
       call lineout 'stderr', cnt" primes less than 10,000"
-    when i = 99999 & i <= maxVal then
+    when i = 99999 & i <= sieveSize then
       call lineout 'stderr', cnt" primes less than 100,000"
-    when i = 999999 & i <= maxVal then
+    when i = 999999 & i <= sieveSize then
       call lineout 'stderr', cnt" primes less than 1,000,000"
-    when i = 9999999 & i <= maxVal then
+    when i = 9999999 & i <= sieveSize then
       call lineout 'stderr', cnt" primes less than 10,000,000"
-    when i = maxVal | i = maxVal - 1 then
-      call lineout 'stderr', cnt" primes less than or equal to "format(maxVal)
+    when i = sieveSize | i = sieveSize - 1 then
+      call lineout 'stderr', cnt" primes less than or equal to "format(sieveSize)
     otherwise
       nop
   end /* select */
 end i
 return
 
+/*
+** SquareRoot function uses Newton's approximation method. There is no square
+** root function in REXX.
+*/
 SquareRoot: procedure
 parse arg number
 guess = number / 2
-guess2 = .5 * (number / guess + guess)
+guess2 = 0.5 * (number / guess + guess)
 do while abs(guess2 - guess) > .0001
   guess = guess2
-  guess2 = .5 * (number / guess + guess)
+  guess2 = 0.5 * (number / guess + guess)
 end /* while */
 return guess2
-
+/*
+** Format:
+**   Print a passed number with embedded commas.
+**   The method was originally developed by Doug Nadel of
+**   IBM.
+*/
 Format: procedure
 parse arg num
 temp1 = "abc,def,ghi,jkl,mno,pqr,stu,vwx"
 temp2 = "abcdefghijklmnopqrstuvwx"
-l = length(num)
-l3 = (3 - (l//3)) // 3
-i = right(num,l+l3)
-return strip(space(translate(temp1,i,temp2),0),"T",",")
+l = length(num) 
+num = right(num,l+((3 - (l//3)) // 3))
+return strip(space(translate(temp1,num,temp2),0),"T",",")

--- a/PrimeREXX/solution_1/README.md
+++ b/PrimeREXX/solution_1/README.md
@@ -17,36 +17,36 @@ The second parameter "0" is an output mode. The following output modes can be us
 
 1   Print all the primes less-than-or-equal-to the target ("1000000")
     
-    docker run --entrypoint "rexx" ubuntu_rexx .\PrimeREXX.rex 1000000 1
+    docker run --entrypoint "rexx" ubuntu_rexx ./PrimeREXX.rex 1000000 1
 
 2   (summary) Print only the count of primes less-than-or-equal-to 100, 1000, 10000, 100000 and 1000000
     The summary lines depend on what target value is. Thus if a target of 89000 is specified, then
     the count of primes less-than-or-equal-to 100, 1000, 10000 and 89000 will be listed.
     
-    docker run --entrypoint "rexx" ubuntu_rexx .\PrimeREXX.rex 1000000 2
+    docker run --entrypoint "rexx" ubuntu_rexx ./PrimeREXX.rex 1000000 2
 
-3   Print both the summary (mode 2) and the list of primes (mode 1)
-    docker run --entrypoint "rexx" ubuntu_rexx .\PrimeREXX.rex 1000000 3
+3   Print the list of primes (mode 1) and then the summary (mode 2) 
+    docker run --entrypoint "rexx" ubuntu_rexx ./PrimeREXX.rex 1000000 3
 
 All output modes print the <label>;<iterations>;<total_time>;<num_threads>;<tags> line outlined in
 the "CONTRIBUTING.md" file.
 
 
 ## Output
-joss_REXX;21;5.001000;1;algorithm=base,bits=8,faithful=no
+joss_REXX;13;5.125499;1;algorithm=base,bits=8,faithful=no
 
 output mode 1 (partial output shown)
-joss_REXX;21;5.015000;1;algorithm=base,bits=8,faithful=no
+joss_REXX;12;5.234103;1;algorithm=base,bits=8,faithful=no
        2       3       5       7      11      13      17      19      23      29      31      37      41      43      47      53      59      61      67      71
       73      79      83      89      97     101     103     107     109     113     127     131     137     139     149     151     157     163     167     173
      179     181     191     193     197     199     211     223     227     229     233     239     241     251     257     263     269     271     277     281
      283     293     307     311     313     317     331     337     347     349     353     359     367     373     379     383     389     397     401     409
      419     421     431     433     439     443     449     457     461     463     467     479     487     491     499     503     509     521     523     541
      547     557     563     569     571     577     587     593     599     601     607     613     617     619     631     641     643     647     653     659
-     661     673     677     683 ...
+     661     673     677     683     ...
 
 output mode 2
-joss_REXX;21;5.055000;1;algorithm=base,bits=8,faithful=no
+joss_REXX;13;5.281553;1;algorithm=base,bits=8,faithful=no
 25 primes less than 100
 168 primes less than 1,000
 1229 primes less than 10,000

--- a/PrimeREXX/solution_2/Dockerfile
+++ b/PrimeREXX/solution_2/Dockerfile
@@ -1,0 +1,27 @@
+FROM ubuntu:20.04
+WORKDIR /home/netREXX
+RUN apt-get update \
+    && apt-get install -y unzip curl default-jre \
+    && curl -G http://netrexx.org/files/NetRexx-4.01-GA.zip -o ./NetREXX4.zip \
+    && unzip ./NetREXX4.zip -d . \
+    && export PATH=$PATH:/home/netREXX/bin
+    
+COPY ./PrimeNetRexx.nrx .
+RUN java -jar lib/NetRexxF.jar -compile PrimeNetRexx
+
+ENTRYPOINT ["java","-cp","lib/NetRexxF.jar:.","PrimeNetRexx"]
+
+#Print the primes <= 1000000
+#ENTRYPOINT ["java","-cp","lib/NetRexxF.jar:.","PrimeNetRexx","100000","1"]
+# - or -
+#docker run --rm --entrypoint "java" imageName -cp lib/NetRexxF.jar:. PrimeNetRexx 1000000 1
+
+#Print a summary of the prime counts up to 100, 1000, 10000, 100000 and 1000000
+#ENTRYPOINT ["java","-cp","lib/NetRexxF.jar:.","PrimeNetRexx","100000","2"]
+# - or -
+#docker run --rm --entrypoint "java" imageName -cp lib/NetRexxF.jar:. PrimeNetRexx 1000000 2
+
+#Print the primes <= 1000000 and also a summary as above
+#ENTRYPOINT ["java","-cp","lib/NetRexxF.jar:.","PrimeNetRexx","100000","3"]
+# - or -
+#docker run --rm --entrypoint "java" imageName -cp lib/NetRexxF.jar:. PrimeNetRexx 1000000 3

--- a/PrimeREXX/solution_2/PrimeNetRexx.nrx
+++ b/PrimeREXX/solution_2/PrimeNetRexx.nrx
@@ -1,0 +1,191 @@
+/*
+** NetRexx program to determine the prime numbers less than a number passed as a
+** program parameter (sieveSize). The default sieveSize is 1,000,000
+*/
+
+class PrimeNetRexx public uses RexxTime
+properties static public
+	sqRt = int 
+	iterations = int
+    elapsedTime
+	primes = boolean[]
+	primesInit = boolean[]
+
+
+method main(args = String[]) static
+	a = args.length
+	if a > 1 then
+		do
+			sieveSize = Rexx args[0]
+			outputMode = Rexx args[1]
+		end
+	else if a = 1 then
+		do
+			sieveSize = args[0]
+			outputMode = 0
+		end
+	else
+		do
+			sieveSize = 1000000
+			outputMode = 0
+		end
+	test = (sieveSize.translate("           ","0123456789.")).space(0)
+	if test \= "" then
+		sieveSize = 1000000
+	test = (outputMode.translate("          ","0123456789.")).space(0)
+	if test \= "" then
+		outputMode = 0
+	if sieveSize = 0 | sieveSize = 1 | sieveSize = 2 | sieveSize = 3 then
+	  do
+		/* user did not supply the sieve size, use default 1,000,000 */
+		outputMode = sieveSize
+		sieveSize = 1000000
+	  end
+	/*
+	** arrays start at 0, to bypass offsetting the entry for integer x by 1
+	** inside the Sieve() method, allocate an array 1 entry larger than 
+	** sieveSize. Then entry 0 represents 0, ...
+	*/
+	primesInit = boolean[sieveSize + 1]
+	loop i = 0 to sieveSize
+		primesInit[i] = 1
+	end
+	primes = boolean[sieveSize + 1]
+	
+	/*
+	** Note:
+	** o  The final iteration of the do while time("E") <= 5 loop may finish
+	**    outside the 5 second mark. So perhaps the final count is too high by
+	**    1 iteration, especially as the sieveSize gets larger.
+	**
+	*/
+	sqRt = SquareRoot(sieveSize).trunc
+	iterations = Sieve(sieveSize)
+
+	/*
+	** Sieve iterations are complete, print the results
+	*/
+	say "joss_NetRexx;"iterations";"elapsedtime";1;algorithm=base,bits=8,faithful=no"
+	select
+	  when outputMode = 1 then
+		PrintDetail(sieveSize)
+	  when outputMode = 2 then
+		PrintSummary(sieveSize)
+	  when outputMode = 3 then
+		do
+		  /* print summary last so you don't have to scroll to the top
+		  ** of the detail output to see the summary
+		  */
+		  PrintDetail(sieveSize)
+		  PrintSummary(sieveSize)
+		end
+	  otherwise
+		nop
+	end /* select*/
+	exit 0
+
+
+method Sieve(sieveSize) static
+	/* 
+	** start the timer. This is not interrupt driven so the outer loop will
+	** always run at least one time. For sieveSize over 10,000,000 the loop will
+	** run well over 5 seconds.
+	*/
+	time("R")
+	iterations = 0
+	loop while time("E") <= 5
+		primes = primesInit
+		loop i = 3 to SqRt by 2
+			if primes[i] = 1 then
+			do
+				incr = i + i
+				/*
+				** Since i is a prime, all odd numbers up to
+				** i^2 have been marked as composite, so start
+				** marking the multiples of i starting at i^2.
+				*/
+				strt = i * i
+				loop j = strt to sieveSize by incr
+					primes[j] = 0
+				end
+			end
+		end 
+	  iterations = iterations + 1
+	end
+	/* capture the elapsed time of all iterations */
+	elapsedTime = time("E") 
+	return iterations
+
+
+method PrintDetail(sieveSize) static
+	printWidth	= int sieveSize.length() + 1
+	line		= 2.right(printWidth)
+	primesPerLine	= 1
+
+	loop i = 3 to sieveSize by 2
+	  if primes[i] then
+	   do
+		 line = line||i.right(printWidth," ")
+		 primesPerLine = primesPerLine + 1
+		 if primesPerLine = 20 then
+		   do
+			 say line
+			 line = ""
+			 primesPerLine = 0
+		   end
+	   end
+	end i
+	if primesPerLine > 0 then
+	  say line
+	return
+
+
+method PrintSummary(sieveSize) static
+	cnt			= int 1 /* accounts for 2 as prime */
+
+	loop i = 3 to sieveSize by 2
+	  if primes[i] then
+		cnt = cnt + 1
+	  select
+		when i = 99 & i <= sieveSize then
+		  say cnt" primes less than 100 (expected 25)"
+		when i = 999 & i <= sieveSize then
+		  say  cnt" primes less than 1,000 (expected 168)"
+		when i = 9999 & i <= sieveSize then
+		  say  Format(cnt)" primes less than 10,000 (expected 1,229)"
+		when i = 99999 & i <= sieveSize then
+		  say  Format(cnt)" primes less than 100,000 (expected 9,592)"
+		when i = 999999 & i <= sieveSize then
+		  say  Format(cnt)" primes less than 1,000,000 (expected 78,948)"
+		when i = 9999999 & i <= sieveSize then
+		  say Format(cnt)" primes less than 10,000,000 (expected 664,579)"
+		when i = 99999999 & i <= sieveSize then
+		  say Format(cnt)" primes less than 100,000,000 (expected 5,761,455)"
+		when i = 999999999 & i <= sieveSize then
+		  say Format(cnt)" primes less than 1,000,000,000 (expected 50,847,534)"
+		when i = sieveSize | i = sieveSize - 1 then
+		  say Format(cnt)" primes less than or equal to "format(sieveSize)
+		otherwise
+		  nop
+	  end /* select */
+	end i
+	return
+
+
+method SquareRoot(number) static
+	guess = number / 2
+	guess2 = 0.5 * (number / guess + guess)
+	loop while (guess2 - guess).abs() > 0.0001
+	  guess = guess2
+	  guess2 = 0.5 * (number / guess + guess)
+	end /* while */
+	return guess2
+
+
+method Format(num) static 
+	temp1		= "abc,def,ghi,jkl,mno,pqr,stu,vwx"
+	temp2		= "abcdefghijklmnopqrstuvwx"
+	l			= num.length()
+	l3			= (3 - (l//3)) // 3
+	i			= num.right(l+l3)
+	return temp1.translate(i,temp2).space(0).strip("T",",")

--- a/PrimeREXX/solution_2/README.md
+++ b/PrimeREXX/solution_2/README.md
@@ -1,0 +1,74 @@
+# NetRexx solution by joss
+Sieve of Erastosthones for the NetRexx language.
+Uses the RexxLA (Rexx Language Association) translator to compile the program PrimeNetRexx.NetRexx
+
+NetRexx translates source code into Java compiled classes. The NetRexx syntax is similar to REXX,
+but there are enough differences to be a separate language. For example: stem variables are not
+supported in NetRexx and classes, methods and properties are not supported in REXX.
+
+A Dockerfile has been supplied. It is based upon an Ubuntu:20.04 image. I wanted to use the openjdk
+docker image, but I didn't know which OS underlaid it and how to install NetRexx via curl and
+unzip therein.
+
+Notes:
+In the sieve I tried having the iterators "i" and "j" be both NetRexx types and native java
+types (by declaring them as int before running the loops). The NetRexx types version of
+PrimeNetRexx returned iteration counts in the range 110-120. The java version returned an
+iteration count 35.
+
+While NetRexx does generate java classes, the resultant classes do not have the iteration
+counts shown by the drag-race native java programs.
+
+## Run instructions
+The supplied Dockerfile runs the default test:
+
+ENTRYPOINT ["java","-cp","lib/NetRexxF.jar:.","PrimeNetRexx"]
+
+PrimeNetRexx takes 3 parameters:
+The first parameter (default = 1000000) is the target (highest value to test for prime-acy)
+The second parameter (default=0) is an output mode. The following output modes can be used:
+0   The standard test as outlined in the "CONTRIBUTING.md" file
+
+1   Print all the primes less-than-or-equal-to the target ("1000000")
+    
+    docker run --entrypoint "java" ubuntu_netrexx -cp lib/NetRexxF.jar:. PrimeNetRexx 1000000 1
+
+2   (summary) Print only the count of primes less-than-or-equal-to 100, 1000, 10000, 100000 and 1000000
+    The summary lines depend on what target value is. Thus if a target of 89000 is specified, then
+    the count of primes less-than-or-equal-to 100, 1000, 10000 and 89000 will be listed.
+    
+    docker run --entrypoint "java" ubuntu_netrexx -cp lib/NetRexxF.jar:. PrimeNetRexx 1000000 2
+
+3   Print the list of primes (mode 1) and then the summary (mode 2) 
+   docker run --entrypoint "java" ubuntu_netrexx -cp lib/NetRexxF.jar:. PrimeNetRexx 1000000 3
+
+All output modes print the <label>;<iterations>;<total_time>;<num_threads>;<tags> line outlined in
+the "CONTRIBUTING.md" file.
+
+
+## Output
+joss_NetREXX;118;5.065878;1;algorithm=base,bits=8,faithful=no
+
+Notes
+o   although the source code creates a class PrimeNetRexx, the program is simply a set of static methods run from main(). For this
+    reason, I marked the runs as faithful=no as no objects are ever instantiated.
+o   The NetRexx program shows significant improvement over the interpreted Rexx program (116-118 iterations versus fewer than 20). However, it 
+    is still slow compared to true compiled/optimized languages.
+    
+output mode 1 (partial output shown)
+joss_NetREXX;116;5.019622;1;algorithm=base,bits=8,faithful=no
+       2       3       5       7      11      13      17      19      23      29      31      37      41      43      47      53      59      61      67      71
+      73      79      83      89      97     101     103     107     109     113     127     131     137     139     149     151     157     163     167     173
+     179     181     191     193     197     199     211     223     227     229     233     239     241     251     257     263     269     271     277     281
+     283     293     307     311     313     317     331     337     347     349     353     359     367     373     379     383     389     397     401     409
+     419     421     431     433     439     443     449     457     461     463     467     479     487     491     499     503     509     521     523     541
+     547     557     563     569     571     577     587     593     599     601     607     613     617     619     631     641     643     647     653     659
+     661     673     677     683     ...
+
+output mode 2
+joss_NetREXX;117;5.012450;1;algorithm=base,bits=8,faithful=no
+25 primes less than 100 (expected 25)
+168 primes less than 1,000 (expected 168)
+1,229 primes less than 10,000 (expected 1,229)
+9,592 primes less than 100,000 (expected 9,592)
+78,498 primes less than 1,000,000 (expected 78,948)


### PR DESCRIPTION
	Modified variable names to match the sample C# names in
	solution_1 (for example sieveSize).
	Moved the Sieve() function to the middle of the code. It was at
	the top because the interpreter starts at the top looking for a
	subroutine when it is called. But since it is only called once
	and since the timer has been moved to the subroutine, there is
	no reason for Sieve() to sit alone at the top of the program.
	corrected the "docker run" comments to change the directory
	separator character to "/".
	New Dockerfile to build the NetRexx solution
	NetRexx sieve of Erasthosthenes program
	How to build and run the Sieve.

## Description
<!--
Add your description yere.
-->

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
