### PR TITLE
Rust idiomatic improvements for `solution_1`

### DIFF
--- a/PrimeRust/solution_1/Dockerfile
+++ b/PrimeRust/solution_1/Dockerfile
@@ -6,7 +6,7 @@
 # Note: Debian based, not Alpine; for some reason, the 
 # Alpine malloc call is slower than it should be.
 #
-FROM rust:1.52.1 AS build
+FROM rust:1.53 AS build
 
 WORKDIR /app
 COPY . .

--- a/PrimeRust/solution_1/README.md
+++ b/PrimeRust/solution_1/README.md
@@ -8,7 +8,8 @@
 ![Bit count](https://img.shields.io/badge/Bits-8-yellowgreen)
 
 Contributors:
-- Michael Barber @mike-barber https://www.github.com/mike-barber
+- Michael Barber @mike-barber https://www.github.com/mike-barber -- original author
+- Kai Rese @Kulasko https://github.com/Kulasko -- numerous idiomatic improvements and detailed code review
 
 This is a somewhat Rust-idiomatic version that has the storage of prime flags abstracted out, with the prime sieve algorithm generic over the storage. Two kinds of storage are implemented:
     
@@ -35,14 +36,14 @@ Tested on a Ryzen 3900X, Rust 1.53, running on WSL2.
 
 This is as reported on `stdout`:
 ```
-mike-barber_byte-storage;18543;5.0002603531;1;algorithm=base,faithful=yes,bits=8
-mike-barber_bit-storage;12082;5.0004081726;1;algorithm=base,faithful=yes,bits=1
-mike-barber_bit-storage-rotate;12484;5.0002326965;1;algorithm=base,faithful=yes,bits=1
-mike-barber_bit-storage-striped;15576;5.0002875328;1;algorithm=base,faithful=yes,bits=1
-mike-barber_byte-storage;168821;5.0012035370;24;algorithm=base,faithful=yes,bits=8
-mike-barber_bit-storage;134987;5.0009522438;24;algorithm=base,faithful=yes,bits=1
-mike-barber_bit-storage-rotate;159453;5.0008320808;24;algorithm=base,faithful=yes,bits=1
-mike-barber_bit-storage-striped;182613;5.0009403229;24;algorithm=base,faithful=yes,bits=1
+mike-barber_byte-storage;18133;5.0003032684;1;algorithm=base,faithful=yes,bits=8
+mike-barber_bit-storage;11900;5.0003099442;1;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-rotate;14026;5.0002503395;1;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-striped;18840;5.0001025200;1;algorithm=base,faithful=yes,bits=1
+mike-barber_byte-storage;168113;5.0010471344;24;algorithm=base,faithful=yes,bits=8
+mike-barber_bit-storage;134415;5.0008001328;24;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-rotate;165800;5.0009751320;24;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-striped;189954;5.0009155273;24;algorithm=base,faithful=yes,bits=1
 ```
 
 We report more informative metrics to `stderr` too, but these don't go into the report, as recorded below.

--- a/PrimeRust/solution_1/README.md
+++ b/PrimeRust/solution_1/README.md
@@ -36,14 +36,14 @@ Tested on a Ryzen 3900X, Rust 1.53, running on WSL2.
 
 This is as reported on `stdout`:
 ```
-mike-barber_byte-storage;18133;5.0003032684;1;algorithm=base,faithful=yes,bits=8
-mike-barber_bit-storage;11900;5.0003099442;1;algorithm=base,faithful=yes,bits=1
-mike-barber_bit-storage-rotate;14026;5.0002503395;1;algorithm=base,faithful=yes,bits=1
-mike-barber_bit-storage-striped;18840;5.0001025200;1;algorithm=base,faithful=yes,bits=1
-mike-barber_byte-storage;168113;5.0010471344;24;algorithm=base,faithful=yes,bits=8
-mike-barber_bit-storage;134415;5.0008001328;24;algorithm=base,faithful=yes,bits=1
-mike-barber_bit-storage-rotate;165800;5.0009751320;24;algorithm=base,faithful=yes,bits=1
-mike-barber_bit-storage-striped;189954;5.0009155273;24;algorithm=base,faithful=yes,bits=1
+mike-barber_byte-storage;18899;5.0000662804;1;algorithm=base,faithful=yes,bits=8
+mike-barber_bit-storage;12078;5.0003247261;1;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-rotate;14249;5.0003366470;1;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-striped;19021;5.0002198219;1;algorithm=base,faithful=yes,bits=1
+mike-barber_byte-storage;171065;5.0014705658;24;algorithm=base,faithful=yes,bits=8
+mike-barber_bit-storage;134961;5.0008754730;24;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-rotate;166345;5.0007843971;24;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-striped;190855;5.0008077621;24;algorithm=base,faithful=yes,bits=1
 ```
 
 We report more informative metrics to `stderr` too, but these don't go into the report, as recorded below.

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -115,7 +115,7 @@ pub mod primes {
         fn create_true(size: usize) -> Self {
             let num_words = size / U32_BITS + (size % U32_BITS).min(1);
             FlagStorageBitVector {
-                words: vec![0xffffffff; num_words],
+                words: vec![u32::MAX; num_words],
                 length_bits: size,
             }
         }
@@ -155,7 +155,7 @@ pub mod primes {
         fn create_true(size: usize) -> Self {
             let num_words = size / U32_BITS + (size % U32_BITS).min(1);
             FlagStorageBitVectorRotate {
-                words: vec![0xffffffff; num_words],
+                words: vec![u32::MAX; num_words],
                 length_bits: size,
             }
         }
@@ -215,7 +215,7 @@ pub mod primes {
         fn create_true(size: usize) -> Self {
             let num_words = size / U8_BITS + (size % U8_BITS).min(1);
             Self {
-                words: vec![0xff; num_words],
+                words: vec![u8::MAX; num_words],
                 length_bits: size,
             }
         }

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -54,7 +54,7 @@ pub mod primes {
             }
         }
 
-        #[allow(dead_code)]
+        #[cfg(test)]
         pub fn known_results(&self) -> &HashMap<usize, usize> {
             &self.0
         }

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -85,7 +85,7 @@ pub mod primes {
             FlagStorageByteVector(vec![1; size])
         }
 
-        // bounds checks are elided since we're runing up to .len()
+        // bounds checks are elided since we're running up to .len()
         #[inline(always)]
         fn reset_flags(&mut self, start: usize, skip: usize) {
             let mut i = start;

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -95,6 +95,7 @@ pub mod primes {
             }
         }
 
+        #[inline(always)]
         fn get(&self, index: usize) -> bool {
             if let Some(val) = self.0.get(index) {
                 *val == 1
@@ -135,6 +136,7 @@ pub mod primes {
             }
         }
 
+        #[inline(always)]
         fn get(&self, index: usize) -> bool {
             if index >= self.length_bits {
                 return false;
@@ -178,6 +180,7 @@ pub mod primes {
             }
         }
 
+        #[inline(always)]
         fn get(&self, index: usize) -> bool {
             if index >= self.length_bits {
                 return false;
@@ -220,6 +223,7 @@ pub mod primes {
             }
         }
 
+        #[inline(always)]
         fn reset_flags(&mut self, start: usize, skip: usize) {
             let chunk = self.words.len();
             for bit in 0..8 {
@@ -246,6 +250,7 @@ pub mod primes {
             }
         }
 
+        #[inline(always)]
         fn get(&self, index: usize) -> bool {
             if index > self.length_bits {
                 return false;
@@ -276,6 +281,7 @@ pub mod primes {
             }
         }
 
+        #[inline(always)]
         fn is_num_flagged(&self, number: usize) -> bool {
             if number % 2 == 0 {
                 return false;

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -283,16 +283,12 @@ pub mod primes {
 
         #[inline(always)]
         fn is_num_flagged(&self, number: usize) -> bool {
-            if number % 2 == 0 {
-                return false;
-            }
-            let index = number / 2;
-            self.flags.get(index)
+            self.flags.get(number)
         }
 
         // count number of primes (not optimal, but doesn't need to be)
         pub fn count_primes(&self) -> usize {
-            (1..self.sieve_size)
+            (0..self.sieve_size / 2)
                 .filter(|v| self.is_num_flagged(*v))
                 .count()
         }
@@ -306,9 +302,9 @@ pub mod primes {
             // fail to catch cases like sieve_size = 1000
             while factor <= q {
                 // find next factor - next still-flagged number
-                factor = (factor..self.sieve_size)
+                factor = (factor / 2..self.sieve_size / 2)
                     .find(|n| self.is_num_flagged(*n))
-                    .unwrap();
+                    .unwrap() * 2 + 1;
 
                 // reset flags starting at `start`, every `factor`'th flag
                 let start = factor * factor / 2;

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -166,11 +166,11 @@ pub mod primes {
         fn reset_flags(&mut self, start: usize, skip: usize) {
             let mut i = start;
             let roll_bits = skip as u32;
-            let mut rolling_mask1 = !(1 << start % U32_BITS);
-            let mut rolling_mask2 = !(1 << (start + skip) % U32_BITS);
-            
+            let mut rolling_mask1 = !(1 << (start % U32_BITS));
+            let mut rolling_mask2 = !(1 << ((start + skip) % U32_BITS));
+
             // if the skip is larger than the word size, we're clearing bits in different
-            // words: we can unroll the loop
+            // words each time: we can unroll the loop
             if skip > U32_BITS {
                 let roll_bits_double = roll_bits * 2;
                 let unrolled_end = (self.words.len() * U32_BITS).saturating_sub(skip);
@@ -178,7 +178,7 @@ pub mod primes {
                     let word_idx1 = i / U32_BITS;
                     let word_idx2 = (i + skip) / U32_BITS;
                     // Safety: We have ensured that (i+skip) < self.words.len() * U32_BITS.
-                    // The compiler will not elide these bounds checks, 
+                    // The compiler will not elide these bounds checks,
                     // so there is a performance benefit to using get_unchecked_mut here.
                     unsafe {
                         *self.words.get_unchecked_mut(word_idx1) &= rolling_mask1;
@@ -193,7 +193,7 @@ pub mod primes {
             while i < self.words.len() * U32_BITS {
                 let word_idx = i / U32_BITS;
                 // Safety: We have ensured that word_index < self.words.len().
-                // Unsafe usage to ensure that we elide the bounds check reliably.
+                // Unsafe required to ensure that we elide the bounds check reliably.
                 unsafe {
                     *self.words.get_unchecked_mut(word_idx) &= rolling_mask1;
                 }
@@ -264,7 +264,7 @@ pub mod primes {
                 if chunk_start < chunk {
                     let slice = &mut self.words[chunk_start..];
                     let mut i = 0;
-                    
+
                     // unrolled loop
                     let end_unrolled = slice.len().saturating_sub(skip);
                     while i < end_unrolled {
@@ -278,7 +278,7 @@ pub mod primes {
                         i += skip + skip;
                     }
 
-                    // remainder - compiler elides these bounds checks as 
+                    // remainder - compiler elides these bounds checks as
                     // the loop is simple enough
                     while i < slice.len() {
                         slice[i] &= mask;

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -281,10 +281,18 @@ pub mod primes {
             }
         }
 
+        fn is_num_flagged(&self, number: usize) -> bool {
+            if number % 2 == 0 {
+                return false;
+            }
+            let index = number / 2;
+            self.flags.get(index)
+        }
+
         // count number of primes (not optimal, but doesn't need to be)
         pub fn count_primes(&self) -> usize {
-            (0..self.sieve_size / 2)
-                .filter(|v| self.flags.get(*v))
+            (1..self.sieve_size)
+                .filter(|v| self.is_num_flagged(*v))
                 .count()
         }
 
@@ -325,7 +333,7 @@ pub mod primes {
     ) {
         if show_results {
             eprint!("2,");
-            for num in (3..prime_sieve.sieve_size).filter(|n| prime_sieve.flags.get(*n)) {
+            for num in (3..prime_sieve.sieve_size).filter(|n| prime_sieve.is_num_flagged(*n)) {
                 print!("{},", num);
             }
             eprintln!();

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -224,7 +224,7 @@ pub mod primes {
             let chunk = self.words.len();
             for bit in 0..8 {
                 // get mask for this bit position
-                let mask = !(1_u8 << bit);
+                let mask = !(1 << bit);
 
                 // calculate start word for this stripe
                 let chunk_start = bit * chunk;

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -12,6 +12,12 @@ use structopt::StructOpt;
 pub mod primes {
     use std::{collections::HashMap, time::Duration, usize};
 
+    /// Shorthand for the `u8` bit count to avoid additional conversions.
+    const U8_BITS: usize = u8::BITS as usize;
+
+    /// Shorthand for the `u32` bit count to avoid additional conversions.
+    const U32_BITS: usize = u32::BITS as usize;
+
     /// Validator to compare against known primes.
     /// Pulled this out into a separate struct, as it's defined
     /// `const` in C++. There are various ways to do this in Rust, including
@@ -105,8 +111,6 @@ pub mod primes {
         length_bits: usize,
     }
 
-    const U32_BITS: usize = 32;
-
     impl FlagStorage for FlagStorageBitVector {
         fn create_true(size: usize) -> Self {
             let num_words = size / U32_BITS + (size % U32_BITS).min(1);
@@ -196,8 +200,6 @@ pub mod primes {
     /// only for sieves that fit inside the processor cache. For processors with
     /// smaller caches or larger sieves, this algorithm will result in a lot of
     /// cache thrashing.
-    const U8_BITS: usize = 8;
-
     pub struct FlagStorageBitVectorStriped {
         words: Vec<u8>,
         length_bits: usize,

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -281,15 +281,10 @@ pub mod primes {
             }
         }
 
-        #[inline(always)]
-        fn is_num_flagged(&self, number: usize) -> bool {
-            self.flags.get(number)
-        }
-
         // count number of primes (not optimal, but doesn't need to be)
         pub fn count_primes(&self) -> usize {
             (0..self.sieve_size / 2)
-                .filter(|v| self.is_num_flagged(*v))
+                .filter(|v| self.flags.get(*v))
                 .count()
         }
 
@@ -303,8 +298,10 @@ pub mod primes {
             while factor <= q {
                 // find next factor - next still-flagged number
                 factor = (factor / 2..self.sieve_size / 2)
-                    .find(|n| self.is_num_flagged(*n))
-                    .unwrap() * 2 + 1;
+                    .find(|n| self.flags.get(*n))
+                    .unwrap()
+                    * 2
+                    + 1;
 
                 // reset flags starting at `start`, every `factor`'th flag
                 let start = factor * factor / 2;
@@ -328,7 +325,7 @@ pub mod primes {
     ) {
         if show_results {
             eprint!("2,");
-            for num in (3..prime_sieve.sieve_size).filter(|n| prime_sieve.is_num_flagged(*n)) {
+            for num in (3..prime_sieve.sieve_size).filter(|n| prime_sieve.flags.get(*n)) {
                 print!("{},", num);
             }
             eprintln!();

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -55,8 +55,8 @@ pub mod primes {
         }
 
         #[cfg(test)]
-        pub fn known_results(&self) -> &HashMap<usize, usize> {
-            &self.0
+        pub fn known_results_iter(&self) -> impl Iterator<Item = (&usize, &usize)> {
+            self.0.iter()
         }
     }
 
@@ -599,7 +599,7 @@ mod tests {
 
     fn sieve_known_correct<T: FlagStorage>() {
         let validator = PrimeValidator::default();
-        for (sieve_size, expected_primes) in validator.known_results().iter() {
+        for (sieve_size, expected_primes) in validator.known_results_iter() {
             let mut sieve: PrimeSieve<T> = primes::PrimeSieve::new(*sieve_size);
             sieve.run_sieve();
             assert_eq!(

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -431,7 +431,7 @@ fn main() {
     // run all implementations if no options are specified (default)
     let run_all = [opt.bits, opt.bits_rotate, opt.bits_striped, opt.bytes]
         .iter()
-        .all(|b| !b);
+        .all(|b| !*b);
 
     for threads in thread_options {
         if opt.bytes || run_all {

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -329,7 +329,7 @@ pub mod primes {
             for num in (3..prime_sieve.sieve_size).filter(|n| prime_sieve.is_num_flagged(*n)) {
                 print!("{},", num);
             }
-            eprint!("\n");
+            eprintln!();
         }
 
         let count = prime_sieve.count_primes();


### PR DESCRIPTION
## Description

@Kulasko and I have worked through the improvements to make the code more idiomatic. There are a couple of performance improvements in there too.

Ideally, we would also like to refactor the single `main.rs` into separate files. However, this will make review more painful as it's hard to see what lines were changed when doing this, so we haven't done it yet. 

It might be easier if this is in a completely separate refactor-only PR. @rbergen would it be easier doing the file split separately? Or would you prefer us to add it to this PR? It's also an option to just not do it at all -- I know you guys have a lot on your plates.

## Contributing requirements
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
