### PR TITLE
[C++ Solution 1/2] Fixed incorrect array size

### DIFF
--- a/PrimeCPP/solution_1/PrimeCPP.cpp
+++ b/PrimeCPP/solution_1/PrimeCPP.cpp
@@ -20,7 +20,7 @@ class BitArray {
     size_t arrSize;
 
     inline static size_t arraySize(size_t size) {
-        return (size >> 5) + ((size & 0x31) > 0);
+        return (size >> 5) + ((size & 31) > 0);
     }
 
     inline static size_t index(size_t n) {
@@ -37,7 +37,7 @@ class BitArray {
 public:
     explicit BitArray(size_t size) : arrSize(size) {
         array = new uint32_t[arraySize(size)];
-        std::memset(array, 0xFF, (size >> 3) + ((size & 0x07) > 0));
+        std::memset(array, 0xFF, (size >> 3) + ((size & 7) > 0));
     }
 
     ~BitArray() {delete [] array;}

--- a/PrimeCPP/solution_2/PrimeCPP_PAR.cpp
+++ b/PrimeCPP/solution_2/PrimeCPP_PAR.cpp
@@ -25,7 +25,7 @@ class BitArray {
     size_t arrSize;
 
     inline static size_t arraySize(size_t size) {
-        return (size >> 5) + ((size & 0x31) > 0);
+        return (size >> 5) + ((size & 31) > 0);
     }
 
     inline static size_t index(size_t n) {
@@ -42,7 +42,7 @@ class BitArray {
 public:
     explicit BitArray(size_t size) : arrSize(size) {
         array = new uint32_t[arraySize(size)];
-        std::memset(array, 0xFF, (size >> 3) + ((size & 0x07) > 0));
+        std::memset(array, 0xFF, (size >> 3) + ((size & 7) > 0));
     }
 
     ~BitArray() {delete [] array;}


### PR DESCRIPTION
These AND masks need to be in decimal rather than hex.  The 0x31 mask happens to work for 1 million sieve size but you get a compiler warning if you try to compile for 1 million + 2 for example (complains that you're trying to fill 1 too many bytes with memset.)

0x07 is obviously the same in hex as it is in decimal.  Just changed it for consistency.