### PR TITLE
Rust `solution_1` bit storage improvements

### DIFF
--- a/PrimeRust/solution_1/README.md
+++ b/PrimeRust/solution_1/README.md
@@ -79,7 +79,7 @@ bit-storage     Passes: 151710, Threads: 24, Time: 5.0007929802, Average: 0.0000
 bit-storage     Passes: 151644, Threads: 24, Time: 5.0008230209, Average: 0.0000329774, Limit: 1000000, Counts: 78498, Valid: Pass
 ```
 
-## Performance - **Raspberri Pi 4**
+## Performance - **Raspberry Pi 4**
 
 Tested on a **Raspberry Pi 4**, standard clock with active cooling, running 64-bit Ubuntu Server 20.04.
 - Examples are run with `cargo run --release -- --repetitions=3` to get 3 repetitions.

--- a/PrimeRust/solution_1/README.md
+++ b/PrimeRust/solution_1/README.md
@@ -36,14 +36,18 @@ Tested on a Ryzen 3900X, Rust 1.53, running on WSL2.
 
 This is as reported on `stdout`:
 ```
-mike-barber_byte-storage;18899;5.0000662804;1;algorithm=base,faithful=yes,bits=8
-mike-barber_bit-storage;12078;5.0003247261;1;algorithm=base,faithful=yes,bits=1
-mike-barber_bit-storage-rotate;14249;5.0003366470;1;algorithm=base,faithful=yes,bits=1
-mike-barber_bit-storage-striped;19021;5.0002198219;1;algorithm=base,faithful=yes,bits=1
-mike-barber_byte-storage;171065;5.0014705658;24;algorithm=base,faithful=yes,bits=8
-mike-barber_bit-storage;134961;5.0008754730;24;algorithm=base,faithful=yes,bits=1
-mike-barber_bit-storage-rotate;166345;5.0007843971;24;algorithm=base,faithful=yes,bits=1
-mike-barber_bit-storage-striped;190855;5.0008077621;24;algorithm=base,faithful=yes,bits=1
+mike-barber_byte-storage;18661;5.0000872612;1;algorithm=base,faithful=yes,bits=8
+mike-barber_bit-storage;12098;5.0002989769;1;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-rotate;14090;5.0002450943;1;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-striped;19205;5.0002722740;1;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-striped-blocks;21305;5.0001897812;1;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-striped-blocks-small;20338;5.0000920296;1;algorithm=base,faithful=yes,bits=1
+mike-barber_byte-storage;170552;5.0009374619;24;algorithm=base,faithful=yes,bits=8
+mike-barber_bit-storage;134112;5.0011000633;24;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-rotate;164057;5.0006699562;24;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-striped;191961;5.0007262230;24;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-striped-blocks;221099;5.0007972717;24;algorithm=base,faithful=yes,bits=1
+mike-barber_bit-storage-striped-blocks-small;224842;5.0006871223;24;algorithm=base,faithful=yes,bits=1
 ```
 
 We report more informative metrics to `stderr` too, but these don't go into the report, as recorded below.

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -768,7 +768,7 @@ fn run_implementation<T: 'static + FlagStorage + Send>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::primes::{PrimeValidator, BLOCK_SIZE_DEFAULT};
+    use crate::primes::PrimeValidator;
 
     #[test]
     fn sieve_known_correct_bits() {

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -242,7 +242,7 @@ pub mod primes {
     /// only for sieves that fit inside the processor cache. For processors with
     /// smaller caches or larger sieves, this algorithm will result in a lot of
     /// cache thrashing due to multiple passes. It really doesn't work well on something 
-    /// like a raspberri pi. 
+    /// like a raspberry pi. 
     ///
     /// [`FlagStorageBitVectorStripedBlocks`] takes a more cache-friendly approach.
     pub struct FlagStorageBitVectorStriped {
@@ -329,7 +329,7 @@ pub mod primes {
     pub const BLOCK_SIZE_DEFAULT: usize = 16 * 1024;
 
     /// This is a good block size for [`FlagStorageBitVectorStriped`] for CPUs with
-    /// less L1 cache available. It's also useful when running heavily many sieves
+    /// less L1 cache available. It's also useful when running many sieves
     /// in parallel.
     pub const BLOCK_SIZE_SMALL: usize = 4 * 1024;
 

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -330,7 +330,6 @@ pub mod primes {
     }
 
     impl<const N: usize> FlagStorage for FlagStorageBitVectorStripedBlocks<N> {
-        #[inline(always)]
         fn create_true(size: usize) -> Self {
             let num_blocks = size / Self::BLOCK_SIZE_BITS + (size % Self::BLOCK_SIZE_BITS).min(1);
             Self {

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -9,6 +9,8 @@ use std::{
 };
 use structopt::StructOpt;
 
+use crate::primes::FlagStorageBitVectorStripedBlocks;
+
 pub mod primes {
     use std::{collections::HashMap, time::Duration, usize};
 
@@ -538,6 +540,10 @@ struct CommandLineOptions {
     #[structopt(long)]
     bits_striped: bool,
 
+    /// Run variant that uses bit-level storage, using striped storage in blocks
+    #[structopt(long)]
+    bits_striped_blocks: bool,
+
     /// Run variant that uses byte-level storage
     #[structopt(long)]
     bytes: bool,
@@ -558,9 +564,15 @@ fn main() {
     };
 
     // run all implementations if no options are specified (default)
-    let run_all = [opt.bits, opt.bits_rotate, opt.bits_striped, opt.bytes]
-        .iter()
-        .all(|b| !*b);
+    let run_all = [
+        opt.bits,
+        opt.bits_rotate,
+        opt.bits_striped,
+        opt.bits_striped_blocks,
+        opt.bytes,
+    ]
+    .iter()
+    .all(|b| !*b);
 
     for threads in thread_options {
         if opt.bytes || run_all {
@@ -614,6 +626,21 @@ fn main() {
             for _ in 0..repetitions {
                 run_implementation::<FlagStorageBitVectorStriped>(
                     "bit-storage-striped",
+                    1,
+                    run_duration,
+                    threads,
+                    limit,
+                    opt.print,
+                );
+            }
+        }
+
+        if opt.bits_striped_blocks || run_all {
+            thread::sleep(Duration::from_secs(1));
+            print_header(threads, limit, run_duration);
+            for _ in 0..repetitions {
+                run_implementation::<FlagStorageBitVectorStripedBlocks>(
+                    "bit-storage-striped-blocks",
                     1,
                     run_duration,
                     threads,


### PR DESCRIPTION
## Description

This PR adds a variant of `striped-bits` that addresses the locality problem with the original one. It was always pretty fast on CPUs with plenty of cache, but performed pretty poorly on smaller CPUs. This solves the locality problem by dealing with smaller blocks that fit better in cache.

Changes: 
- corrected extra iteration bug on main sieve
- added more cache-friendly `FlagStorageBitVectorStripedBlocks` version of the striped implementation
- simplified stripe/word accounting on `FlagStorageBitVectorStriped` based on learnings from the above
- added more tests to validate storage directly

@rbergen - apologies for the recent frequency of PRs for this solution. I'm hoping this is the last one for a while - this was the last big thing to address. 

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
