### PR TITLE
Allow Python solution_1 to accept sieve size as first argument.

### DIFF
--- a/PrimePython/solution_1/PrimePY.py
+++ b/PrimePython/solution_1/PrimePY.py
@@ -9,6 +9,7 @@
 # Updated 3/22/2021 for Dave's Garage episode comparing C++, C#, and Python
 
 from sys import stdout                      # So I can print without an automatic python newline
+from sys import argv
 from math import sqrt                       # Used by the sieve
 import timeit                               # For timing the durations
 
@@ -123,9 +124,10 @@ class prime_sieve(object):
 
 tStart = timeit.default_timer()                         # Record our starting time
 passes = 0                                              # We're going to count how many passes we make in fixed window of time
+target = int(argv[1]) if len(argv) > 1 else 1000000
 
 while (timeit.default_timer() - tStart < 5):           # Run until more than 10 seconds have elapsed
-    sieve = prime_sieve(1000000)                        #  Calc the primes up to a million
+    sieve = prime_sieve(target)                         #  Calc the primes up to a million
     sieve.runSieve()                                    #  Find the results
     passes = passes + 1                                 #  Count this pass
     


### PR DESCRIPTION
## Description
This is a simple change to allow `PrimePython/solution_1` to take an optional first argument for specifying the sieve size. I added this so running the script with different sizes can be compared without having to change the hard-coded value every time which gets annoyingly clunky. 

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
