### PR TITLE
C solution 3 optimize for L1 cache usage

### DIFF
--- a/PrimeC/solution_3/README.md
+++ b/PrimeC/solution_3/README.md
@@ -5,7 +5,7 @@
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
 ![Bit count](https://img.shields.io/badge/Bits-1-green)
 
-This is an implementation in C. The basic calculation is based on [solution_2/sieve_1of2.c](../solution_2/sieve_1of2.c) by Daniel Spångberg. However, this implementation has the segmented optimization built on top of that.
+This is an implementation in C. The basic calculation is based on [solution_2/sieve_1of2.c](../solution_2/sieve_1of2.c) by Daniel Spångberg. However, this implementation has the segmented and L1 cache optimization built on top of that.
 
 ## The segmented algorithm
 
@@ -36,6 +36,12 @@ The algorithm consists of the following steps:
 4. Fill the array until and including the second product found in step 2 with copies of the words from word `1` to the product found in step 2.
 5. Repeat step 3 and 4 foreach prime found in step 2 but this time start with the prime from the array. For the last prime use the number of words as the upper bound for the copy.
 6. Cross-out the remaining primes as usual, start with the largest prime from step 2 plus 2.
+
+## L1 cache optimization
+
+A CPU has level one (L1) cache. This is the fastest memory the CPU can use, but it is limited in size. On my CPU it is 32kb. This is about half the size in case of one million as a limit. To have the sieve stay as long as possible in the L1 cache, the processing of the cross out is done in blocks of just under 32 kb. This has a big improvement of about 20% on my hardware. However, with hardware that has a 64 kb L1 cache it might have a bad impact. Next step is to dynamically determine the size of the L1 cache and have that size as a parameter.
+
+This optimization was inspired by the Cython solution 1 by ssolvest.
 
 ## Choice of Dockerfile
 

--- a/PrimeC/solution_3/compile.sh
+++ b/PrimeC/solution_3/compile.sh
@@ -1,5 +1,4 @@
 #!/bin/sh
-#CC="gcc -Ofast -march=native -mtune=native -funroll-all-loops -DCOMPILE_64_BIT"
 CC="gcc -Ofast -march=native -mtune=native -funroll-all-loops" 
 for x in primes_words; do
     $CC -o $x $x.c -lm


### PR DESCRIPTION
## Description

This improvement is inspired by the Cython solution 1 by @ssovest.  Sorry for yet an other improvement on the same subject in such a short time. There is still one thing pending in this code and that is to dynamically determine the size of L1 cache, but I have no idea at this moment on how to do that.

## Contributing requirements

* [X] I read the contribution guidelines in CONTRIBUTING.md.
* [X] I placed my solution in the correct solution folder.
* [X] I added a README.md with the right badge(s).
* [X] I added a Dockerfile that builds and runs my solution.
* [X] I selected `drag-race` as the target branch.
* [X] All code herein is licensed compatible with BSD-3.
