### PR TITLE
Java solution_1 implemented a SimpleBitSet that is faster than the previous boolean[]

### DIFF
--- a/PrimeJava/solution_1/PrimeSieveJava.java
+++ b/PrimeJava/solution_1/PrimeSieveJava.java
@@ -5,24 +5,22 @@ public class PrimeSieveJava
 {
 	private static final Map<Integer, Integer> VALIDATION_DATA;
 	
-	// Java has a BitSet class included but switching to a boolean array of size improves performance by a lot
-	// This brings the limitation of the sieve only being able to test numbers up to Integer.MAX_VALUE - 2 (Requested array size exceeds VM limit)
-	private final boolean[] dataSet;
+	private final SimpleBitSet dataSet;
 	private final int sieveSize;
 	
 	public PrimeSieveJava(int sieveSize)
 	{
 		this.sieveSize = sieveSize;
 		// unlike the other old implementations the dataSet isn't initialized with true values to optimize speed
-		dataSet = new boolean[(sieveSize + 1) >> 1];
+		dataSet = new SimpleBitSet(sieveSize + 1 >> 1);
 	}
 	
 	public int countPrimes()
 	{
 		int count = 0;
-		for (int i = 0; i < dataSet.length; i++)
+		for (int i = 0; i < dataSet.count; i++)
 		{
-			if (!dataSet[i])
+			if (dataSet.get(i))
 			{
 				count++;
 			}
@@ -46,24 +44,24 @@ public class PrimeSieveJava
 	// Also rather interesting: checking index % 2 != 0 is slower than index % 2 == 1
 	private boolean getBit(int index)
 	{
-		return (index & 1) == 1 && !dataSet[index >> 1];
+		return dataSet.get(index >> 1);
 	}
 	
 	// Again instead of checking if index is even we just update the array at that index equivalent to that check
 	// to boost performance
 	private void clearBit(int index)
 	{
-		dataSet[index >> 1] = (index & 1) == 1;
+		dataSet.set(index >> 1);
 	}
 	
 	public void runSieve()
 	{
 		int factor = 3;
-		int q = (int) Math.sqrt(sieveSize);
+		int q = (int) Math.sqrt(sieveSize) + 1;
 		
 		while (factor < q)
 		{
-			for (int num = factor; num <= sieveSize; num++)
+			for (int num = factor; num <= sieveSize; num += 2)
 			{
 				if (getBit(num))
 				{
@@ -72,8 +70,9 @@ public class PrimeSieveJava
 				}
 			}
 			
-			for (int num = factor * factor; num <= sieveSize; num += factor * 2)
+			for (int num = factor * factor; num <= sieveSize; num += factor * 2) {
 				clearBit(num);
+			}
 			
 			factor += 2;
 		}
@@ -87,7 +86,7 @@ public class PrimeSieveJava
 		}
 		
 		int count = 1;
-		for (int num = 3; num <= this.sieveSize; num++)
+		for (int num = 3; num <= this.sieveSize; num += 2)
 		{
 			if (getBit(num))
 			{
@@ -145,4 +144,26 @@ public class PrimeSieveJava
 		VALIDATION_DATA.put(10000000, 664579);
 		VALIDATION_DATA.put(100000000, 5761455);
 	}
+
+	static class SimpleBitSet {
+        final int[] bits;
+        final int count;
+
+        SimpleBitSet(final int count) {
+            bits = new int[count + 31 >> 5];
+            this.count = count;
+        }
+
+        boolean get(final int index) {
+            final int i = index >> 5;
+
+            return (bits[i] & 1 << index) == 0;
+        }
+
+        public void set(final int index) {
+            final int i = index >> 5;
+
+            bits[i] |= 1 << index;
+        }
+    }
 }

--- a/PrimeJava/solution_1/README.md
+++ b/PrimeJava/solution_1/README.md
@@ -3,4 +3,4 @@
 ![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
 ![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
-![Bit count](https://img.shields.io/badge/Bits-unknown-yellowgreen)
+![Bit count](https://img.shields.io/badge/Bits-1-green)


### PR DESCRIPTION
## Description
Java solution_1
- Added SimpleBitSet which is faster than the boolean[] and uses far less data
- Update to indicate Java solution_1 is using bits
- Fixed bug where sqrt of initial number was using LT instead of LTE

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [ ] I placed my solution in the correct solution folder. (Existing solution)
* [x] I added a README.md with the right badge(s).
* [ ] I added a Dockerfile that builds and runs my solution. (Existing solution)
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
