### PR TITLE
Mark bool array sieves as using 8 bits per prime.

### DIFF
--- a/PrimeCSharp/solution_1/Sieves/PrimeSieveBool.cs
+++ b/PrimeCSharp/solution_1/Sieves/PrimeSieveBool.cs
@@ -8,6 +8,7 @@ namespace PrimeCSharp.Sieves
         public string QuickName => "bool";
         public string Name => "Bool Array";
         public bool IsBaseAlgorithm => true;
+        public int? BitsPerPrime => 8;
 
         public int SieveSize { get; }
         private readonly bool[] boolArray;

--- a/PrimeCSharp/solution_1/Sieves/PrimeSieveInvBool.cs
+++ b/PrimeCSharp/solution_1/Sieves/PrimeSieveInvBool.cs
@@ -8,6 +8,7 @@ namespace PrimeCSharp.Sieves
         public string QuickName => "ibool";
         public string Name => "Inverted Bool Array";
         public bool IsBaseAlgorithm => true;
+        public int? BitsPerPrime => 8;
 
         public int SieveSize { get; }
         private readonly bool[] boolArray;

--- a/PrimeCSharp/solution_1/Sieves/PrimeSieveInvBoolB.cs
+++ b/PrimeCSharp/solution_1/Sieves/PrimeSieveInvBoolB.cs
@@ -8,6 +8,7 @@ namespace PrimeCSharp.Sieves
         public string QuickName => "dbool";
         public string Name => "Inverted Bool Array, Direct";
         public bool IsBaseAlgorithm => true;
+        public int? BitsPerPrime => 8;
 
         public int SieveSize { get; }
         private readonly bool[] boolArray;


### PR DESCRIPTION
## Description
Mark the output for bool array sieves as using 8 bits per prime.

## Contributing requirements
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
