### PR TITLE
Some improvements in Go solution_2

### DIFF
--- a/PrimeGo/solution_2/sieve_other.go
+++ b/PrimeGo/solution_2/sieve_other.go
@@ -3,7 +3,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"math"
 	"math/bits"
 	"time"
 	"unsafe"
@@ -22,54 +21,94 @@ var primeCounts = map[uintptr]uintptr{
 	100000000: 5761455,
 }
 
+type Bitarray []uint64
+
+func NewBitarray(length uintptr) Bitarray {
+	return make(Bitarray, (length+63)/64)
+}
+
+func (b Bitarray) SetSliceTrue(start, stop, step uintptr) {
+	var index, next, end uintptr
+	var mask uint64
+	begin := unsafe.Pointer(&b[0])
+	end = (stop + 63) / 64
+
+	next = start / 64
+	mask = 0
+	index = next
+
+	for next == index {
+		mask |= bits.RotateLeft64(1, int(start))
+		start += step
+		next = start / 64
+	}
+
+	*(*uint64)(unsafe.Pointer(uintptr(begin) + index*8)) |= mask
+
+	i := 0
+	for i < 64 && next < end {
+
+		mask = 0
+		index = next
+
+		for next == index {
+			mask |= bits.RotateLeft64(1, int(start))
+			i++
+			start += step
+			next = start / 64
+		}
+
+		for ; index < end; index += step {
+			*(*uint64)(unsafe.Pointer(uintptr(begin) + index*8)) |= mask
+		}
+	}
+}
+
+func (b Bitarray) Find(val bool, start, stop uintptr) uintptr {
+	begin := unsafe.Pointer(&b[0])
+	for start < stop && val != ((*(*uint64)(unsafe.Pointer(uintptr(begin) + (start/64)*8))&bits.RotateLeft64(1, int(start))) != 0) {
+		start++
+	}
+	return start
+}
+
+func (b Bitarray) Count(val bool, start, stop uintptr) uintptr {
+	begin := unsafe.Pointer(&b[0])
+	var count uintptr
+	for ; start < stop; start++ {
+		if val == ((*(*uint64)(unsafe.Pointer(uintptr(begin) + (start/64)*8)) & bits.RotateLeft64(1, int(start))) != 0) {
+			count++
+		}
+	}
+	return count
+}
+
 type Sieve struct {
-	bits []uint32
+	bits Bitarray
 	size uintptr
 }
 
 func (s Sieve) RunSieve() {
+	var factor, start, stop, step uintptr
+	stop = (s.size + 1) / 2
 
-	var factor, start, step, index, next uintptr
-	var mask uint32
-	end := ((s.size + 1) / 2 + 31) / 32
-	q := uintptr(math.Sqrt(float64(s.size)) / 2)
-	begin := unsafe.Pointer(&s.bits[0])
-
-	for factor = 1; factor <= q; factor++ {
-		if (*(*uint32)(unsafe.Pointer(uintptr(begin) + (factor/32)*4)) & bits.RotateLeft32(1, int(factor))) != 0 {
-			continue
-		}
+	for {
+		factor = s.bits.Find(false, factor+1, stop)
 
 		start = 2 * factor * (factor + 1)
-		step  = factor * 2 + 1
+		step = factor*2 + 1
 
-		next = start / 32
-		i := 0
-		for i < 32 && next < end {
-			mask = 0
-			index = next
-
-			for next == index {
-				mask |= bits.RotateLeft32(1, int(start))
-				i++
-				start += step
-				next = start / 32
-			}
-
-			for ; index < end; index += step {
-				*(*uint32)(unsafe.Pointer(uintptr(begin) + index*4)) |= mask
-			}
+		// start is factor squared, so it's the same as factor <= q
+		if start >= stop {
+			break
 		}
+
+		s.bits.SetSliceTrue(start, stop, step)
 	}
 }
 
 func (s Sieve) CountPrimes() uintptr {
-	t := uintptr(0)
-	end := (s.size + 1) / 2
-	for i := uintptr(0); i < end; i++ {
-		t += uintptr(bits.RotateLeft32(^s.bits[i/32], -int(i)) & 1)
-	}
-	return t
+	return s.bits.Count(false, 0, (s.size+1)/2)
 }
 
 func (s Sieve) ValidateResults() bool {
@@ -78,6 +117,7 @@ func (s Sieve) ValidateResults() bool {
 }
 
 func main() {
+
 	var limit uintptr
 	var l64 uint64
 	var duration time.Duration
@@ -101,18 +141,20 @@ loop:
 		case <-stop:
 			break loop
 		default:
-			sieve = Sieve{make([]uint32, (limit+63)/64), limit}
+			sieve = Sieve{NewBitarray((limit + 1) / 2), limit}
 			sieve.RunSieve()
 			passes++
 		}
 	}
 
 	timeDelta := time.Since(start).Seconds()
+
 	if verbose {
-		avg := float64(timeDelta)/float64(passes)
+		avg := float64(timeDelta) / float64(passes)
 		count := sieve.CountPrimes()
 		valid := sieve.ValidateResults()
 		fmt.Printf("Passes: %v, Time: %v, Avg: %v, Limit: %v, Count: %v, Valid: %v\n\n", passes, timeDelta, avg, limit, count, valid)
 	}
+
 	fmt.Printf("%v;%v;%v;1;algorithm=other,faithful=yes,bits=1\n", label, passes, timeDelta)
 }


### PR DESCRIPTION
## Description
For some reason, moving the bit reset logic from the sieve loop to a method of a custom type gave a huge speed boost in sieve_other.go.
But now the sieve loop looks almost identically to that of Python [solution_2](https://github.com/PlummersSoftwareLLC/Primes/blob/drag-race/PrimePython/solution_2/PrimePY.py#L40) and some other solutions implementing the base algorithm. And the Bitarray type doesn't know anything about primes, it just sets every n-th bit in a given range. But the logic in the Bitarray was ported from the [PrimeCY_32](https://github.com/PlummersSoftwareLLC/Primes/blob/drag-race/PrimeCython/solution_1/PrimeCY_32.pyx#L63) implementation which is marked as implementing "other" algorithm. So now i'm not sure how to classify this implementation. Should i mark it as "base" (and remove other implementations in the solution folder, as they are far less performant) or leave it "other"?

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [ ] I added a README.md with the right badge(s).
* [ ] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
