### PR TITLE
Performance improvements to PrimeAssembly/solution_1/primes_ff_bitshift.asm

### DIFF
--- a/PrimeAssembly/solution_1/primes_ff_bitshift.asm
+++ b/PrimeAssembly/solution_1/primes_ff_bitshift.asm
@@ -352,7 +352,7 @@ countLoop:
 
 nextItem:
     add         ecx, 2                      ; bitIndex += 2
-    cmp         ecx, SIEVE_SIZE             ; if bitIndex < SIEVE_SIZE
+    cmp         ecx, [rdi+sieve.sieveSize]  ; if bitIndex < sieveSize
     jb          countLoop                   ; ...continue counting
 
     ret                                     ; end of countPrimes


### PR DESCRIPTION
I've moved my performance optimizations from PR #537 into the existing solution as discussed in the now closed original PR.  I'm seeing about the same performance here as in my separate solution.

Without optimizations:  rbergen_x64ff_bitshift;4582;5.000;1;algorithm=base,faithful=yes,bits=1

With optimizations:  rbergen_x64ff_bitshift;5767;5.000;1;algorithm=base,faithful=yes,bits=1

The two optimizations implemented are:

- Use the 128bit SIMD movdqa in initLoop (small perf boost, but measurable)
- Use a rolling mask, similar to C++ solution 1 (large perf boost)