### PR TITLE
Cython compile flags

### DIFF
--- a/PrimeCython/solution_1/buildall.sh
+++ b/PrimeCython/solution_1/buildall.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-CFLAGS="-march=native -mtune=native `python3-config --embed --includes`"
+CFLAGS="-march=native `python3-config --embed --includes`"
 LDFLAGS=`python3-config --embed --ldflags`
 CC=gcc
 

--- a/PrimeCython/solution_1/buildall.sh
+++ b/PrimeCython/solution_1/buildall.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-CFLAGS=`python3-config --embed --includes`
+CFLAGS="-march=native -mtune=native `python3-config --embed --includes`"
 LDFLAGS=`python3-config --embed --ldflags`
 CC=gcc
 

--- a/PrimeCython/solution_1/buildall.sh
+++ b/PrimeCython/solution_1/buildall.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-CFLAGS="-march=native `python3-config --embed --includes`"
+CFLAGS=`python3-config --embed --includes`
 LDFLAGS=`python3-config --embed --ldflags`
 CC=gcc
 
@@ -10,4 +10,4 @@ cython -3 --embed PrimeCY_32.pyx -o PrimeCY_32.c -X cdivision=True -X boundschec
 
 $CC -O3 $CFLAGS $LDFLAGS PrimeCY_bytearray.c -o PrimeCY_bytearray
 $CC -O3 $CFLAGS $LDFLAGS PrimeCY_bitarray.c -o PrimeCY_bitarray
-$CC -O3 -fopenmp $CFLAGS $LDFLAGS PrimeCY_32.c -o PrimeCY_32
+$CC -O3 -march=native -fopenmp $CFLAGS $LDFLAGS PrimeCY_32.c -o PrimeCY_32


### PR DESCRIPTION
## Description
Added -march=native and -mtune=native flags for Cython solution_1, it seems a little faster after that

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [ ] I added a README.md with the right badge(s).
* [ ] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
