### PR TITLE
Go/solution_2 loop unrolling

### DIFF
--- a/PrimeGo/solution_2/sieve32.go
+++ b/PrimeGo/solution_2/sieve32.go
@@ -3,14 +3,13 @@ package main
 import (
 	"flag"
 	"fmt"
-	"math"
 	"math/bits"
 	"time"
 )
 
 var label string = "ssovest-go-uint32"
 
-var primeCounts = map[uintptr]uintptr{
+var primeCounts = map[uint64]uint64{
 	10:        4,
 	100:       25,
 	1000:      168,
@@ -21,37 +20,85 @@ var primeCounts = map[uintptr]uintptr{
 	100000000: 5761455,
 }
 
+type Bitarray []uint32
+
+func (b Bitarray) SetSliceTrue(start, stop, step uint64) {
+	var index, end uint64
+	var mask uint32
+	end = (stop + 31) / 32
+
+	step2 := step * 2
+	step3 := step * 3
+	step4 := step * 4
+	step5 := step * 5
+	step6 := step * 6
+	step7 := step * 7
+	step8 := step * 8
+
+	for i := 0; i < 32; i++ {
+		mask = bits.RotateLeft32(1, int(start))
+		index = start / 32
+		start += step
+
+		for ; index+step8 < end; index += step8 {
+			b[index] |= mask
+			b[index+step] |= mask
+			b[index+step2] |= mask
+			b[index+step3] |= mask
+			b[index+step4] |= mask
+			b[index+step5] |= mask
+			b[index+step6] |= mask
+			b[index+step7] |= mask
+		}
+
+		for ; index < end; index += step {
+			b[index] |= mask
+		}
+	}
+}
+
+func (b Bitarray) Find(val bool, start, stop uint64) uint64 {
+	for start < stop && val != (b[start/32]&bits.RotateLeft32(1, int(start)) != 0) {
+		start++
+	}
+	return start
+}
+
+func (b Bitarray) Count(val bool, start, stop uint64) uint64 {
+	var count uint64
+	for ; start < stop; start++ {
+		if val == (b[start/32]&bits.RotateLeft32(1, int(start)) != 0) {
+			count++
+		}
+	}
+	return count
+}
+
 type Sieve struct {
-	bits []uint32
-	size uintptr
+	bits Bitarray
+	size uint64
 }
 
 func (s Sieve) RunSieve() {
-	var factor, start, step uintptr
-	end := (s.size + 1) / 2
-	q := uintptr(math.Sqrt(float64(s.size)) / 2)
+	var factor, start, stop, step uint64
+	stop = (s.size + 1) / 2
+	for {
+		factor = s.bits.Find(false, factor+1, stop)
 
-	for factor = 1; factor <= q; factor++ {
-		if (s.bits[factor/32] & bits.RotateLeft32(1, int(factor))) != 0 {
-			continue
-		}
-
-		start = 2 * (factor*factor + factor)
+		start = 2 * factor * (factor + 1)
 		step = factor*2 + 1
 
-		for ; start < end; start += step {
-			s.bits[start/32] |= bits.RotateLeft32(1, int(start))
+		// start is factor squared, so it's the same as factor <= q
+		if start >= stop {
+			break
 		}
+
+		s.bits.SetSliceTrue(start, stop, step)
 	}
 }
 
-func (s Sieve) CountPrimes() uintptr {
-	t := uintptr(0)
-	end := (s.size + 1) / 2
-	for i := uintptr(0); i < end; i++ {
-		t += uintptr(bits.RotateLeft32(^s.bits[i/32], -int(i)) & 1)
-	}
-	return t
+func (s Sieve) CountPrimes() uint64 {
+	return s.bits.Count(false, 0, (s.size+1)/2)
 }
 
 func (s Sieve) ValidateResults() bool {
@@ -60,18 +107,16 @@ func (s Sieve) ValidateResults() bool {
 }
 
 func main() {
-	var limit uintptr
-	var l64 uint64
+	var limit uint64
 	var duration time.Duration
 	var verbose bool
 	var sieve Sieve
 
-	flag.Uint64Var(&l64, "limit", 1000000, "limit")
+	flag.Uint64Var(&limit, "limit", 1000000, "limit")
 	flag.DurationVar(&duration, "time", 5*time.Second, "duration")
 	flag.BoolVar(&verbose, "v", false, "verbose output")
 	flag.Parse()
 
-	limit = uintptr(l64)
 	stop := make(chan struct{})
 	passes := 0
 	start := time.Now()
@@ -83,7 +128,7 @@ loop:
 		case <-stop:
 			break loop
 		default:
-			sieve = Sieve{make([]uint32, (limit+63)/64), limit}
+			sieve = Sieve{make(Bitarray, (limit+63)/64), limit}
 			sieve.RunSieve()
 			passes++
 		}
@@ -91,7 +136,7 @@ loop:
 
 	timeDelta := time.Since(start).Seconds()
 	if verbose {
-		avg := float64(timeDelta)/float64(passes)
+		avg := float64(timeDelta) / float64(passes)
 		count := sieve.CountPrimes()
 		valid := sieve.ValidateResults()
 		fmt.Printf("Passes: %v, Time: %v, Avg: %v, Limit: %v, Count: %v, Valid: %v\n\n", passes, timeDelta, avg, limit, count, valid)

--- a/PrimeGo/solution_2/sieve_other.go
+++ b/PrimeGo/solution_2/sieve_other.go
@@ -9,7 +9,7 @@ import (
 
 var label string = "ssovest-go-other"
 
-var primeCounts = map[uintptr]uintptr{
+var primeCounts = map[uint64]uint64{
 	10:        4,
 	100:       25,
 	1000:      168,
@@ -22,12 +22,12 @@ var primeCounts = map[uintptr]uintptr{
 
 type Bitarray []uint64
 
-func NewBitarray(length uintptr) Bitarray {
+func NewBitarray(length uint64) Bitarray {
 	return make(Bitarray, (length+63)/64)
 }
 
-func (b Bitarray) SetSliceTrue(start, stop, step uintptr) {
-	var index, next, end uintptr
+func (b Bitarray) SetSliceTrue(start, stop, step uint64) {
+	var index, next, end uint64
 	var mask uint64
 	end = (stop + 63) / 64
 
@@ -79,15 +79,15 @@ func (b Bitarray) SetSliceTrue(start, stop, step uintptr) {
 	}
 }
 
-func (b Bitarray) Find(val bool, start, stop uintptr) uintptr {
+func (b Bitarray) Find(val bool, start, stop uint64) uint64 {
 	for start < stop && val != (b[start/64]&bits.RotateLeft64(1, int(start)) != 0) {
 		start++
 	}
 	return start
 }
 
-func (b Bitarray) Count(val bool, start, stop uintptr) uintptr {
-	var count uintptr
+func (b Bitarray) Count(val bool, start, stop uint64) uint64 {
+	var count uint64
 	for ; start < stop; start++ {
 		if val == (b[start/64]&bits.RotateLeft64(1, int(start)) != 0) {
 			count++
@@ -98,11 +98,11 @@ func (b Bitarray) Count(val bool, start, stop uintptr) uintptr {
 
 type Sieve struct {
 	bits Bitarray
-	size uintptr
+	size uint64
 }
 
 func (s Sieve) RunSieve() {
-	var factor, start, stop, step uintptr
+	var factor, start, stop, step uint64
 	stop = (s.size + 1) / 2
 	for {
 		factor = s.bits.Find(false, factor+1, stop)
@@ -116,7 +116,7 @@ func (s Sieve) RunSieve() {
 	}
 }
 
-func (s Sieve) CountPrimes() uintptr {
+func (s Sieve) CountPrimes() uint64 {
 	return s.bits.Count(false, 0, (s.size+1)/2)
 }
 
@@ -126,19 +126,17 @@ func (s Sieve) ValidateResults() bool {
 }
 
 func main() {
-	var limit uintptr
-	var l64 uint64
+	var limit uint64
 	var duration time.Duration
 	var verbose bool
 	var sieve Sieve
 
-	flag.Uint64Var(&l64, "limit", 1000000, "limit")
+	flag.Uint64Var(&limit, "limit", 1000000, "limit")
 	flag.DurationVar(&duration, "time", 5*time.Second, "duration")
 	flag.BoolVar(&verbose, "v", false, "verbose output")
 
 	flag.Parse()
 
-	limit = uintptr(l64)
 	stop := make(chan struct{})
 	passes := 0
 	start := time.Now()


### PR DESCRIPTION
## Description
Modified sieve_other.go:
 - Added loop unrolling
 - Now it's using slice indexing instead of pointer arithmetic. When compiled with "-B" flag, it has about the same performace, but is more readable.

Modified sieve32.go:

 - Moved bit clearing logic to Bitarray type, like in sieve_other.go
 - The bit clearing loop now utilizes some optimizations from sieve_other.go. It still does one write operation per cleared bit.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [ ] I added a README.md with the right badge(s).
* [ ] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
