### PR TITLE
Docker: disable compsec (distorts benchmarks)

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -267,7 +267,7 @@ For the installation of Docker follow the instructions as described in <https://
 Below is an example of the benchmark output.
 
 ```bash
-                                                                   Single-threaded                                                                    
+                                                                   Single-threaded
 ┌───────┬────────────────┬──────────┬───────────────────────────────────┬────────┬───────────┬─────────┬───────────┬──────────┬──────┬───────────────┐
 │ Index │ Implementation │ Solution │ Label                             │ Passes │ Duration  │ Threads │ Algorithm │ Faithful │ Bits │ Passes/Second │
 ├───────┼────────────────┼──────────┼───────────────────────────────────┼────────┼───────────┼─────────┼───────────┼──────────┼──────┼───────────────┤
@@ -282,7 +282,7 @@ etc
 │  74   │ powershell     │ 1        │ crowbar27_ps1                     │   1    │ 150.03900 │    1    │   base    │   yes    │ 1    │    0.00666    │
 └───────┴────────────────┴──────────┴───────────────────────────────────┴────────┴───────────┴─────────┴───────────┴──────────┴──────┴───────────────┘
 
-                                                                   Multi-threaded                                                                    
+                                                                   Multi-threaded
 ┌───────┬────────────────┬──────────┬───────────────────────────────────┬────────┬──────────┬─────────┬───────────┬──────────┬──────┬───────────────┐
 │ Index │ Implementation │ Solution │ Label                             │ Passes │ Duration │ Threads │ Algorithm │ Faithful │ Bits │ Passes/Second │
 ├───────┼────────────────┼──────────┼───────────────────────────────────┼────────┼──────────┼─────────┼───────────┼──────────┼──────┼───────────────┤
@@ -319,7 +319,7 @@ added 229 packages in 11.074s
 info: Detected architecture: amd64
 info: [PrimeCrystal][solution_1] Building...
 info: [PrimeCrystal][solution_1] Running...
-                                                       Single-threaded                                                        
+                                                       Single-threaded
 ┌───────┬────────────────┬──────────┬────────────┬────────┬──────────┬─────────┬───────────┬──────────┬──────┬───────────────┐
 │ Index │ Implementation │ Solution │ Label      │ Passes │ Duration │ Threads │ Algorithm │ Faithful │ Bits │ Passes/Second │
 ├───────┼────────────────┼──────────┼────────────┼────────┼──────────┼─────────┼───────────┼──────────┼──────┼───────────────┤
@@ -339,15 +339,15 @@ make DIRECTORY=PrimeCPP
 
 For some interpreted languages (Python, Ruby, NodeJS), docker has a non-zero affect slowing on CPU-intensive code.
 See https://github.com/moby/moby/issues/41389 for the related docker issue. You can disable some of the sandboxing
-to obtain near-native performance (at least on Linux) with the `UNCONFINED=true` option:
+to obtain near-native performance (at least on Linux) with the `UNCONFINED=1` option:
 ```bash
-make UNCONFINED=true
-make DIRECTORY=PrimeMyFavoriteInterpretedLanguage UNCONFINED=true
+make UNCONFINED=1
+make DIRECTORY=PrimeMyFavoriteInterpretedLanguage UNCONFINED=1
 ```
 
 ## Output formats
 
-The benchmark suite supports multiple output formats; if no formatter is specified, it will default to the `table` format. 
+The benchmark suite supports multiple output formats; if no formatter is specified, it will default to the `table` format.
 Here are the supported values:
 
 * table

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -335,6 +335,16 @@ Make the `DIRECTORY` variable point to the directory that contains the solutions
 make DIRECTORY=PrimeCPP
 ```
 
+## Running in unconfined mode
+
+For some interpreted languages (Python, Ruby, NodeJS), docker has a non-zero affect slowing on CPU-intensive code.
+See https://github.com/moby/moby/issues/41389 for the related docker issue. You can disable some of the sandboxing
+to obtain near-native performance (at least on Linux) with the `UNCONFINED=true` option:
+```bash
+make UNCONFINED=true
+make DIRECTORY=PrimeMyFavoriteInterpretedLanguage UNCONFINED
+```
+
 ## Output formats
 
 The benchmark suite supports multiple output formats; if no formatter is specified, it will default to the `table` format. 

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -267,7 +267,7 @@ For the installation of Docker follow the instructions as described in <https://
 Below is an example of the benchmark output.
 
 ```bash
-                                                                   Single-threaded
+                                                                   Single-threaded                                                                    
 ┌───────┬────────────────┬──────────┬───────────────────────────────────┬────────┬───────────┬─────────┬───────────┬──────────┬──────┬───────────────┐
 │ Index │ Implementation │ Solution │ Label                             │ Passes │ Duration  │ Threads │ Algorithm │ Faithful │ Bits │ Passes/Second │
 ├───────┼────────────────┼──────────┼───────────────────────────────────┼────────┼───────────┼─────────┼───────────┼──────────┼──────┼───────────────┤
@@ -282,7 +282,7 @@ etc
 │  74   │ powershell     │ 1        │ crowbar27_ps1                     │   1    │ 150.03900 │    1    │   base    │   yes    │ 1    │    0.00666    │
 └───────┴────────────────┴──────────┴───────────────────────────────────┴────────┴───────────┴─────────┴───────────┴──────────┴──────┴───────────────┘
 
-                                                                   Multi-threaded
+                                                                   Multi-threaded                                                                    
 ┌───────┬────────────────┬──────────┬───────────────────────────────────┬────────┬──────────┬─────────┬───────────┬──────────┬──────┬───────────────┐
 │ Index │ Implementation │ Solution │ Label                             │ Passes │ Duration │ Threads │ Algorithm │ Faithful │ Bits │ Passes/Second │
 ├───────┼────────────────┼──────────┼───────────────────────────────────┼────────┼──────────┼─────────┼───────────┼──────────┼──────┼───────────────┤
@@ -319,7 +319,7 @@ added 229 packages in 11.074s
 info: Detected architecture: amd64
 info: [PrimeCrystal][solution_1] Building...
 info: [PrimeCrystal][solution_1] Running...
-                                                       Single-threaded
+                                                       Single-threaded                                                        
 ┌───────┬────────────────┬──────────┬────────────┬────────┬──────────┬─────────┬───────────┬──────────┬──────┬───────────────┐
 │ Index │ Implementation │ Solution │ Label      │ Passes │ Duration │ Threads │ Algorithm │ Faithful │ Bits │ Passes/Second │
 ├───────┼────────────────┼──────────┼────────────┼────────┼──────────┼─────────┼───────────┼──────────┼──────┼───────────────┤
@@ -335,20 +335,19 @@ Make the `DIRECTORY` variable point to the directory that contains the solutions
 make DIRECTORY=PrimeCPP
 ```
 
-## Running with seccomp sandboxing
+## Running in unconfined mode
 
-For some interpreted languages (Python, Ruby, NodeJS), docker has a non-zero affect slowing on CPU-intensive code
-due to some of its security sandboxing. See https://github.com/moby/moby/issues/41389 for the related docker issue.
-By default, we disable this (because the benchmark code is reviewed, we trust it, and we want near-native speeds).
-To re-enable seccomp when running benchmarks use the `UNCONFINED=false` option:
+For some interpreted languages (Python, Ruby, NodeJS), docker has a non-zero affect slowing on CPU-intensive code.
+See https://github.com/moby/moby/issues/41389 for the related docker issue. You can disable some of the sandboxing
+to obtain near-native performance (at least on Linux) with the `UNCONFINED=true` option:
 ```bash
-make UNCONFINED=false
-make DIRECTORY=PrimeMyFavoriteLanguage UNCONFINED=false
+make UNCONFINED=true
+make DIRECTORY=PrimeMyFavoriteInterpretedLanguage UNCONFINED=true
 ```
 
 ## Output formats
 
-The benchmark suite supports multiple output formats; if no formatter is specified, it will default to the `table` format.
+The benchmark suite supports multiple output formats; if no formatter is specified, it will default to the `table` format. 
 Here are the supported values:
 
 * table

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -337,7 +337,7 @@ make DIRECTORY=PrimeCPP
 
 ## Running in unconfined mode
 
-For some interpreted languages (Python, Ruby, NodeJS), docker has a non-zero affect slowing on CPU-intensive code.
+For some interpreted languages (Python, Ruby, NodeJS), docker has a non-zero effect slowing CPU-intensive code.
 See https://github.com/moby/moby/issues/41389 for the related docker issue. You can disable some of the sandboxing
 to obtain near-native performance (at least on Linux) with the `UNCONFINED=1` option:
 ```bash

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -342,7 +342,7 @@ See https://github.com/moby/moby/issues/41389 for the related docker issue. You 
 to obtain near-native performance (at least on Linux) with the `UNCONFINED=true` option:
 ```bash
 make UNCONFINED=true
-make DIRECTORY=PrimeMyFavoriteInterpretedLanguage UNCONFINED
+make DIRECTORY=PrimeMyFavoriteInterpretedLanguage UNCONFINED=true
 ```
 
 ## Output formats

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -267,7 +267,7 @@ For the installation of Docker follow the instructions as described in <https://
 Below is an example of the benchmark output.
 
 ```bash
-                                                                   Single-threaded                                                                    
+                                                                   Single-threaded
 ┌───────┬────────────────┬──────────┬───────────────────────────────────┬────────┬───────────┬─────────┬───────────┬──────────┬──────┬───────────────┐
 │ Index │ Implementation │ Solution │ Label                             │ Passes │ Duration  │ Threads │ Algorithm │ Faithful │ Bits │ Passes/Second │
 ├───────┼────────────────┼──────────┼───────────────────────────────────┼────────┼───────────┼─────────┼───────────┼──────────┼──────┼───────────────┤
@@ -282,7 +282,7 @@ etc
 │  74   │ powershell     │ 1        │ crowbar27_ps1                     │   1    │ 150.03900 │    1    │   base    │   yes    │ 1    │    0.00666    │
 └───────┴────────────────┴──────────┴───────────────────────────────────┴────────┴───────────┴─────────┴───────────┴──────────┴──────┴───────────────┘
 
-                                                                   Multi-threaded                                                                    
+                                                                   Multi-threaded
 ┌───────┬────────────────┬──────────┬───────────────────────────────────┬────────┬──────────┬─────────┬───────────┬──────────┬──────┬───────────────┐
 │ Index │ Implementation │ Solution │ Label                             │ Passes │ Duration │ Threads │ Algorithm │ Faithful │ Bits │ Passes/Second │
 ├───────┼────────────────┼──────────┼───────────────────────────────────┼────────┼──────────┼─────────┼───────────┼──────────┼──────┼───────────────┤
@@ -319,7 +319,7 @@ added 229 packages in 11.074s
 info: Detected architecture: amd64
 info: [PrimeCrystal][solution_1] Building...
 info: [PrimeCrystal][solution_1] Running...
-                                                       Single-threaded                                                        
+                                                       Single-threaded
 ┌───────┬────────────────┬──────────┬────────────┬────────┬──────────┬─────────┬───────────┬──────────┬──────┬───────────────┐
 │ Index │ Implementation │ Solution │ Label      │ Passes │ Duration │ Threads │ Algorithm │ Faithful │ Bits │ Passes/Second │
 ├───────┼────────────────┼──────────┼────────────┼────────┼──────────┼─────────┼───────────┼──────────┼──────┼───────────────┤
@@ -335,19 +335,20 @@ Make the `DIRECTORY` variable point to the directory that contains the solutions
 make DIRECTORY=PrimeCPP
 ```
 
-## Running in unconfined mode
+## Running with seccomp sandboxing
 
-For some interpreted languages (Python, Ruby, NodeJS), docker has a non-zero affect slowing on CPU-intensive code.
-See https://github.com/moby/moby/issues/41389 for the related docker issue. You can disable some of the sandboxing
-to obtain near-native performance (at least on Linux) with the `UNCONFINED=true` option:
+For some interpreted languages (Python, Ruby, NodeJS), docker has a non-zero affect slowing on CPU-intensive code
+due to some of its security sandboxing. See https://github.com/moby/moby/issues/41389 for the related docker issue.
+By default, we disable this (because the benchmark code is reviewed, we trust it, and we want near-native speeds).
+To re-enable seccomp when running benchmarks use the `UNCONFINED=false` option:
 ```bash
-make UNCONFINED=true
-make DIRECTORY=PrimeMyFavoriteInterpretedLanguage UNCONFINED=true
+make UNCONFINED=false
+make DIRECTORY=PrimeMyFavoriteLanguage UNCONFINED=false
 ```
 
 ## Output formats
 
-The benchmark suite supports multiple output formats; if no formatter is specified, it will default to the `table` format. 
+The benchmark suite supports multiple output formats; if no formatter is specified, it will default to the `table` format.
 Here are the supported values:
 
 * table

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SHELL := /bin/bash
 
 DIRECTORY := $(shell pwd)
 FORMATTER := "table"
+UNCONFINED := "false"
 
 .PHONY: all
 all: benchmark
@@ -11,7 +12,7 @@ all: benchmark
 .PHONY: benchmark
 benchmark: check-env
 	@REALPATH=$$(cd "$${DIRECTORY}" && pwd); \
-	ARGS=("-d $${REALPATH}" "-f $(FORMATTER)"); \
+	ARGS=("-d $${REALPATH}" "-f $(FORMATTER)" "-u $(UNCONFINED)"); \
 	[ ! -z $${OUTPUT_FILE} ] && ARGS+=( "-o $${OUTPUT_FILE}" ); \
 	cd ./tools; npm ci --silent && npm start --silent -- benchmark $${ARGS[@]}
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 
 DIRECTORY := $(shell pwd)
 FORMATTER := "table"
-UNCONFINED := "true"
+UNCONFINED := "false"
 
 .PHONY: all
 all: benchmark

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL := /bin/bash
 
 DIRECTORY := $(shell pwd)
 FORMATTER := "table"
-UNCONFINED := "false"
+UNCONFINED := "true"
 
 .PHONY: all
 all: benchmark

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ SHELL := /bin/bash
 
 DIRECTORY := $(shell pwd)
 FORMATTER := "table"
-UNCONFINED := "false"
 
 .PHONY: all
 all: benchmark

--- a/Makefile
+++ b/Makefile
@@ -12,8 +12,9 @@ all: benchmark
 .PHONY: benchmark
 benchmark: check-env
 	@REALPATH=$$(cd "$${DIRECTORY}" && pwd); \
-	ARGS=("-d $${REALPATH}" "-f $(FORMATTER)" "-u $(UNCONFINED)"); \
+	ARGS=("-d $${REALPATH}" "-f $(FORMATTER)"); \
 	[ ! -z $${OUTPUT_FILE} ] && ARGS+=( "-o $${OUTPUT_FILE}" ); \
+	[ ! -z $${UNCONFINED} ] && ARGS+=( "--unconfined" ); \
 	cd ./tools; npm ci --silent && npm start --silent -- benchmark $${ARGS[@]}
 
 .PHONY: check-env

--- a/tools/src/commands/benchmark.ts
+++ b/tools/src/commands/benchmark.ts
@@ -49,6 +49,12 @@ export const command = new Command('benchmark')
       return;
     }
 
+    // Collect runtime options for docker images
+    let options: Array<string> = [];
+    if (unconfined) {
+      options.push('--security-opt seccomp=unconfined')
+    }
+
     // Determine architecture
     const architecture = ARCHITECTURES[uname().machine] || 'amd64';
     logger.info(`Detected architecture: ${architecture}`);
@@ -93,7 +99,7 @@ export const command = new Command('benchmark')
       let output = '';
       try {
         logger.info(`[${implementation}][${solution}] Running...`);
-        output = dockerService.runContainer(imageName, unconfined);
+        output = dockerService.runContainer(imageName, options);
       } catch (err) {
         logger.warn(
           `[${implementation}][${solution}] Exited with abnormal code: ${err.status}. Results might be partial...`

--- a/tools/src/commands/benchmark.ts
+++ b/tools/src/commands/benchmark.ts
@@ -29,8 +29,12 @@ export const command = new Command('benchmark')
   .requiredOption('-d, --directory <directory>', 'Implementation directory')
   .option('-f, --formatter <type>', 'Output formatter', 'table')
   .option('-o, --output-file <file>', 'Write output to given file')
+  .option('-u, --unconfined <bool>', 'Run with seccomp:unconfined (native performance for interpreted languages)')
   .action(async (args) => {
     const directory = path.resolve(args.directory as string);
+    const unconfined = args.unconfined === 'true';
+
+    logger.info(`Unconfined mode: ${unconfined}`);
 
     // Making sure the outputs directory exists
     if (!fs.existsSync(directory)) {
@@ -89,7 +93,7 @@ export const command = new Command('benchmark')
       let output = '';
       try {
         logger.info(`[${implementation}][${solution}] Running...`);
-        output = dockerService.runContainer(imageName);
+        output = dockerService.runContainer(imageName, unconfined);
       } catch (err) {
         logger.warn(
           `[${implementation}][${solution}] Exited with abnormal code: ${err.status}. Results might be partial...`

--- a/tools/src/commands/benchmark.ts
+++ b/tools/src/commands/benchmark.ts
@@ -29,10 +29,10 @@ export const command = new Command('benchmark')
   .requiredOption('-d, --directory <directory>', 'Implementation directory')
   .option('-f, --formatter <type>', 'Output formatter', 'table')
   .option('-o, --output-file <file>', 'Write output to given file')
-  .option('-u, --unconfined <bool>', 'Run with seccomp:unconfined (native performance for interpreted languages)')
+  .option('-u, --unconfined', 'Run with seccomp:unconfined (native performance for interpreted languages)')
   .action(async (args) => {
     const directory = path.resolve(args.directory as string);
-    const unconfined = args.unconfined === 'true';
+    const unconfined = args.unconfined === true;
 
     logger.info(`Unconfined mode: ${unconfined}`);
 

--- a/tools/src/services/docker.ts
+++ b/tools/src/services/docker.ts
@@ -8,7 +8,7 @@ export default class DockerService {
   }
 
   public runContainer(imageName: string): string {
-    const output = child_process.execSync(`docker run --rm ${imageName}`, {
+    const output = child_process.execSync(`docker run --security-opt seccomp=unconfined --rm ${imageName}`, {
       stdio: 'pipe'
     });
     return output.toString('utf8');

--- a/tools/src/services/docker.ts
+++ b/tools/src/services/docker.ts
@@ -7,8 +7,13 @@ export default class DockerService {
     });
   }
 
-  public runContainer(imageName: string): string {
-    const output = child_process.execSync(`docker run --security-opt seccomp=unconfined --rm ${imageName}`, {
+  public runContainer(imageName: string, unconfined: boolean): string {
+    let options = '--rm';
+    if (unconfined) {
+      options += ' --security-opt seccomp=unconfined'
+    }
+
+    const output = child_process.execSync(`docker run ${options} ${imageName}`, {
       stdio: 'pipe'
     });
     return output.toString('utf8');

--- a/tools/src/services/docker.ts
+++ b/tools/src/services/docker.ts
@@ -7,13 +7,8 @@ export default class DockerService {
     });
   }
 
-  public runContainer(imageName: string, unconfined: boolean): string {
-    let options = '--rm';
-    if (unconfined) {
-      options += ' --security-opt seccomp=unconfined'
-    }
-
-    const output = child_process.execSync(`docker run ${options} ${imageName}`, {
+  public runContainer(imageName: string, options: Array<string>): string {
+    const output = child_process.execSync(`docker run --rm ${options.join(' ')} ${imageName}`, {
       stdio: 'pipe'
     });
     return output.toString('utf8');


### PR DESCRIPTION
## Description

Disables seccomp when running docker.

For unknown reasons, running python under docker can be over 50% slower than native usage. This is a performance bug in docker, which has something to do with its use of seccomp. See https://pythonspeed.com/articles/docker-performance-overhead/
and the corresponding docker issue https://github.com/moby/moby/issues/41389

Practically, the performance difference is clear - locally when running `make DIRECTORY=PrimePython`, on a linux system the performance of `ssovtest`'s solution goes from **1998** passes to **4110**. It seems seccomp doesn't affect the usage of compiled languages (in particular the non-faithful numpy solution seems unaffected), but you *may* see a speed boost for some other interpreted languages with this fix.

### Other considerations

Should we disable seccomp if it's providing security? Well, if all code in this repo has been reviewed and verified, it should be absolutely fine (note all the containers are running as root user anyway, so we better hope this is the case).

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [ ] I added a README.md with the right badge(s).
* [ ] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.

~                                                              