### PR TITLE
TeX solution 2: clean up loose comment and syntax

### DIFF
--- a/PrimeTeX/solution_2/wheel_sieve.tex
+++ b/PrimeTeX/solution_2/wheel_sieve.tex
@@ -3,7 +3,7 @@
 % date:   2021/07/27
 %
 % This file defines syntax for a  "Sieve object" in TeX lingua with its
-% associated methods: sieve, reset, settocount, outtofile.
+% associated methods: sieve, reset (not implemented), settocount, outtofile.
 %
 % Usage:
 %
@@ -314,10 +314,11 @@
     % will happen until we have exhausted all potential factors up to B = isqrt(range)
     % 
     \cntb\cstB
-        % make sure we never get 0 modulo 2310 as our cogids array
-        % indices start at 1
+        % make sure we never get an even number modulo 2310 as our cogids array indices
+        % start at 1 and the array entries are meaningful only for odd indices
         \ifodd\cntb\else\advance\cntb-\@ne\fi
     \cntc\cntb
+    % For the sieve range set to 1000000, this division gives zero as 1000<2310
     \divide\cntc\wheelmodulus
     \cntd\cntc
     \multiply\cntd\wheelcogcount
@@ -373,8 +374,8 @@
         % 
         \cnta \cstA % Range
         \divide\cnta\cntc % Range//factor
-        % make sure we never get 0 modulo 2310 as our cogids array
-        % indices start at 1
+        % make sure we never get an even number modulo 2310 as our cogids array indices
+        % start at 1 and the array entries are meaningful only for odd indices
         \ifodd\cnta\else\advance\cnta-\@ne\fi
         %
         \cntb\cnta
@@ -442,15 +443,15 @@
     % will happen until we have exhausted all potential factors up to B = isqrt(range)
     % 
     \cnta\cstA
-        % make sure we never get 0 modulo 2310 as our cogids array
-        % indices start at 1
+        % make sure we never get an even number modulo 2310 as our cogids array indices
+        % start at 1 and the array entries are meaningful only for odd indices
         \ifodd\cnta\else\advance\cnta-\@ne\fi
     \cntc\cnta
     \divide\cntc\wheelmodulus
     \cntd\cntc
     \multiply\cntd\wheelcogcount
     \multiply\cntc\wheelmodulus
-    \advance\cnta-\cntc % this is A modulo 2310 (A odd so never 0)
+    \advance\cnta-\cntc % this is A modulo 2310 (A odd so this is odd too)
     \advance\cntd\fontdimen\cnta\wheelcogids
     %
     % We need to iterate \cntd-1 times to go from
@@ -530,15 +531,15 @@
     % will happen until we have exhausted all potential factors up to B = isqrt(range)
     % 
     \cnta\cstA
-        % make sure we never get 0 modulo 2310 as our cogids array
-        % indices start at 1
+        % make sure we never get an even number modulo 2310 as our cogids indices
+        % start at 1 and the array entries are meaningful only for odd indices
         \ifodd\cnta\else\advance\cnta-\@ne\fi
     \cntc\cnta
     \divide\cntc\wheelmodulus
     \cntd\cntc
     \multiply\cntd\wheelcogcount
     \multiply\cntc\wheelmodulus
-    \advance\cnta-\cntc % this is A modulo 2310 (A odd so never 0)
+    \advance\cnta-\cntc % this is A modulo 2310 (A odd so this is odd too)
     \advance\cntd\fontdimen\cnta\wheelcogids
     %
     % We need to iterate \cntd-1 times to go from

--- a/PrimeTeX/solution_2/wheel_sieve.tex
+++ b/PrimeTeX/solution_2/wheel_sieve.tex
@@ -300,8 +300,9 @@
 \def\SieveSieve#1{%
     % Set \_svobjarray to the font array
     \expandafter\let\expandafter\_svobjarray\csname _svobjarray.#1\endcsname
-    % Set \cstA to be the sieve range
-    \cstA\csname _svobj.#1.range\endcsname\relax
+    % Set \cstA to be the sieve range. Attention that \_svobj.<foo>.range
+    % is defined to gobble a {}...
+    \cstA\csname _svobj.#1.range\endcsname{}\relax
     % Set \cstB to its square root
     % nota bene: move this to the "init" and add corresponding attribute to
     % object data?
@@ -433,8 +434,9 @@
   % #2 is the file name
     % Set \_svobjarray to the font array
     \expandafter\let\expandafter\_svobjarray\csname _svobjarray.#1\endcsname
-    % Set \cstA to be the sieve range
-    \cstA\csname _svobj.#1.range\endcsname\relax
+    % Set \cstA to be the sieve range. Attention that \_svobj.<foo>.range
+    % is defined to gobble a {}...
+    \cstA\csname _svobj.#1.range\endcsname{}\relax
     %
     % We need to precompute a priori how many elementary steps of the wheel
     % will happen until we have exhausted all potential factors up to B = isqrt(range)
@@ -520,8 +522,9 @@
   \immediate\write\out{11}%
     % Set \_svobjarray to the font array
     \expandafter\let\expandafter\_svobjarray\csname _svobjarray.#1\endcsname
-    % Set \cstA to be the sieve range
-    \cstA\csname _svobj.#1.range\endcsname\relax
+    % Set \cstA to be the sieve range. Attention that \_svobj.<foo>.range
+    % is defined to gobble a {}...
+    \cstA\csname _svobj.#1.range\endcsname{}\relax
     %
     % We need to precompute a priori how many elementary steps of the wheel
     % will happen until we have exhausted all potential factors up to B = isqrt(range)


### PR DESCRIPTION
## Description
<!--
Add your description yere.
-->

The "wheel" TeX code had a code typo with a a missing `{}`. The TeX macro expansion was by luck not impacted because some unexpandable token quickly arose and terminated the prior assignment despite the missing (from being misadvertendly gobbled) `\relax`.

Also I fix some code comment: the sieving range `N` is replaced by the immediately preceding odd number `A` not only in order for the residue modulo `2310` to be distinct from `0` but for it not to be *even*, because an "array" which is used in the code has meaningful entries only for *odd* indices. (it is an array which has recorded for each odd number `j < 2310` how many numbers less than or equal to `j` are prime to `2310`).

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
