### PR TITLE
dart: improve 1-bit performance

### DIFF
--- a/PrimeDart/solution_1/README.md
+++ b/PrimeDart/solution_1/README.md
@@ -97,10 +97,10 @@ platform, but Dart will generate a standard ELF binary on *nix systems.
 ### Docker Results (runs all implementations)
 
 ```
-eagerestwolf&mmcdon20_8bit;4736;5.00113;1;algorithm=base,faithful=yes,bits=8
-eagerestwolf&mmcdon20_8bit_par;10888;5.001292;12;algorithm=base,faithful=yes,bits=8
-eagerestwolf&mmcdon20_1bit;3609;5.000836;1;algorithm=base,faithful=yes,bits=1
-eagerestwolf&mmcdon20_1bit_par;20329;5.000964;12;algorithm=base,faithful=yes,bits=1
+eagerestwolf&mmcdon20_8bit;4766;5.000781;1;algorithm=base,faithful=yes,bits=8
+eagerestwolf&mmcdon20_8bit_par;10417;5.002521;12;algorithm=base,faithful=yes,bits=8
+eagerestwolf&mmcdon20_1bit;4171;5.001069;1;algorithm=base,faithful=yes,bits=1
+eagerestwolf&mmcdon20_1bit_par;24669;5.001305;12;algorithm=base,faithful=yes,bits=1
 ```
 
 ### Dart SDK (running PrimeDart.dart)

--- a/PrimeDart/solution_1/bin/PrimeDartOneBit.dart
+++ b/PrimeDart/solution_1/bin/PrimeDartOneBit.dart
@@ -51,7 +51,7 @@ class PrimeSieve {
   /// Also, as stated previously, Dart doesn't have a way to specify an integer
   /// size, but it does allow you to have lists of specific integer sizes.
   /// Values are truncated when placed into the list.
-  final Uint8List _bits;
+  final Uint64List _bits;
 
   /// This field contains the results we would expect to find for any given
   /// [sieveSize].
@@ -92,19 +92,19 @@ class PrimeSieve {
     /// I'll try to break down the following expression so that is clear how
     /// it works.
     ///
-    /// "index >> 3" is equivalent to "index / 8". We divide the index by 8
-    /// when we call _bits[index >> 3] because we are storing the bits in
-    /// groups of 8 (Uint8 values). And this narrows it down to the right
-    /// group of 8 bits.
+    /// "index >> 6" is equivalent to "index / 64". We divide the index by 64
+    /// when we call _bits[index >> 6] because we are storing the bits in
+    /// groups of 64 (Uint64 values). And this narrows it down to the right
+    /// group of 64 bits.
     ///
-    /// What "(1 << (index % 8))" does is it puts a 1 bit in the position
-    /// within the 8 bits that we are interested in. For example if index
-    /// is 13, then 13 % 8 is 5 and 1 << 5 is 0010_0000 in binary.
+    /// What "(1 << (index % 64))" does is it puts a 1 bit in the position
+    /// within the 64 bits that we are interested in. For example if index
+    /// is 133, then 133 % 64 is 5 and 1 << 5 is 0010_0000 in binary.
     ///
     /// When we & the two values together we will get back either the value
     /// 0010_0000 or 0000_0000 depending on weather or not the value returned
-    /// by "_bits[index >> 3]" also contained a 1 in the same digit place.
-    return (_bits[index >> 3] & (1 << (index % 8))) != 0;
+    /// by "_bits[index >> 6]" also contained a 1 in the same digit place.
+    return (_bits[index >> 6] & (1 << (index % 64))) != 0;
   }
 
   /// This method sets the bit at [index] to 0.
@@ -116,20 +116,21 @@ class PrimeSieve {
     index >>= 1;
 
     /// This works similarly to the _getBit method above.
-    /// Lets assume again that index is 13. "(1 << (index % 8))" is then equivalent
+    /// Lets assume again that index is 133. "(1 << (index % 64))" is then equivalent
     /// to 0010_0000 in binary. ~ negates this and so we get 1101_1111.
     ///
     /// Now when we & the two values any value in the same digit place as the 0 will
     /// also be set to 0.
-    _bits[index >> 3] &= ~(1 << (index % 8));
+    _bits[index >> 6] &= ~(1 << (index % 64));
   }
 
   /// This method constructs a new instance of the PrimeSieve object, where the
   /// [sieveSize] is set by the first positional argument, and the [bits] list
-  /// will be initialized to 1/16 the [sieveSize] and filled with 0xff.
-  PrimeSieve(this._sieveSize) : _bits = Uint8List((_sieveSize + 15) >> 4) {
+  /// will be initialized to 1/128 the [sieveSize] and filled with 0xffffffffffffffff.
+  /// 0xffffffffffffffff is a 64 bit integer which in binary contains only 1s.
+  PrimeSieve(this._sieveSize) : _bits = Uint64List((_sieveSize + 127) >> 7) {
     for (var i = 0; i < _bits.length; i++) {
-      _bits[i] = 0xff;
+      _bits[i] = 0xffffffffffffffff;
     }
   }
 


### PR DESCRIPTION
## Description
<!--
Add your description here.
-->

I was experimenting with the dart implementation and discovered that the 1-bit implementation has better performance when using `Uint64List` rather than `Uint8List`. I suspect this is because the `int` type in dart is using 64 bit integers, so when you place an `int` into a `Uint64List` it doesn't need to be truncated, and when you pull a value out, it doesn't need to be expanded.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
