### PR TITLE
Tag PrimeTeX/solution_2 as 32bits (and fix some random typos)

### DIFF
--- a/PrimeTeX/solution_2/erato_benchmark.tex
+++ b/PrimeTeX/solution_2/erato_benchmark.tex
@@ -78,7 +78,7 @@
 % which will be then cat by run.sh
 \newwrite\out
 \immediate\openout\out=\jobname-out.txt
-\immediate\write\out{jfbu-tex;\the\nbofpasses;\T;1;algorithm=base,faithful=no}
+\immediate\write\out{jfbu-tex;\the\nbofpasses;\T;1;algorithm=base,faithful=no,bits=32}
 %
 % Validate
 \expandafter\ifx\csname PrimeCount\BenchmarkRange\endcsname\relax

--- a/PrimeTeX/solution_2/erato_primestofile_timings.txt
+++ b/PrimeTeX/solution_2/erato_primestofile_timings.txt
@@ -5,7 +5,7 @@
 
 Done on a
 
-hardware: 2 GHz Intel Core i7
+hardware: 2 GHz Intel Core i7 (1cpu, 2cores, mid-2012)
           8 Go 1600 MHz DDR3
 OS: mac osx high sierra
 

--- a/PrimeTeX/solution_2/erato_sieve.tex
+++ b/PrimeTeX/solution_2/erato_sieve.tex
@@ -41,7 +41,7 @@
 %   array in memory represents only odd numbers, first one 3.
 %
 % - For a range N (at least 3) we thus instantiate an array of J "32bits
-%   words" (perhaps 64bits on some installations of pdftex ??? not checked)
+%   words"
 %   with maximal J such that 2J+1<=N, i.e. J=(N-1)//2.
 %
 % Acknowledgements:
@@ -151,7 +151,7 @@
   \advance\instance\@ne
   \expandafter\edef\csname _svobj.#1.instance\endcsname##1{\the\instance}%
   %
-  % an array of font dimensions (each a 32bit word)
+  % an array of font dimensions (each a 32bits word)
   \cntb 665
   \advance\cntb\instance
   % Initialize a font

--- a/PrimeTeX/solution_2/texmf.cnf
+++ b/PrimeTeX/solution_2/texmf.cnf
@@ -4,8 +4,8 @@
 % re-compiling the pdftex binary itself).
 %
 % For a range as in the benchmark of 1,000,000 each pass consumes
-% 500,000 word of memory so this allows about (147483647-20000)/500000
-% =294.9.. i.e. 294 passes, max.
+% 500,000 words of memory (each 32bits) so this allows about
+% (147483647-20000)/500000 =294.9.. i.e. 294 passes, max.
 %
 % To activate this memory setting execute
 %    export TEXMFCNF="$(pwd):"

--- a/PrimeTeX/solution_2/wheel_benchmark.tex
+++ b/PrimeTeX/solution_2/wheel_benchmark.tex
@@ -78,7 +78,7 @@
 % which will be then cat by run.sh
 \newwrite\out
 \immediate\openout\out=\jobname-out.txt
-\immediate\write\out{jfbu-tex-480of2310;\the\nbofpasses;\T;1;algorithm=wheel,faithful=no}
+\immediate\write\out{jfbu-tex-480of2310;\the\nbofpasses;\T;1;algorithm=wheel,faithful=no,bits=32}
 %
 % Validate
 \expandafter\ifx\csname PrimeCount\BenchmarkRange\endcsname\relax

--- a/PrimeTeX/solution_2/wheel_primestofile_timings.txt
+++ b/PrimeTeX/solution_2/wheel_primestofile_timings.txt
@@ -5,7 +5,7 @@
 
 Done on a
 
-hardware: 2 GHz Intel Core i7
+hardware: 2 GHz Intel Core i7 (1cpu, 2cores, mid-2012)
           8 Go 1600 MHz DDR3
 OS: mac osx high sierra
 

--- a/PrimeTeX/solution_2/wheel_sieve.tex
+++ b/PrimeTeX/solution_2/wheel_sieve.tex
@@ -246,7 +246,7 @@
   \advance\instance\@ne
   \expandafter\edef\csname _svobj.#1.instance\endcsname##1{\the\instance}%
   %
-  % an array of font dimensions (each a 32bit word)
+  % an array of font dimensions (each a 32bits word)
   \cntb 669 % as 666, 667, 668, 669 are already in use
   \advance\cntb\instance % instance id at least 1 so this will be 670 at least
   % Initialize a font


### PR DESCRIPTION
## Description
<!--
Add your description yere.
-->
I have queried the luatex maintainers and [the answer](https://tug.org/pipermail/luatex/2021-August/007567.html) is that the "array" structure I use is 32bits per entry also with luatex. This is an unspecified implementation specifics but the Dockerfile pins the luatex used to a TeXLive 2018 based texlive-minimal image, so I decided I should tag solution_2 as 32bits, which this PR does.

It also fixes one or two orthographical typos, gives a precision on my hardware (it is Intel Core i7 but an old one with only 2 cores) and makes some other cosmetic changes here and there, not affecting the code.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
