### PR TITLE
Use while loop instead of `@simd` for loop for PrimeJulia/solution_3

### DIFF
--- a/PrimeJulia/solution_3/README.md
+++ b/PrimeJulia/solution_3/README.md
@@ -13,15 +13,6 @@ Julia to get as much as speed as possible out of the language. It is
 This solution requires at least **Julia 1.5** to run. Julia 1.6 is
 recommended and is used in the Docker image.
 
-### Things to note
-
-1. The `@simd` annotation on the loop inside `clear_factors!` may
-   actually hurt performance on older and/or slower systems for some
-   reason, such as on older x86 processors and on the Raspberry Pi.
-   You can safely remove the `@simd` annotation if you wish to.
-   Feedback is appreciated as to whether `@simd` helps or hurts
-   performance in your case.
-
 ## Description
 
 Instead of using Julia's native `BitVector` type, this solution

--- a/PrimeJulia/solution_3/primes_1of2.jl
+++ b/PrimeJulia/solution_3/primes_1of2.jl
@@ -13,20 +13,7 @@
 
 
 const _uint_bit_length = sizeof(UInt) * 8
-# This is basically `log2(_uint_bit_length)`.
-if UInt == UInt8
-    const _div_uint_size_shift = 3
-elseif UInt == UInt16
-    const _div_uint_size_shift = 4
-elseif UInt == UInt32
-    const _div_uint_size_shift = 5
-elseif UInt == UInt64
-    const _div_uint_size_shift = 6
-elseif UInt == UInt128
-    const _div_uint_size_shift = 7
-else
-    error("Unknown UInt type ($UInt)")
-end
+const _div_uint_size_shift = Int(log2(_uint_bit_length))
 
 # Functions like the ones defined below are also used in Julia's Base
 # library to speed up things such as Julia's native BitArray type.
@@ -38,11 +25,6 @@ end
 # This function also takes inspiration from Base._mod64 (bitarray.jl).
 @inline _mod_uint_size(i::Integer) = i & (_uint_bit_length - 1)
 @inline _div_uint_size(i::Integer) = i >> _div_uint_size_shift
-# These functions are similar to Base.get_chunk_id (bitarray.jl).
-# This is definitely a bit more complicated due to one-based indexing.
-# _div_uint_size(i + (_uint_bit_length - 1)) == _div_uint_size(i - 1) + 1
-@inline _get_chunk_index(i::Integer) = _div_uint_size(i + (_uint_bit_length - 1))
-@inline _get_bit_index_mask(i::Integer) = UInt(1) << _mod_uint_size(i - 1)
 
 
 struct PrimeSieve
@@ -68,43 +50,32 @@ end
 # for testing in the REPL.
 PrimeSieve(sieve_size::Int) = PrimeSieve(UInt(sieve_size))
 
-@inline function unsafe_get_bit_at_index(arr::Vector{UInt}, index::Integer)
-    return @inbounds arr[_get_chunk_index(index)] & _get_bit_index_mask(index)
-end
-
-# This is used in unsafe_find_next_factor_index since we bitrotate the
-# bitmask there instead of calling unsafe_get_bit_index_mask each time.
-@inline function unsafe_get_bit_at_index_with_bitmask(arr::Vector{UInt}, index::Integer, bitmask::Integer)
-    return @inbounds arr[_get_chunk_index(index)] & bitmask
-end
-
-@inline function unsafe_set_bit_at_index!(arr::Vector{UInt}, index::Integer)
-    @inbounds arr[_get_chunk_index(index)] |= _get_bit_index_mask(index)
-end
 
 function unsafe_find_next_factor_index(arr::Vector{UInt}, start_index::Integer, max_index::Integer)
-    # Bit rotating the mask might be slower on platforms without a
-    # native bit rotate instruction. Requires at least Julia 1.5.
-    start_index += 1
-    bitmask = _get_bit_index_mask(start_index)
-    for index in start_index:max_index
-        if iszero(unsafe_get_bit_at_index_with_bitmask(arr, index, bitmask))
-            return index
+    # This loop calculates indices as if they are zero-based then adds
+    # 1 when accessing the array since Julia uses 1-based indexing.
+    zero_index = start_index
+    @inbounds while zero_index < max_index
+        if iszero(
+            arr[_div_uint_size(zero_index) + 1] & (UInt(1) << _mod_uint_size(zero_index))
+        )
+            return zero_index + 1
         end
-        bitmask = bitrotate(bitmask, 1)
+        zero_index += 1
     end
     # UNSAFE: you need to check this in the caller or make sure it
     # never happens
     return max_index + 1
 end
 
-function clear_factors!(arr::Vector{UInt}, factor_index::Integer, max_index::Integer)
+function unsafe_clear_factors!(arr::Vector{UInt}, factor_index::Integer, max_index::Integer)
     factor = _map_to_factor(factor_index)
-    # Since the for loop carries some memory dependencies (no two
-    # iterations should access the same UInt at the same time), we can
-    # only use `@simd` and not `@simd ivdep`.
-    @simd for index in _div2(factor * factor):factor:max_index
-        unsafe_set_bit_at_index!(arr, index)
+    # This function also uses zero-based indexing calculations similar
+    # to unsafe_find_next_factor_index.
+    zero_index = _div2(factor * factor) - 1
+    @inbounds while zero_index < max_index
+        arr[_div_uint_size(zero_index) + 1] |= UInt(1) << _mod_uint_size(zero_index)
+        zero_index += factor
     end
 end
 
@@ -115,14 +86,21 @@ function run_sieve!(sieve::PrimeSieve)
     max_factor_index = _map_to_index(unsafe_trunc(UInt, sqrt(sieve_size)))
     factor_index = UInt(1) # 1 => 3, 2 => 5, 3 => 7, ...
     while factor_index <= max_factor_index
-        clear_factors!(is_not_prime, factor_index, max_bits_index)
+        unsafe_clear_factors!(is_not_prime, factor_index, max_bits_index)
         factor_index = unsafe_find_next_factor_index(is_not_prime, factor_index, max_factor_index)
     end
     return is_not_prime
 end
 
+
 # These functions aren't optimized, but they aren't being benchmarked,
 # so it's fine.
+
+@inline function unsafe_get_bit_at_index(arr::Vector{UInt}, index::Integer)
+    zero_index = index - 1
+    return @inbounds arr[_div_uint_size(zero_index) + 1] & (UInt(1) << _mod_uint_size(zero_index))
+end
+
 function count_primes(sieve::PrimeSieve)
     arr = sieve.is_not_prime
     max_bits_index = _map_to_index(sieve.sieve_size)

--- a/PrimeJulia/solution_3/primes_1of2.jl
+++ b/PrimeJulia/solution_3/primes_1of2.jl
@@ -51,7 +51,7 @@ end
 PrimeSieve(sieve_size::Int) = PrimeSieve(UInt(sieve_size))
 
 
-function unsafe_find_next_factor_index(arr::Vector{UInt}, start_index::Integer, max_index::Integer)
+@inline function unsafe_find_next_factor_index(arr::Vector{UInt}, start_index::Integer, max_index::Integer)
     # This loop calculates indices as if they are zero-based then adds
     # 1 when accessing the array since Julia uses 1-based indexing.
     zero_index = start_index
@@ -68,7 +68,7 @@ function unsafe_find_next_factor_index(arr::Vector{UInt}, start_index::Integer, 
     return max_index + 1
 end
 
-function unsafe_clear_factors!(arr::Vector{UInt}, factor_index::Integer, max_index::Integer)
+@inline function unsafe_clear_factors!(arr::Vector{UInt}, factor_index::Integer, max_index::Integer)
     factor = _map_to_factor(factor_index)
     # This function also uses zero-based indexing calculations similar
     # to unsafe_find_next_factor_index.


### PR DESCRIPTION
## Description
<!--
Add your description yere.
-->
This PR is a bit unusual in terms of performance. On my Core i5 9th Gen machine, this hurts the performance a little bit:
```
❯ julia primes_1of2.jl && julia primes_edited.jl
Settings: sieve_size = 1000000 | duration = 5
Number of trues: 78498
primes_1of2.jl: Passes: 9609 | Elapsed: 5.000175952911377 | Passes per second: 1921.7323731188126 | Average pass duration: 0.0005203638206797145
louie-github_port_1of2;9609;5.000175952911377;1;algorithm=base,faithful=yes,bits=1
Settings: sieve_size = 1000000 | duration = 5
Number of trues: 78498
primes_1of2.jl: Passes: 9515 | Elapsed: 5.000458002090454 | Passes per second: 1902.8257003702922 | Average pass duration: 0.0005255342093631586
louie-github_port_1of2;9515;5.000458002090454;1;algorithm=base,faithful=yes,bits=1
```

However, on the Raspberry Pi, it is much faster because of the lack of `@simd`:
```
❯ julia primes_1of2.jl && julia primes_edited.jl
Settings: sieve_size = 1000000 | duration = 5
Number of trues: 78498
primes_1of2.jl: Passes: 870 | Elapsed: 5.0015950202941895 | Passes per second: 173.94451099498002 | Average pass duration: 0.005748959793441597
louie-github_port_1of2;870;5.0015950202941895;1;algorithm=base,faithful=yes,bits=1
Settings: sieve_size = 1000000 | duration = 5
Number of trues: 78498
primes_1of2.jl: Passes: 1149 | Elapsed: 5.001935958862305 | Passes per second: 229.71105776838877 | Average pass duration: 0.004353295003361449
louie-github_port_1of2;1149;5.001935958862305;1;algorithm=base,faithful=yes,bits=1
```

I think it is worth the slight performance hit (at least, until I find more optimizations) to make the results more consistent across machines with different CPUs and different CPU architectures.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [X] I read the contribution guidelines in CONTRIBUTING.md.
* [X] I placed my solution in the correct solution folder.
* [X] I added a README.md with the right badge(s).
* [X] I added a Dockerfile that builds and runs my solution.
* [X] I selected `drag-race` as the target branch.
* [X] All code herein is licensed compatible with BSD-3.
