### PR TITLE
made CI.yml more consistent

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,21 +1,17 @@
 name: CI
 
-on:
-  push:
-    branches: ["**"]
-  pull_request:
-    branches: ["**"]
+on: ["push", "pull_request"]
 
 jobs:
   collect-solutions:
     runs-on: ubuntu-20.04
 
     steps:
-      - name: "Checkout code"
+      - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: "Find Dockerfiles"
-        id: "solutions"
+      - name: Find Dockerfiles
+        id: solutions
         run: |
           SOLUTIONS=$(find Prime* -type f -name Dockerfile -exec dirname {} \; | sort | sed -e 's|^./||' | jq -R '[.]' | jq -s -c -M 'add')
           echo "::set-output name=solutions::${SOLUTIONS}"
@@ -24,7 +20,7 @@ jobs:
       solutions: ${{ steps.solutions.outputs.solutions }}
 
   build:
-    runs-on: "ubuntu-20.04"
+    runs-on: ubuntu-20.04
 
     needs: ["collect-solutions"]
 
@@ -34,10 +30,10 @@ jobs:
         solution: ${{ fromJson(needs.collect-solutions.outputs.solutions) }}
 
     steps:
-      - name: "Checkout code"
+      - name: Checkout code
         uses: actions/checkout@v2
       
-      - name: "Normalize solution name"
+      - name: Normalize solution name
         id: solution-name
         run: |
           NAME=$(echo "${{ matrix.solution }}" | sed -r 's/\//_/g' | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
## Description
Made the workflow more consistent. At some points quotation marks were used and at some points they weren't. I also changed the on defenition. It does exactly the same. Not defining a branch is the same as using a double wildcard (**)

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [ ] I placed my solution in the correct solution folder.
* [ ] I added a README.md with the right badge(s).
* [ ] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
