### PR TITLE
add trailing slash to COPY * command

### DIFF
--- a/PrimeLisp/solution_2/Dockerfile
+++ b/PrimeLisp/solution_2/Dockerfile
@@ -2,7 +2,7 @@ FROM daewok/sbcl:2.1.6-alpine3.13
 
 WORKDIR /opt/app
 
-COPY *.lisp .
+COPY *.lisp ./
 COPY run.sh .
 
 RUN chmod +x run.sh


### PR DESCRIPTION
## Description

This PR contains a fix to the copy command in the Dockerfile as discussed  in #560 

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
