### PR TITLE
dart 1-bit optimization

### DIFF
--- a/PrimeDart/solution_1/README.md
+++ b/PrimeDart/solution_1/README.md
@@ -97,10 +97,10 @@ platform, but Dart will generate a standard ELF binary on *nix systems.
 ### Docker Results (runs all implementations)
 
 ```
-eagerestwolf&mmcdon20_8bit;4766;5.000781;1;algorithm=base,faithful=yes,bits=8
-eagerestwolf&mmcdon20_8bit_par;10417;5.002521;12;algorithm=base,faithful=yes,bits=8
-eagerestwolf&mmcdon20_1bit;4171;5.001069;1;algorithm=base,faithful=yes,bits=1
-eagerestwolf&mmcdon20_1bit_par;24669;5.001305;12;algorithm=base,faithful=yes,bits=1
+eagerestwolf&mmcdon20_8bit;4661;5.000105;1;algorithm=base,faithful=yes,bits=8
+eagerestwolf&mmcdon20_8bit_par;10710;5.001459;12;algorithm=base,faithful=yes,bits=8
+eagerestwolf&mmcdon20_1bit;4234;5.000628;1;algorithm=base,faithful=yes,bits=1
+eagerestwolf&mmcdon20_1bit_par;24644;5.001196;12;algorithm=base,faithful=yes,bits=1
 ```
 
 ### Dart SDK (running PrimeDart.dart)

--- a/PrimeDart/solution_1/bin/PrimeDartOneBit.dart
+++ b/PrimeDart/solution_1/bin/PrimeDartOneBit.dart
@@ -51,7 +51,7 @@ class PrimeSieve {
   /// Also, as stated previously, Dart doesn't have a way to specify an integer
   /// size, but it does allow you to have lists of specific integer sizes.
   /// Values are truncated when placed into the list.
-  final Uint64List _bits;
+  final Int64List _bits;
 
   /// This field contains the results we would expect to find for any given
   /// [sieveSize].
@@ -104,7 +104,7 @@ class PrimeSieve {
     /// When we & the two values together we will get back either the value
     /// 0010_0000 or 0000_0000 depending on weather or not the value returned
     /// by "_bits[index >> 6]" also contained a 1 in the same digit place.
-    return (_bits[index >> 6] & (1 << (index % 64))) != 0;
+    return (_bits[index >> 6] & (1 << (index % 64))) == 0;
   }
 
   /// This method sets the bit at [index] to 0.
@@ -117,22 +117,17 @@ class PrimeSieve {
 
     /// This works similarly to the _getBit method above.
     /// Lets assume again that index is 133. "(1 << (index % 64))" is then equivalent
-    /// to 0010_0000 in binary. ~ negates this and so we get 1101_1111.
+    /// to 0010_0000 in binary.
     ///
-    /// Now when we & the two values any value in the same digit place as the 0 will
-    /// also be set to 0.
-    _bits[index >> 6] &= ~(1 << (index % 64));
+    /// Now when we | the two values any value in the same digit place as the 1 will
+    /// also be set to 1.
+    _bits[index >> 6] |= (1 << (index % 64));
   }
 
   /// This method constructs a new instance of the PrimeSieve object, where the
   /// [sieveSize] is set by the first positional argument, and the [bits] list
-  /// will be initialized to 1/128 the [sieveSize] and filled with 0xffffffffffffffff.
-  /// 0xffffffffffffffff is a 64 bit integer which in binary contains only 1s.
-  PrimeSieve(this._sieveSize) : _bits = Uint64List((_sieveSize + 127) >> 7) {
-    for (var i = 0; i < _bits.length; i++) {
-      _bits[i] = 0xffffffffffffffff;
-    }
-  }
+  /// will be initialized to 1/128 the [sieveSize] and filled with 0
+  PrimeSieve(this._sieveSize) : _bits = Int64List((_sieveSize + 127) >> 7);
 
   /// This method runs the sieve. For more intormation about the algorithm,
   /// please check back to Dave's original video.


### PR DESCRIPTION
## Description
<!--
Add your description here.
-->

I was looking at the solutions for node and typescript and noticed an optimization that could also be applied to the dart solution. Those solutions took advantage of the fact that the values in the integer lists were initialized to 0, and use a 0 bit to indicate a prime value rather than 1.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
