### PR TITLE
Go/solution_2 a few new cache-friendly implementations 

### DIFF
--- a/PrimeGo/solution_2/README.md
+++ b/PrimeGo/solution_2/README.md
@@ -2,15 +2,21 @@
 
 Collection of 1-bit single-threaded Go solutions.
 
-*sieve8.go* stores bits in []uint8. Implements the base algorithm.
+*sieve8.go* stores bits in []uint8. Implements the base algorithm. The slowest one, it's here just for comparison.
 
-*sieve32.go* stores bits in []uint32. Implements the base algorithm.
+*sieve32.go* stores bits in []uint32. Implements the base algorithm, but uses a datatype optimized for setting ranges of bits.
+
+*sieve32_block.go* is a modified version of the above. Optimized for CPUs with small cache. Slower than sieve32.go if cache is not a problem.
 
 *sieve_ptr.go* stores bits in []uint32 and uses unsafe pointers instead of slice indexing. Implements the base algorithm.
 
-*sieve_other.go* stores bits in []uint32 and uses unsafe pointers instead of slice indexing. Implements other algorithm, but is close to the base one.
+*sieve_other.go* stores bits in []uint32. Implements the Sieve of Eratosthenes, but doesn't fit into the definition of the `base` algorithm.
 
-Every file compiles in 2 versions: with and without "-B" flag, which disables bounds check.
+*sieve_other_block.go* is a modified version of the above. Uses the same optimizations as sieve32_block.go
+
+*sieve_other_segmented.go* is a segmented version of sieve_other.go. It's not as fast as the `block` version on small limits, but is quite performant on large numbers.
+
+Every version is compiled with boundscheck disabled (`-B` compiler flag).
 
 ## Run instructions
 
@@ -32,6 +38,10 @@ go run --gcflags="-B" sieve8.go [args]
 `-time X`: Duration, in [Go duration format](https://golang.org/pkg/time/#ParseDuration). Default is "5s"
 
 `-v`: Provide additional human-readable output
+
+And for `block`/`segmented` versions:
+
+`-block`: Block size, in bits. Default is 128_000
 
 ## Output
 

--- a/PrimeGo/solution_2/README.md
+++ b/PrimeGo/solution_2/README.md
@@ -47,5 +47,11 @@ And for `block`/`segmented` versions:
 
 AMD A4-3305M 1.9 GHz, Windows 7 64 bit
 ```
-ssovest-go;2434;5.0042862;1;algorithm=base,faithful=yes,bits=1
+ssovest-go-u32-B;8138;5.000469686;1;algorithm=base,faithful=yes,bits=1
+ssovest-go-u32-blocks-B;6916;5.001404427;1;algorithm=base,faithful=yes,bits=1
+ssovest-go-u8-B;2053;5.003531582;1;algorithm=base,faithful=yes,bits=1
+ssovest-go-other-B;13586;5.000640339;1;algorithm=other,faithful=yes,bits=1
+ssovest-go-other-blocks-B;10723;5.000676751;1;algorithm=other,faithful=yes,bits=1
+ssovest-go-other-segmented-B;8315;5.000506643;1;algorithm=other,faithful=yes,bits=1
+ssovest-go-ptr-B;2360;5.000475421;1;algorithm=base,faithful=yes,bits=1
 ```

--- a/PrimeGo/solution_2/build.sh
+++ b/PrimeGo/solution_2/build.sh
@@ -1,10 +1,11 @@
 #!/bin/sh
 
-go build -o ./sieves/sieve8 sieve8.go &&
-go build -o ./sieves/sieve32 sieve32.go &&
-go build -o ./sieves/sieve_ptr sieve_ptr.go &&
-go build -o ./sieves/sieve_other sieve_other.go &&
-go build --gcflags="-B" --ldflags="-X 'main.label=ssovest-go-uint8-B'" -o ./sieves/sieve8_b sieve8.go &&
-go build --gcflags="-B" --ldflags="-X 'main.label=ssovest-go-uint32-B'" -o ./sieves/sieve32_b sieve32.go &&
-go build --gcflags="-B" --ldflags="-X 'main.label=ssovest-go-ptr-B'" -o ./sieves/sieve_ptr_b sieve_ptr.go &&
-go build --gcflags="-B" --ldflags="-X 'main.label=ssovest-go-other-B'" -o ./sieves/sieve_other_b sieve_other.go
+for f in sieve*.go ; do go build --gcflags="-B" -o ./sieves/ $f; done
+#go build -o ./sieves/sieve8 sieve8.go &&
+#go build -o ./sieves/sieve32 sieve32.go &&
+#go build -o ./sieves/sieve_ptr sieve_ptr.go &&
+#go build -o ./sieves/sieve_other sieve_other.go &&
+#go build --gcflags="-B" --ldflags="-X 'main.label=ssovest-go-uint8-B'" -o ./sieves/sieve8_b sieve8.go &&
+#go build --gcflags="-B" --ldflags="-X 'main.label=ssovest-go-uint32-B'" -o ./sieves/sieve32_b sieve32.go &&
+#go build --gcflags="-B" --ldflags="-X 'main.label=ssovest-go-ptr-B'" -o ./sieves/sieve_ptr_b sieve_ptr.go &&
+#go build --gcflags="-B" --ldflags="-X 'main.label=ssovest-go-other-B'" -o ./sieves/sieve_other_b sieve_other.go

--- a/PrimeGo/solution_2/build.sh
+++ b/PrimeGo/solution_2/build.sh
@@ -1,11 +1,3 @@
 #!/bin/sh
 
 for f in sieve*.go ; do go build --gcflags="-B" -o ./sieves/ $f; done
-#go build -o ./sieves/sieve8 sieve8.go &&
-#go build -o ./sieves/sieve32 sieve32.go &&
-#go build -o ./sieves/sieve_ptr sieve_ptr.go &&
-#go build -o ./sieves/sieve_other sieve_other.go &&
-#go build --gcflags="-B" --ldflags="-X 'main.label=ssovest-go-uint8-B'" -o ./sieves/sieve8_b sieve8.go &&
-#go build --gcflags="-B" --ldflags="-X 'main.label=ssovest-go-uint32-B'" -o ./sieves/sieve32_b sieve32.go &&
-#go build --gcflags="-B" --ldflags="-X 'main.label=ssovest-go-ptr-B'" -o ./sieves/sieve_ptr_b sieve_ptr.go &&
-#go build --gcflags="-B" --ldflags="-X 'main.label=ssovest-go-other-B'" -o ./sieves/sieve_other_b sieve_other.go

--- a/PrimeGo/solution_2/run.sh
+++ b/PrimeGo/solution_2/run.sh
@@ -1,10 +1,12 @@
 #!/bin/sh
 
-./sieves/sieve8 "$@" &&
-./sieves/sieve32 "$@" &&
-./sieves/sieve_ptr "$@" &&
-./sieves/sieve_other "$@" &&
-./sieves/sieve8_b "$@" &&
-./sieves/sieve32_b "$@" &&
-./sieves/sieve_ptr_b "$@" &&
-./sieves/sieve_other_b "$@"
+for f in ./sieves/sieve* ; do $f "$@"; done
+
+#./sieves/sieve8 "$@" &&
+#./sieves/sieve32 "$@" &&
+#./sieves/sieve_ptr "$@" &&
+#./sieves/sieve_other "$@" &&
+#./sieves/sieve8_b "$@" &&
+#./sieves/sieve32_b "$@" &&
+#./sieves/sieve_ptr_b "$@" &&
+#./sieves/sieve_other_b "$@"

--- a/PrimeGo/solution_2/run.sh
+++ b/PrimeGo/solution_2/run.sh
@@ -1,12 +1,3 @@
 #!/bin/sh
 
 for f in ./sieves/sieve* ; do $f "$@"; done
-
-#./sieves/sieve8 "$@" &&
-#./sieves/sieve32 "$@" &&
-#./sieves/sieve_ptr "$@" &&
-#./sieves/sieve_other "$@" &&
-#./sieves/sieve8_b "$@" &&
-#./sieves/sieve32_b "$@" &&
-#./sieves/sieve_ptr_b "$@" &&
-#./sieves/sieve_other_b "$@"

--- a/PrimeGo/solution_2/sieve32.go
+++ b/PrimeGo/solution_2/sieve32.go
@@ -7,7 +7,7 @@ import (
 	"time"
 )
 
-var label string = "ssovest-go-uint32"
+var label string = "ssovest-go-u32-B"
 
 var primeCounts = map[uint64]uint64{
 	10:        4,

--- a/PrimeGo/solution_2/sieve32_block.go
+++ b/PrimeGo/solution_2/sieve32_block.go
@@ -7,7 +7,9 @@ import (
 	"time"
 )
 
-var label string = "ssovest-go-other-B"
+var label string = "ssovest-go-u32-blocks-B"
+
+var blockSize uint64
 
 var primeCounts = map[uint64]uint64{
 	10:        4,
@@ -20,16 +22,14 @@ var primeCounts = map[uint64]uint64{
 	100000000: 5761455,
 }
 
-type Bitarray []uint64
-
-func NewBitarray(length uint64) Bitarray {
-	return make(Bitarray, (length+63)/64)
-}
+type Bitarray []uint32
 
 func (b Bitarray) SetSliceTrue(start, stop, step uint64) {
-	var index, next, end uint64
-	var mask uint64
-	end = (stop + 63) / 64
+	var index, blockEnd, b8e, end uint64
+	var mask uint32
+	var masks [32]uint32
+	var indices [32]uint64
+	end = (stop + 31) / 32
 
 	step2 := step * 2
 	step3 := step * 3
@@ -39,48 +39,53 @@ func (b Bitarray) SetSliceTrue(start, stop, step uint64) {
 	step7 := step * 7
 	step8 := step * 8
 
-	next = start / 64
-	mask = 0
-	index = next
-
-	for next == index {
-		mask |= bits.RotateLeft64(1, int(start))
+	i := 0
+	for ; i < 32; i++ {
+		masks[i] = bits.RotateLeft32(1, int(start))
+		indices[i] = start / 32
 		start += step
-		next = start / 64
 	}
 
-	b[index] |= mask
+	for blockEnd < end {
 
-	for i := 0; i < 64 && next < end; {
-
-		mask = 0
-		index = next
-		for next == index {
-			mask |= bits.RotateLeft64(1, int(start))
-			i++
-			start += step
-			next = start / 64
+		blockEnd += blockSize
+		if blockEnd > end {
+			blockEnd = end
 		}
 
-		for ; index+step8 < end; index += step8 {
-			b[index] |= mask
-			b[index+step] |= mask
-			b[index+step2] |= mask
-			b[index+step3] |= mask
-			b[index+step4] |= mask
-			b[index+step5] |= mask
-			b[index+step6] |= mask
-			b[index+step7] |= mask
+		b8e = blockEnd - step8
+		if blockEnd < step8 {
+			b8e = 0
 		}
 
-		for ; index < end; index += step {
-			b[index] |= mask
+		for i, mask = range masks {
+
+			index = indices[i]
+
+			for ; index < b8e; index += step8 {
+				b[index] |= mask
+				b[index+step] |= mask
+				b[index+step2] |= mask
+				b[index+step3] |= mask
+				b[index+step4] |= mask
+				b[index+step5] |= mask
+				b[index+step6] |= mask
+				b[index+step7] |= mask
+			}
+
+			for ; index < blockEnd; index += step {
+				b[index] |= mask
+			}
+
+			indices[i] = index
+
 		}
 	}
+
 }
 
 func (b Bitarray) Find(val bool, start, stop uint64) uint64 {
-	for start < stop && val != (b[start/64]&bits.RotateLeft64(1, int(start)) != 0) {
+	for start < stop && val != (b[start/32]&bits.RotateLeft32(1, int(start)) != 0) {
 		start++
 	}
 	return start
@@ -89,7 +94,7 @@ func (b Bitarray) Find(val bool, start, stop uint64) uint64 {
 func (b Bitarray) Count(val bool, start, stop uint64) uint64 {
 	var count uint64
 	for ; start < stop; start++ {
-		if val == (b[start/64]&bits.RotateLeft64(1, int(start)) != 0) {
+		if val == (b[start/32]&bits.RotateLeft32(1, int(start)) != 0) {
 			count++
 		}
 	}
@@ -106,12 +111,15 @@ func (s Sieve) RunSieve() {
 	stop = (s.size + 1) / 2
 	for {
 		factor = s.bits.Find(false, factor+1, stop)
+
 		start = 2 * factor * (factor + 1)
 		step = factor*2 + 1
+
 		// start is factor squared, so it's the same as factor <= q
 		if start >= stop {
 			break
 		}
+
 		s.bits.SetSliceTrue(start, stop, step)
 	}
 }
@@ -126,16 +134,21 @@ func (s Sieve) ValidateResults() bool {
 }
 
 func main() {
-	var limit uint64
+	var limit, bsize uint64
 	var duration time.Duration
 	var verbose bool
 	var sieve Sieve
 
 	flag.Uint64Var(&limit, "limit", 1000000, "limit")
+	flag.Uint64Var(&bsize, "block", 128_000, "block size")
 	flag.DurationVar(&duration, "time", 5*time.Second, "duration")
 	flag.BoolVar(&verbose, "v", false, "verbose output")
-
 	flag.Parse()
+
+	if bsize == 0 {
+		bsize = 128_000
+	}
+	blockSize = bsize / 32
 
 	stop := make(chan struct{})
 	passes := 0
@@ -148,20 +161,18 @@ loop:
 		case <-stop:
 			break loop
 		default:
-			sieve = Sieve{NewBitarray((limit + 1) / 2), limit}
+			sieve = Sieve{make(Bitarray, (limit+63)/64), limit}
 			sieve.RunSieve()
 			passes++
 		}
 	}
 
 	timeDelta := time.Since(start).Seconds()
-
 	if verbose {
 		avg := float64(timeDelta) / float64(passes)
 		count := sieve.CountPrimes()
 		valid := sieve.ValidateResults()
 		fmt.Printf("Passes: %v, Time: %v, Avg: %v, Limit: %v, Count: %v, Valid: %v\n\n", passes, timeDelta, avg, limit, count, valid)
 	}
-
-	fmt.Printf("%v;%v;%v;1;algorithm=other,faithful=yes,bits=1\n", label, passes, timeDelta)
+	fmt.Printf("%v;%v;%v;1;algorithm=base,faithful=yes,bits=1\n", label, passes, timeDelta)
 }

--- a/PrimeGo/solution_2/sieve32_block.go
+++ b/PrimeGo/solution_2/sieve32_block.go
@@ -46,12 +46,7 @@ func (b Bitarray) SetSliceTrue(start, stop, step uint64) {
 		start += step
 	}
 
-	blockEnd = indices[31]
-	if blockEnd >= end {
-		blockEnd = end - 1
-	}
-
-	for blockEnd < end {
+	for blockEnd = indices[0]; blockEnd < end; {
 
 		blockEnd += blockSize
 		if blockEnd > end {

--- a/PrimeGo/solution_2/sieve32_block.go
+++ b/PrimeGo/solution_2/sieve32_block.go
@@ -46,6 +46,11 @@ func (b Bitarray) SetSliceTrue(start, stop, step uint64) {
 		start += step
 	}
 
+	blockEnd = indices[i]
+	if blockEnd >= end {
+		blockEnd = end - 1
+	}
+
 	for blockEnd < end {
 
 		blockEnd += blockSize

--- a/PrimeGo/solution_2/sieve32_block.go
+++ b/PrimeGo/solution_2/sieve32_block.go
@@ -46,7 +46,7 @@ func (b Bitarray) SetSliceTrue(start, stop, step uint64) {
 		start += step
 	}
 
-	blockEnd = indices[i]
+	blockEnd = indices[31]
 	if blockEnd >= end {
 		blockEnd = end - 1
 	}

--- a/PrimeGo/solution_2/sieve8.go
+++ b/PrimeGo/solution_2/sieve8.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-var label string = "ssovest-go-uint8"
+var label string = "ssovest-go-u8-B"
 
 var primeCounts = map[uintptr]uintptr{
 	10:        4,

--- a/PrimeGo/solution_2/sieve_ptr.go
+++ b/PrimeGo/solution_2/sieve_ptr.go
@@ -9,7 +9,7 @@ import (
 	"unsafe"
 )
 
-var label string = "ssovest-go-ptr"
+var label string = "ssovest-go-ptr-B"
 
 var primeCounts = map[uintptr]uintptr{
 	10:        4,


### PR DESCRIPTION
## Description
Some new implementations which (well, in theory) solve the problem with low performance on CPUs with small cache.

 - *sieve32_block.go* is a modification of sieve32.go. The sieve loop is untouched, but the bit clearing loop now processes the buffer in blocks.
 - *sieve_other_block.go* is a modification of sieve_other.go. The bit clearing loop is modified in a similar manner.
 - *sieve_other_segmented.go* is a segmented version of sieve_other.go. It's not a `base` implementation anyway, so why not :)

Also, now all versions are only compiled with `-B` flag, so, despite of adding 3 more files, the total number of actual running versions is 1 less. (By the way, is there a maximum number of implementations a solution can have? I'm not planning to add more, just curious.)

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [ ] I added a README.md with the right badge(s).
* [ ] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
