### PR TITLE
TeX/solution_2 speed boost

### DIFF
--- a/PrimeTeX/solution_2/README.md
+++ b/PrimeTeX/solution_2/README.md
@@ -28,18 +28,16 @@ Two algorithms are implemented:
 
 - the base one with sieving out starting at `factor * factor`
 and going by steps of `2 * factor`.
-- and a refinement using the "480 out of 2310" wheel (`2*3*5*7*11`). With `pdftex`
-this runs almost 3X times faster than the odd-only algorithm, but with `luatex`
-the improvement is more like 2.2X, for unknown reasons.
+- and a refinement using the "480 out of 2310" wheel (`2*3*5*7*11`).
 
 Even configuring `pdftex` (which has no dynamic memory allocation) to its
 maximal TeXLive memory setting, a maximum of `294` passes can be done with it
 for the sieving range of `1,000,000` (each pass consuming about `500,000`
 words of font memory).
 
-As at my locale I achieve with `pdftex` `23` passes for the wheel
-implementation (compared to `8` for the base implementation), a computer about
-`13` times faster than mine would exhaust `pdftex` maximal font memory during
+As at my locale I achieve with `pdftex` `40` passes for the wheel
+implementation, a computer about
+`7.5` times faster than mine would exhaust `pdftex` maximal font memory during
 the benchmark.
 
 For this reason the Dockerfile is configured to run only the `luatex`
@@ -81,29 +79,29 @@ DDR3 of memory (mid-2012 machine).
 Docker run:
 
 ```
-jfbu-tex;10;5.38837;1;algorithm=base,faithful=no
-jfbu-tex-480of2310;23;5.04814;1;algorithm=wheel,faithful=no,bits=32
+jfbu-tex;22;5.10106;1;algorithm=base,faithful=no,bits=32
+jfbu-tex-480of2310;33;5.13968;1;algorithm=wheel,faithful=no,bits=32
 ```
 
-Native run (with `luatex`: `/bin/sh run.sh`):
+Native run (with `luatex`: `/bin/sh run.sh`). The `luatex` is from TeXLive 2021,
+the one of the Dockerfile from TeXLive 2018.
 
 ```
-jfbu-tex;10;5.39767;1;algorithm=base,faithful=no
-jfbu-tex-480of2310;22;5.22046;1;algorithm=wheel,faithful=no,bits=32
+jfbu-tex;20;5.05441;1;algorithm=base,faithful=no,bits=32
+jfbu-tex-480of2310;29;5.04533;1;algorithm=wheel,faithful=no,bits=32
 ```
 
-Native run (with `pdftex`: `/bin/sh runpdftex.sh`):
+Native run (with `pdftex`: `/bin/sh runpdftex.sh`). The `pdftex` is compiled
+locally from sources with compiler flags for speed.
 
 ```
-jfbu-tex;8;5.19325;1;algorithm=base,faithful=no
-jfbu-tex-480of2310;23;5.19388;1;algorithm=wheel,faithful=no,bits=32
+jfbu-tex;25;5.09103;1;algorithm=base,faithful=no,bits=32
+jfbu-tex-480of2310;40;5.06285;1;algorithm=wheel,faithful=no,bits=32
 ```
 
-I don't know why the speed increase from base (one out of two) to wheel (480
-out of 2310) is almost 3 with `pdftex` and lower with `luatex`. Also for some
-reason the Docker runs I did `pdftex` were about `15%` slower than my native
-runs, possibly having to do with the fact that I compiled the `pdftex` binary
-locally but not the `luatex`.
+I don't know why the speed ratio wheel/base is higher with `pdftex` than
+with `luatex`. Also, this ratio is a bit disappointing: perhaps an indication
+my wheel implementation has room for improvements.
 
 ## Information on some of the files
 
@@ -156,7 +154,7 @@ Executing
 pdftex erato_benchmark && cat erato_benchmark-out.txt
 ```
 
-will most certainly fail, except if your computer is very slow.
+will certainly fail due to exhausted `pdftex` memory, except if your computer is very slow.
 
 To fix this, make sure that the repertory contains the contributed file
 `texmf.cnf` and do `export TEXMFCNF="$(pwd):"` and then try again.

--- a/PrimeTeX/solution_2/erato_primestofile_timings.txt
+++ b/PrimeTeX/solution_2/erato_primestofile_timings.txt
@@ -1,7 +1,7 @@
 % Prime Sieve with TeX
 % author: jfbu
 % date:   2021/07/24-25
-%
+% updated timings 2021/08/05
 
 Done on a
 
@@ -32,9 +32,9 @@ Outputting to file listofprimes-1000000.txt...
 No pages of output.
 Transcript written on erato_primestofile.log.
 
-real	0m1.048s
-user	0m1.023s
-sys	0m0.020s
+real	0m0.704s
+user	0m0.675s
+sys	0m0.025s
 
 $ time pdftex erato_primestofile
 This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=pdftex)
@@ -43,19 +43,19 @@ entering extended mode
 (./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 1000000...
-...done (0.00317s)
+...done (0.00322s)
 Sieving...
-...done (0.65s)
+...done (0.1979s)
 Outputting to file listofprimes-1000000.txt...
 78498 primes were written to file listofprimes-1000000.txt
-...done (0.32672s)
+...done (0.35002s)
  ) )
 No pages of output.
 Transcript written on erato_primestofile.log.
 
-real	0m1.163s
-user	0m1.137s
-sys	0m0.020s
+real	0m0.741s
+user	0m0.713s
+sys	0m0.024s
 
 ==============
 N = 10,000,000
@@ -76,9 +76,9 @@ Outputting to file listofprimes-10000000.txt...
 No pages of output.
 Transcript written on erato_primestofile.log.
 
-real	0m9.463s
-user	0m9.365s
-sys	0m0.064s 
+real	0m5.506s
+user	0m5.437s
+sys	0m0.053s 
 
 $ time pdftex \\def\\Range{10000000}\\input erato_primestofile
 This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=pdftex)
@@ -87,19 +87,19 @@ entering extended mode
 (./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 10000000...
-...done (0.0237s)
+...done (0.02696s)
 Sieving...
-...done (7.16238s)
+...done (2.101s)
 Outputting to file listofprimes-10000000.txt...
 664579 primes were written to file listofprimes-10000000.txt
-...done (3.1574s)
+...done (3.419s)
  ) )
 No pages of output.
 Transcript written on erato_primestofile.log.
 
-real	0m10.527s
-user	0m10.465s
-sys	0m0.048s
+real	0m5.739s
+user	0m5.644s
+sys	0m0.050s
 
 $ time luatex \\def\\Range{10000000}\\input erato_primestofile
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
@@ -107,25 +107,25 @@ This is LuaTeX, Version 1.13.0 (TeX Live 2021)
 (./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 10000000...
-...done (0.38243s)
+...done (0.40717s)
 Sieving...
-...done (5.52905s)
+...done (2.24257s)
 Outputting to file listofprimes-10000000.txt...
 664579 primes were written to file listofprimes-10000000.txt
-...done (3.93869s)
+...done (4.00287s)
 ))
 warning  (pdf backend): no pages of output.
 Transcript written on erato_primestofile.log.
 
-real	0m10.292s
-user	0m10.201s
-sys	0m0.077s
+real	0m7.002s
+user	0m6.893s
+sys	0m0.074s
 
 =============
 N=100,000,000 
 =============
 
-(possible with pdftex if font memory is enlarged via TEXMFCNF and texmf.cnf)
+(possible with pdftex only if font memory is enlarged via TEXMFCNF and texmf.cnf)
 
 $ time luatex \\def\\Range{100000000}\\input erato_primestofile
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
@@ -133,48 +133,20 @@ This is LuaTeX, Version 1.13.0 (TeX Live 2021)
 (./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 100000000...
-...done (3.79669s)
+...done (4.15056s)
 Sieving...
-...done (59.38228s)
+...done (24.1442s)
 Outputting to file listofprimes-100000000.txt...
 5761455 primes were written to file listofprimes-100000000.txt
-...done (37.46085s)
+...done (37.98708s)
 ))
 warning  (pdf backend): no pages of output.
 Transcript written on erato_primestofile.log.
 
-real	1m41.216s
-user	1m40.649s
-sys	0m0.422s
+real	1m6.762s
+user	1m6.228s
+sys	0m0.420s
 
 This gives 5,761,455 primes less than 100,000,000 and the largest one is
 99,999,989. The output file has 51,099,000 bytes at my locale.
 
-===============
-N = 999,999,999
-===============
-
-(only possible with luatex, or with a pdftex re-compiled from sources)
-
-$ time luatex \\def\\Range{999999999}\\input erato_primestofile
-This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
- restricted system commands enabled.
-(./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))
-(./shared_primestofile.tex
-Instantiate object for sieving up to 999999999...
-...done (38.77844s)
-Sieving...
-...done (646.84377s)
-Outputting to file listofprimes-999999999.txt...
-50847534 primes were written to file listofprimes-999999999.txt
-...done (372.62837s)
-))
-warning  (pdf backend): no pages of output.
-Transcript written on erato_primestofile.log.
-
-real	17m42.136s
-user	17m34.170s
-sys	0m4.729s
-
-It finds 50,847,534 primes, the largest one being 999,999,937. The
-output file has 501,959,790 bytes at my locale.

--- a/PrimeTeX/solution_2/erato_sieve.tex
+++ b/PrimeTeX/solution_2/erato_sieve.tex
@@ -36,6 +36,9 @@
 % - primes are marked as 0, non-primes as 1. The array entries type is
 %   a TeX dimension, which pdftex represents (I think) as 32bits words.
 %   So more precisely primes are marked as 0sp and non-primes as 1sp.
+%   (update: using \dimen's \z@ and \onesp for significantly faster
+%    assignments; I knew this would bring some game but I did not
+%    expect it as big actually)
 %
 % - index j stands for the number 2j+1 and starts at j=1. So the sieving
 %   array in memory represents only odd numbers, first one 3.
@@ -80,6 +83,9 @@
 \catcode`_ 11
 
 \input shared_batteries.tex
+
+% this will serve to mark composites
+\newdimen\onesp \onesp 1sp
 
 % additional count registers 
 \newcount\indexa
@@ -158,21 +164,21 @@
   \font\_svobjarray=cmr10 at \cntb sp % each class instantiation via own font
                                 % point size 666sp, 667sp, ....
   % Create the array of its parameters 
-  \fontdimen\cnta\_svobjarray=0sp
+  \fontdimen\cnta\_svobjarray=\z@
   %
   % Save the name
   \expandafter\let\csname _svobjarray.#1\endcsname\_svobjarray
   %
   % The array entries are set to 0, apart from the first few ones
   % We must fix this here
-  \fontdimen1\_svobjarray=0sp 
-  \fontdimen2\_svobjarray=0sp
-  \fontdimen3\_svobjarray=0sp
-  \fontdimen4\_svobjarray=0sp
-  \fontdimen5\_svobjarray=0sp
-  \fontdimen6\_svobjarray=0sp
-  \fontdimen7\_svobjarray=0sp
-  \fontdimen8\_svobjarray=0sp % needed for usage with luatex
+  \fontdimen1\_svobjarray=\z@ 
+  \fontdimen2\_svobjarray=\z@
+  \fontdimen3\_svobjarray=\z@
+  \fontdimen4\_svobjarray=\z@
+  \fontdimen5\_svobjarray=\z@
+  \fontdimen6\_svobjarray=\z@
+  \fontdimen7\_svobjarray=\z@
+  \fontdimen8\_svobjarray=\z@ % needed for usage with luatex
   %
   % sieve method (the ##1 gobbles the {} of the syntax)
   %
@@ -224,7 +230,7 @@
     \Replicate{\the\cntb}{%
       \advance\indexa\@ne
       % do we have a prime?
-      \ifnum\fontdimen\indexa\_svobjarray=0 %
+      \ifdim\fontdimen\indexa\_svobjarray=\z@ %
         % yes, so let's sieve out its multiples
         % starting with factor*factor
         \cntc \indexa      % will hold the factor
@@ -236,7 +242,7 @@
         %
         \indexb \cntb
         \divide \indexb \tw@ % (odd number x) //2 gives j such that x=2j+1
-        \fontdimen\indexb\_svobjarray=1sp % factor * factor now sieved out
+        \fontdimen\indexb\_svobjarray=\onesp % factor * factor now sieved out
          %
         \cnta \cstA % Range
         \advance\cnta-\cntb % Range - factor * factor
@@ -250,14 +256,14 @@
         \Replicate{\the\cntb}{%
           \ReplicateM{%
             \advance\indexb\cntc % j steps by factor, thus 2*j+1 by 2*factor
-            \fontdimen\indexb\_svobjarray=1sp % sieved out 
+            \fontdimen\indexb\_svobjarray=\onesp % sieved out 
            }%
          }%
         \multiply\cntb\@m
         \advance\cnta-\cntb % this is what remains to be done
         \Replicate{\the\cnta}{%
           \advance\indexb\cntc
-          \fontdimen\indexb\_svobjarray=1sp % sieved out 
+          \fontdimen\indexb\_svobjarray=\onesp % sieved out 
         }%
       \fi % end of branch handling sieving out multiples of a prime factor <= sqrt(Range)
     }%
@@ -286,14 +292,14 @@
         \Replicate{\the\cntb}{%
           \ReplicateM{%
             \advance\indexa\@ne
-            \fontdimen\indexa\_svobjarray=0sp %
+            \fontdimen\indexa\_svobjarray=\z@ %
            }%
          }%
         \multiply\cntb\@m
         \advance\cnta-\cntb % this is what remains to be done
         \Replicate{\the\cnta}{%
           \advance\indexa\@ne
-          \fontdimen\indexa\_svobjarray=0sp %
+          \fontdimen\indexa\_svobjarray=\z@ %
         }%
 }% end of \SieveReset
 
@@ -320,7 +326,7 @@
     \Replicate{\the\cntb}{%
         \ReplicateM{%
           \advance\indexa\@ne
-          \ifnum\fontdimen\indexa\_svobjarray=0
+          \ifdim\fontdimen\indexa\_svobjarray=\z@
              \advance\cntc\@ne % we have a prime
           \fi
          }%
@@ -331,7 +337,7 @@
     % and do it
     \Replicate{\the\cnta}{%
           \advance\indexa\@ne
-          \ifnum\fontdimen\indexa\_svobjarray=0
+          \ifdim\fontdimen\indexa\_svobjarray=\z@
              \advance\cntc\@ne % we have a prime
           \fi
          }%
@@ -369,7 +375,7 @@
     \Replicate{\the\cntb}{%
         \ReplicateM{%
           \advance\indexa\@ne
-          \ifnum\fontdimen\indexa\_svobjarray=0
+          \ifdim\fontdimen\indexa\_svobjarray=\z@
   % we have a prime
   \cntc\indexa
   \advance\cntc\cntc
@@ -385,7 +391,7 @@
     % and do it
     \Replicate{\the\cnta}{%
           \advance\indexa\@ne
-          \ifnum\fontdimen\indexa\_svobjarray=0
+          \ifdim\fontdimen\indexa\_svobjarray=\z@
   % we have a prime
   \cntc\indexa
   \advance\cntc\cntc

--- a/PrimeTeX/solution_2/shared_primestofile.tex
+++ b/PrimeTeX/solution_2/shared_primestofile.tex
@@ -8,7 +8,7 @@
 \catcode`_ 11
 
 % luatex compatibility layer (it does not know \pdfresettimer)
-\ifdefined\directlua
+\ifx\directlua\undefined\else
       % **too** complicated to get this to work with Docker (and I wasted
       % enough time on this)
       % \input pdftexcmds.sty

--- a/PrimeTeX/solution_2/wheel_primestofile_timings.txt
+++ b/PrimeTeX/solution_2/wheel_primestofile_timings.txt
@@ -1,7 +1,7 @@
 % Prime Sieve with TeX
 % author: jfbu
 % date:   2021/07/27
-%
+% updated timings 2021/08/05
 
 Done on a
 
@@ -32,9 +32,9 @@ Outputting to file listofprimes-1000000.txt...
 No pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	0m0.609s
-user	0m0.583s
-sys	0m0.020s
+real	0m0.548s
+user	0m0.519s
+sys	0m0.023s
 
 $ time pdftex wheel_primestofile
 This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=pdftex)
@@ -43,19 +43,19 @@ entering extended mode
 (./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 1000000...
-...done (0.00284s)
+...done (0.00299s)
 Sieving...
-...done (0.22652s)
+...done (0.12943s)
 Outputting to file listofprimes-1000000.txt...
 78498 primes were written to file listofprimes-1000000.txt
-...done (0.25105s)
+...done (0.24924s)
  ) )
 No pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	0m0.672s
-user	0m0.645s
-sys	0m0.023s
+real	0m0.593s
+user	0m0.553s
+sys	0m0.027s
 
 ==============
 N = 10,000,000
@@ -76,9 +76,9 @@ Outputting to file listofprimes-10000000.txt...
 No pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	0m4.751s
-user	0m4.701s
-sys	0m0.041s
+real	0m4.124s
+user	0m4.048s
+sys	0m0.057s
 
 $ time pdftex \\def\\Range{10000000}\\input wheel_primestofile
 This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=pdftex)
@@ -87,19 +87,19 @@ entering extended mode
 (./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 10000000...
-...done (0.02386s)
+...done (0.02771s)
 Sieving...
-...done (2.59813s)
+...done (1.48656s)
 Outputting to file listofprimes-10000000.txt...
 664579 primes were written to file listofprimes-10000000.txt
-...done (2.38518s)
+...done (2.57507s)
  ) )
 No pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	0m5.199s
-user	0m5.145s
-sys	0m0.044s
+real	0m4.286s
+user	0m4.204s
+sys	0m0.063s
 
 $ time luatex \\def\\Range{10000000}\\input wheel_primestofile
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
@@ -107,19 +107,19 @@ This is LuaTeX, Version 1.13.0 (TeX Live 2021)
 (./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 10000000...
-...done (0.39095s)
+...done (0.38805s)
 Sieving...
-...done (2.319s)
+...done (1.64871s)
 Outputting to file listofprimes-10000000.txt...
 664579 primes were written to file listofprimes-10000000.txt
-...done (3.0409s)
+...done (3.24814s)
 ))
 warning  (pdf backend): no pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	0m6.197s
-user	0m6.109s
-sys	0m0.079s
+real	0m5.630s
+user	0m5.520s
+sys	0m0.091s
 
 =============
 N=100,000,000 
@@ -133,19 +133,19 @@ This is LuaTeX, Version 1.13.0 (TeX Live 2021)
 (./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 100000000...
-...done (3.84619s)
+...done (3.81114s)
 Sieving...
-...done (26.5682s)
+...done (17.0527s)
 Outputting to file listofprimes-100000000.txt...
 5761455 primes were written to file listofprimes-100000000.txt
-...done (28.48254s)
+...done (27.75099s)
 ))
 warning  (pdf backend): no pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	0m59.444s
-user	0m58.895s
-sys	0m0.445s
+real	0m49.053s
+user	0m48.591s
+sys	0m0.392s
 
 This gives 5,761,455 primes less than 100,000,000 and the largest one is
 99,999,989. The output file has 51,099,000 bytes at my locale.
@@ -157,25 +157,24 @@ N = 999,999,999
 (only possible with luatex, or with a pdftex re-compiled from sources)
 
 $ time luatex \\def\\Range{999999999}\\input wheel_primestofile
-
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
  restricted system commands enabled.
 (./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 999999999...
-...done (42.57521s)
+...done (37.31293s)
 Sieving...
-...done (309.85982s)
+...done (192.27728s)
 Outputting to file listofprimes-999999999.txt...
 50847534 primes were written to file listofprimes-999999999.txt
-...done (288.52357s)
+...done (268.8449s)
 ))
 warning  (pdf backend): no pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	10m46.004s
-user	10m33.819s
-sys	0m7.745s
+real	8m19.685s
+user	8m15.340s
+sys	0m3.626s
 
 It finds 50,847,534 primes, the largest one being 999,999,937. The
 output file has 501,959,790 bytes at my locale.

--- a/PrimeTeX/solution_2/wheel_sieve.tex
+++ b/PrimeTeX/solution_2/wheel_sieve.tex
@@ -54,6 +54,9 @@
 
 \input shared_batteries.tex
 
+% this will serve to mark composites
+\newdimen\onesp \onesp 1sp
+
 % additional count registers 
 \newcount\indexa
 \newcount\indexb 
@@ -109,42 +112,42 @@
 % regarding even numbers we handle them by cancel culture.
 %
 % reserve enough space:
-\fontdimen\wheelmodulus\wheelcogids=0sp
+\fontdimen\wheelmodulus\wheelcogids=\z@
 % sieve out multiples of three up to 2310
 \indexa-3
-\Replicate{385}{\advance\indexa6 \fontdimen\indexa\wheelcogids=1sp }%
+\Replicate{385}{\advance\indexa6 \fontdimen\indexa\wheelcogids=\onesp }%
 % sieve out multiples of five up to 2310
 \indexa-5
-\Replicate{231}{\advance\indexa10 \fontdimen\indexa\wheelcogids=1sp }%
+\Replicate{231}{\advance\indexa10 \fontdimen\indexa\wheelcogids=\onesp }%
 % sieve out multiples of seven up to 2310
 \indexa-7
-\Replicate{165}{\advance\indexa14 \fontdimen\indexa\wheelcogids=1sp }%
+\Replicate{165}{\advance\indexa14 \fontdimen\indexa\wheelcogids=\onesp }%
 % sieve out multiples of eleven up to 2310
 \indexa-11
-\Replicate{105}{\advance\indexa22 \fontdimen\indexa\wheelcogids=1sp }%
+\Replicate{105}{\advance\indexa22 \fontdimen\indexa\wheelcogids=\onesp }%
 
 % before giving to the cogids[n] their final values let's initiate
 % the cognext and cogdeltas arrays.
 
 \font\wheelcognext=cmr10 at 667sp
-\fontdimen\wheelmodulus\wheelcognext=0sp
+\fontdimen\wheelmodulus\wheelcognext=\z@
 % we don't care about 1 to 7 or 8 possibly already set values
 
 \font\wheelcogdeltas=cmr10 at 668sp
-\fontdimen\wheelmodulus\wheelcogdeltas=0sp
+\fontdimen\wheelmodulus\wheelcogdeltas=\z@
 
 % we now start creating the cogs array. We don't know yet its
 % future size (actually we know it will be 480, but TeX does not
 % know yet). As long as we don't use "\font" we can append
 % to this array.
 \font\wheelcogs=cmr10 at 669sp
-\fontdimen1\wheelcogids=1sp % 1 is first cog
-\fontdimen1\wheelcogs  =1sp % first cog is at 1
+\fontdimen1\wheelcogids=\onesp % 1 is first cog
+\fontdimen1\wheelcogs  =\onesp % first cog is at 1
 \indexa\@ne
 \indexb\@ne
 \indexc\@ne
 \Replicate{1154}{\advance\indexb\tw@
-    \ifnum\fontdimen\indexb\wheelcogids=0 % relatively prime to 2310
+    \ifdim\fontdimen\indexb\wheelcogids=\z@ % relatively prime to 2310
       \advance\indexc\@ne
       \fontdimen\indexc\wheelcogs    =\indexb sp %
       %
@@ -164,8 +167,8 @@
       \fontdimen\indexb\wheelcogids  =\indexc sp
     \fi
 }%
-\fontdimen2309\wheelcognext=1sp %
-\fontdimen2309\wheelcogdeltas=1sp % see divide by 2 above
+\fontdimen2309\wheelcognext=\onesp %
+\fontdimen2309\wheelcogdeltas=\onesp % see divide by 2 above
 
 % we have finished our job with constructing the necessary
 % and useful wheel data.
@@ -252,20 +255,20 @@
   % Initialize a font
   \font\_svobjarray=cmr10 at \cntb sp % each class instantiation impacts memory
   % Create the array of its parameters 
-  \fontdimen\cnta\_svobjarray=0sp
+  \fontdimen\cnta\_svobjarray=\z@
   % and save its name in the object attributes
   \expandafter\let\csname _svobjarray.#1\endcsname\_svobjarray
   %
   % Array entries with indices 1 to 7 (or 8 with luatex) are not
   % initialized to zero, let's fix this
-  \fontdimen1\_svobjarray=0sp 
-  \fontdimen2\_svobjarray=0sp
-  \fontdimen3\_svobjarray=0sp
-  \fontdimen4\_svobjarray=0sp
-  \fontdimen5\_svobjarray=0sp
-  \fontdimen6\_svobjarray=0sp
-  \fontdimen7\_svobjarray=0sp
-  \fontdimen8\_svobjarray=0sp % needed for usage with luatex
+  \fontdimen1\_svobjarray=\z@ 
+  \fontdimen2\_svobjarray=\z@
+  \fontdimen3\_svobjarray=\z@
+  \fontdimen4\_svobjarray=\z@
+  \fontdimen5\_svobjarray=\z@
+  \fontdimen6\_svobjarray=\z@
+  \fontdimen7\_svobjarray=\z@
+  \fontdimen8\_svobjarray=\z@ % needed for usage with luatex
   %
   % sieve method (the ##1 gobbles the {} of the syntax)
   %
@@ -355,7 +358,7 @@
       % update the iteration count
       \advance\cntf\@ne
       % do we have a prime?
-      \ifnum\fontdimen\indexa\_svobjarray=0 %
+      \ifdim\fontdimen\indexa\_svobjarray=\z@ %
         % yes, so let's sieve out its multiples
         % starting with factor*factor
         %
@@ -368,7 +371,7 @@
         %
         \indexb \cntb
         \divide \indexb \tw@ 
-        \fontdimen\indexb\_svobjarray=1sp % factor * factor now sieved out
+        \fontdimen\indexb\_svobjarray=\onesp % factor * factor now sieved out
         %
         % we now need to know exactly how many iterations are needed
         % 
@@ -405,7 +408,7 @@
             \multiply\cntd\fontdimen\indexd\wheelcogdeltas
             \advance\indexb\cntd
             % and mark this index as sieved out
-            \fontdimen\indexb\_svobjarray=1sp % sieved out 
+            \fontdimen\indexb\_svobjarray=\onesp % sieved out 
             % update the class of G modulo modulus
             \indexd\fontdimen\indexd\wheelcognext
            }%
@@ -418,7 +421,7 @@
             \multiply\cntd\fontdimen\indexd\wheelcogdeltas
             \advance\indexb\cntd
             % and mark this index as sieved out
-            \fontdimen\indexb\_svobjarray=1sp % sieved out 
+            \fontdimen\indexb\_svobjarray=\onesp % sieved out 
             % update the class of G modulo modulus
             \indexd\fontdimen\indexd\wheelcognext
         }%
@@ -483,7 +486,7 @@
       % and now update the class modulo wheel modulus
       \indexc\fontdimen\indexc\wheelcognext
       % do we have a prime?
-      \ifnum\fontdimen\indexa\_svobjarray=0 %
+      \ifdim\fontdimen\indexa\_svobjarray=\z@ %
         % we have a prime
         \advance\cntf\@ne
       \fi
@@ -499,7 +502,7 @@
       % and now update the class modulo wheel modulus
       \indexc\fontdimen\indexc\wheelcognext
       % do we have a prime?
-      \ifnum\fontdimen\indexa\_svobjarray=0 %
+      \ifdim\fontdimen\indexa\_svobjarray=\z@ %
         % we have a prime
         \advance\cntf\@ne
       \fi
@@ -571,7 +574,7 @@
       % and now update the class modulo wheel modulus
       \indexc\fontdimen\indexc\wheelcognext
       % do we have a prime?
-      \ifnum\fontdimen\indexa\_svobjarray=0 %
+      \ifdim\fontdimen\indexa\_svobjarray=\z@ %
         % we have a prime
         \cnta\indexa
         \advance\cnta\cnta
@@ -591,7 +594,7 @@
       % and now update the class modulo wheel modulus
       \indexc\fontdimen\indexc\wheelcognext
       % do we have a prime?
-      \ifnum\fontdimen\indexa\_svobjarray=0 %
+      \ifdim\fontdimen\indexa\_svobjarray=\z@ %
       % we have a prime
         \cnta\indexa
         \advance\cnta\cnta


### PR DESCRIPTION
## Description
<!--
Add your description yere.
-->

A simple TeXnical change, using a `\dimen` register when assigning `1` to mark non-primes, rather than a `1sp`  specification, gave a surprisingly significant speed boost, particularly for the base algorithm.

Also fixing usability of some example files with Plain TeX.


## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
