### PR TITLE
Pascal solution_3 single_threaded and multi-threaded

### DIFF
--- a/PrimePascal/solution_3/Dockerfile
+++ b/PrimePascal/solution_3/Dockerfile
@@ -1,14 +1,15 @@
 FROM primeimages/freepascal:3.2.0 AS build
 
-COPY *.pas /opt/app/
-COPY run.sh /opt/app/
 WORKDIR /opt/app
+COPY *.pas ./
+COPY run.sh ./
 
+RUN chmod a+x run.sh
 RUN fpc PrimePas -O3 -v0
-RUN chmod +x run.sh
 
 FROM ubuntu:20.04
-COPY --from=build /opt/app/PrimePas ./
-COPY --from=build /opt/app/run.sh ./
+COPY --from=build /opt/app/PrimePas /opt/app/
+COPY --from=build /opt/app/run.sh /opt/app/
 
+WORKDIR /opt/app
 ENTRYPOINT [ "./run.sh" ]

--- a/PrimePascal/solution_3/Dockerfile
+++ b/PrimePascal/solution_3/Dockerfile
@@ -1,11 +1,14 @@
 FROM primeimages/freepascal:3.2.0 AS build
 
 COPY *.pas /opt/app/
+COPY run.sh /opt/app/
 WORKDIR /opt/app
 
 RUN fpc PrimePas -O3 -v0
+RUN chmod +x run.sh
 
 FROM ubuntu:20.04
-COPY --from=build /opt/app/PrimePas /opt/app/
+COPY --from=build /opt/app/PrimePas ./
+COPY --from=build /opt/app/run.sh ./
 
-ENTRYPOINT [ "/opt/app/PrimePas" ]
+ENTRYPOINT [ "./run.sh" ]

--- a/PrimePascal/solution_3/PrimePas.pas
+++ b/PrimePascal/solution_3/PrimePas.pas
@@ -219,7 +219,7 @@ begin
     writeln;
   end;
 
-  writeln(format('olivierbrun;%d;%.6f;%d;algorithm=base,faithful=yes,bits=1', [totalPasses, duration, threads]));
+  writeln(format('olivierbrun_%d_threads;%d;%.6f;%d;algorithm=base,faithful=yes,bits=1', [threads, totalPasses, duration, threads]));
 end;
 
 // retrieve command line options

--- a/PrimePascal/solution_3/run.sh
+++ b/PrimePascal/solution_3/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+./PrimePas -t1
+./PrimePas
+


### PR DESCRIPTION
## Description
<!--
Add your description yere.
-->
I have provided the ability to run the solution both single-threaded and multi-threaded.
- a run.sh file has been added to run the application once with a -t1 parameter (1 thread) and once without parameter (the number of threads corresponds to the number of CPU cores available on the system)
- the Dockerfile has been updated to make use of the run.sh file
- the program has been updated to display a label containing the number of threads to differentiate both runs

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
