### PR TITLE
TeX/solution_2 small improvement from systematic `=` in assignments

### DIFF
--- a/PrimeTeX/solution_2/README.md
+++ b/PrimeTeX/solution_2/README.md
@@ -79,24 +79,24 @@ DDR3 of memory (mid-2012 machine).
 Docker run:
 
 ```
-jfbu-tex;23;5.15387;1;algorithm=base,faithful=no,bits=32
-jfbu-tex-480of2310;35;5.1453;1;algorithm=wheel,faithful=no,bits=32
+jfbu-tex;23;5.10483;1;algorithm=base,faithful=no,bits=32
+jfbu-tex-480of2310;35;5.03275;1;algorithm=wheel,faithful=no,bits=32
 ```
 
-Native run (with `luatex`: `/bin/sh run.sh`). The `luatex` is from TeXLive 2021,
-the one of the Dockerfile from TeXLive 2018.
+Native run (with `luatex`: `/bin/sh run.sh`). The `luatex` is `1.13` from
+TeXLive 2021, the one of the Dockerfile is `1.07.0` from TeXLive 2018.
 
 ```
-jfbu-tex;21;5.20486;1;algorithm=base,faithful=no,bits=32
-jfbu-tex-480of2310;31;5.10928;1;algorithm=wheel,faithful=no,bits=32
+jfbu-tex;21;5.2344;1;algorithm=base,faithful=no,bits=32
+jfbu-tex-480of2310;31;5.1061;1;algorithm=wheel,faithful=no,bits=32
 ```
 
 Native run (with `pdftex`: `/bin/sh runpdftex.sh`). The `pdftex` is compiled
 locally from sources with compiler flags for speed.
 
 ```
-jfbu-tex;26;5.14963;1;algorithm=base,faithful=no,bits=32
-jfbu-tex-480of2310;42;5.0096;1;algorithm=wheel,faithful=no,bits=32
+jfbu-tex;26;5.12202;1;algorithm=base,faithful=no,bits=32
+jfbu-tex-480of2310;42;5.02986;1;algorithm=wheel,faithful=no,bits=32
 ```
 
 I don't know why the speed ratio wheel/base is slightly higher with `pdftex`

--- a/PrimeTeX/solution_2/README.md
+++ b/PrimeTeX/solution_2/README.md
@@ -35,9 +35,9 @@ maximal TeXLive memory setting, a maximum of `294` passes can be done with it
 for the sieving range of `1,000,000` (each pass consuming about `500,000`
 words of font memory).
 
-As at my locale I achieve with `pdftex` `40` passes for the wheel
+As at my locale I achieve with `pdftex` `42` passes for the wheel
 implementation, a computer about
-`7.5` times faster than mine would exhaust `pdftex` maximal font memory during
+`7` times faster than mine would exhaust `pdftex` maximal font memory during
 the benchmark.
 
 For this reason the Dockerfile is configured to run only the `luatex`
@@ -79,29 +79,29 @@ DDR3 of memory (mid-2012 machine).
 Docker run:
 
 ```
-jfbu-tex;22;5.10106;1;algorithm=base,faithful=no,bits=32
-jfbu-tex-480of2310;33;5.13968;1;algorithm=wheel,faithful=no,bits=32
+jfbu-tex;23;5.15387;1;algorithm=base,faithful=no,bits=32
+jfbu-tex-480of2310;35;5.1453;1;algorithm=wheel,faithful=no,bits=32
 ```
 
 Native run (with `luatex`: `/bin/sh run.sh`). The `luatex` is from TeXLive 2021,
 the one of the Dockerfile from TeXLive 2018.
 
 ```
-jfbu-tex;20;5.05441;1;algorithm=base,faithful=no,bits=32
-jfbu-tex-480of2310;29;5.04533;1;algorithm=wheel,faithful=no,bits=32
+jfbu-tex;21;5.20486;1;algorithm=base,faithful=no,bits=32
+jfbu-tex-480of2310;31;5.10928;1;algorithm=wheel,faithful=no,bits=32
 ```
 
 Native run (with `pdftex`: `/bin/sh runpdftex.sh`). The `pdftex` is compiled
 locally from sources with compiler flags for speed.
 
 ```
-jfbu-tex;25;5.09103;1;algorithm=base,faithful=no,bits=32
-jfbu-tex-480of2310;40;5.06285;1;algorithm=wheel,faithful=no,bits=32
+jfbu-tex;26;5.14963;1;algorithm=base,faithful=no,bits=32
+jfbu-tex-480of2310;42;5.0096;1;algorithm=wheel,faithful=no,bits=32
 ```
 
-I don't know why the speed ratio wheel/base is higher with `pdftex` than
-with `luatex`. Also, this ratio is a bit disappointing: perhaps an indication
-my wheel implementation has room for improvements.
+I don't know why the speed ratio wheel/base is slightly higher with `pdftex`
+than with `luatex`. Also, this ratio is a bit disappointing: perhaps an
+indication my wheel implementation has room for improvements.
 
 ## Information on some of the files
 
@@ -145,6 +145,15 @@ By default it generates `listofprimes-1000000.txt`.
 other configurable range) and then output to `pdf` the prime numbers in a
 column-wise manner, the columns being filled from left to right for the `h`
 version and from top to bottom for the `v` version.
+
+`getlistofprimes_{erato,wheel}.sh` is to be executed with `/bin/sh`. They test
+production of files `listofprimes-<range>.txt` for `<range>` varying from
+`1,000,000` to `999,999,999`.  The costliest part is not the sieving but the
+creation of the text files, one prime per line (I have not tried to experiment
+alternative ways to write from TeX to the created files, as this is not topic
+of the drag-race).  Please check first typical timings on my hardware in
+`{erato,wheel}_primestofile_timings.txt`.
+
 
 ## More info on native runs with pdftex
 

--- a/PrimeTeX/solution_2/erato_primestofile_timings.txt
+++ b/PrimeTeX/solution_2/erato_primestofile_timings.txt
@@ -17,9 +17,9 @@ Outputting to file listofprimes-1000000.txt...
 No pages of output.
 Transcript written on erato_primestofile.log.
 
-real	0m0.691s
-user	0m0.665s
-sys	0m0.021s
+real	0m0.698s
+user	0m0.644s
+sys	0m0.025s
 
 $ time pdftex erato_primestofile
 This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=pdftex)
@@ -28,19 +28,19 @@ entering extended mode
 (./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 1000000...
-...done (0.003s)
+...done (0.00308s)
 Sieving...
-...done (0.19565s)
+...done (0.1964s)
 Outputting to file listofprimes-1000000.txt...
 78498 primes were written to file listofprimes-1000000.txt
-...done (0.35199s)
+...done (0.32129s)
  ) )
 No pages of output.
 Transcript written on erato_primestofile.log.
 
-real	0m0.732s
-user	0m0.708s
-sys	0m0.019s
+real	0m0.715s
+user	0m0.688s
+sys	0m0.021s
 
 ==============
 N = 10,000,000
@@ -61,8 +61,8 @@ Outputting to file listofprimes-10000000.txt...
 No pages of output.
 Transcript written on erato_primestofile.log.
 
-real	0m5.489s
-user	0m5.420s
+real	0m5.147s
+user	0m5.087s
 sys	0m0.050s
 
 $ time pdftex \\def\\Range{10000000}\\input erato_primestofile
@@ -72,19 +72,19 @@ entering extended mode
 (./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 10000000...
-...done (0.02272s)
+...done (0.02281s)
 Sieving...
-...done (2.34718s)
+...done (2.12775s)
 Outputting to file listofprimes-10000000.txt...
 664579 primes were written to file listofprimes-10000000.txt
-...done (3.48041s)
+...done (3.1084s)
  ) )
 No pages of output.
 Transcript written on erato_primestofile.log.
 
-real	0m6.052s
-user	0m5.967s
-sys	0m0.060s
+real	0m5.445s
+user	0m5.396s
+sys	0m0.040s
 
 $ time luatex \\def\\Range{10000000}\\input erato_primestofile
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
@@ -92,19 +92,19 @@ This is LuaTeX, Version 1.13.0 (TeX Live 2021)
 (./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 10000000...
-...done (0.38297s)
+...done (0.38802s)
 Sieving...
-...done (2.27396s)
+...done (2.26599s)
 Outputting to file listofprimes-10000000.txt...
 664579 primes were written to file listofprimes-10000000.txt
-...done (4.04459s)
+...done (3.73978s)
 ))
 warning  (pdf backend): no pages of output.
 Transcript written on erato_primestofile.log.
 
-real	0m7.010s
-user	0m6.933s
-sys	0m0.065s
+real	0m6.706s
+user	0m6.630s
+sys	0m0.066s
 
 ===============
 N = 100,000,000 
@@ -116,19 +116,19 @@ This is LuaTeX, Version 1.13.0 (TeX Live 2021)
 (./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 100000000...
-...done (3.78471s)
+...done (3.97836s)
 Sieving...
-...done (24.47533s)
+...done (24.47266s)
 Outputting to file listofprimes-100000000.txt...
 5761455 primes were written to file listofprimes-100000000.txt
-...done (39.13625s)
+...done (35.46765s)
 ))
 warning  (pdf backend): no pages of output.
 Transcript written on erato_primestofile.log.
 
-real	1m7.814s
-user	1m7.266s
-sys	0m0.444s
+real	1m4.359s
+user	1m3.823s
+sys	0m0.423s
 
 ===============
 N = 999,999,999
@@ -140,16 +140,16 @@ This is LuaTeX, Version 1.13.0 (TeX Live 2021)
 (./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 999999999...
-...done (37.73749s)
+...done (38.58249s)
 Sieving...
-...done (257.18028s)
+...done (268.19083s)
 Outputting to file listofprimes-999999999.txt...
 50847534 primes were written to file listofprimes-999999999.txt
-...done (384.91171s)
+...done (342.9771s)
 ))
 warning  (pdf backend): no pages of output.
 Transcript written on erato_primestofile.log.
 
-real	11m21.888s
-user	11m16.473s
-sys	0m3.793s
+real	10m52.208s
+user	10m46.585s
+sys	0m3.640s

--- a/PrimeTeX/solution_2/erato_primestofile_timings.txt
+++ b/PrimeTeX/solution_2/erato_primestofile_timings.txt
@@ -1,18 +1,3 @@
-% Prime Sieve with TeX
-% author: jfbu
-% date:   2021/07/24-25
-% updated timings 2021/08/05
-
-Done on a
-
-hardware: 2 GHz Intel Core i7 (1cpu, 2cores, mid-2012)
-          8 Go 1600 MHz DDR3
-OS: mac osx high sierra
-
-(tex and pdftex binaries are self-compiled from TeXLive sources at my locale,
-they are not the ones from TeXLive darwin-legacy but the luatex is from
-darwin-legacy)
-
 =============
 N = 1,000,000
 =============
@@ -32,9 +17,9 @@ Outputting to file listofprimes-1000000.txt...
 No pages of output.
 Transcript written on erato_primestofile.log.
 
-real	0m0.704s
-user	0m0.675s
-sys	0m0.025s
+real	0m0.691s
+user	0m0.665s
+sys	0m0.021s
 
 $ time pdftex erato_primestofile
 This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=pdftex)
@@ -43,19 +28,19 @@ entering extended mode
 (./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 1000000...
-...done (0.00322s)
+...done (0.003s)
 Sieving...
-...done (0.1979s)
+...done (0.19565s)
 Outputting to file listofprimes-1000000.txt...
 78498 primes were written to file listofprimes-1000000.txt
-...done (0.35002s)
+...done (0.35199s)
  ) )
 No pages of output.
 Transcript written on erato_primestofile.log.
 
-real	0m0.741s
-user	0m0.713s
-sys	0m0.024s
+real	0m0.732s
+user	0m0.708s
+sys	0m0.019s
 
 ==============
 N = 10,000,000
@@ -76,9 +61,9 @@ Outputting to file listofprimes-10000000.txt...
 No pages of output.
 Transcript written on erato_primestofile.log.
 
-real	0m5.506s
-user	0m5.437s
-sys	0m0.053s 
+real	0m5.489s
+user	0m5.420s
+sys	0m0.050s
 
 $ time pdftex \\def\\Range{10000000}\\input erato_primestofile
 This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=pdftex)
@@ -87,19 +72,19 @@ entering extended mode
 (./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 10000000...
-...done (0.02696s)
+...done (0.02272s)
 Sieving...
-...done (2.101s)
+...done (2.34718s)
 Outputting to file listofprimes-10000000.txt...
 664579 primes were written to file listofprimes-10000000.txt
-...done (3.419s)
+...done (3.48041s)
  ) )
 No pages of output.
 Transcript written on erato_primestofile.log.
 
-real	0m5.739s
-user	0m5.644s
-sys	0m0.050s
+real	0m6.052s
+user	0m5.967s
+sys	0m0.060s
 
 $ time luatex \\def\\Range{10000000}\\input erato_primestofile
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
@@ -107,25 +92,23 @@ This is LuaTeX, Version 1.13.0 (TeX Live 2021)
 (./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 10000000...
-...done (0.40717s)
+...done (0.38297s)
 Sieving...
-...done (2.24257s)
+...done (2.27396s)
 Outputting to file listofprimes-10000000.txt...
 664579 primes were written to file listofprimes-10000000.txt
-...done (4.00287s)
+...done (4.04459s)
 ))
 warning  (pdf backend): no pages of output.
 Transcript written on erato_primestofile.log.
 
-real	0m7.002s
-user	0m6.893s
-sys	0m0.074s
+real	0m7.010s
+user	0m6.933s
+sys	0m0.065s
 
-=============
-N=100,000,000 
-=============
-
-(possible with pdftex only if font memory is enlarged via TEXMFCNF and texmf.cnf)
+===============
+N = 100,000,000 
+===============
 
 $ time luatex \\def\\Range{100000000}\\input erato_primestofile
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
@@ -133,20 +116,40 @@ This is LuaTeX, Version 1.13.0 (TeX Live 2021)
 (./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 100000000...
-...done (4.15056s)
+...done (3.78471s)
 Sieving...
-...done (24.1442s)
+...done (24.47533s)
 Outputting to file listofprimes-100000000.txt...
 5761455 primes were written to file listofprimes-100000000.txt
-...done (37.98708s)
+...done (39.13625s)
 ))
 warning  (pdf backend): no pages of output.
 Transcript written on erato_primestofile.log.
 
-real	1m6.762s
-user	1m6.228s
-sys	0m0.420s
+real	1m7.814s
+user	1m7.266s
+sys	0m0.444s
 
-This gives 5,761,455 primes less than 100,000,000 and the largest one is
-99,999,989. The output file has 51,099,000 bytes at my locale.
+===============
+N = 999,999,999
+===============
 
+$ time luatex \\def\\Range{999999999}\\input erato_primestofile
+This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
+ restricted system commands enabled.
+(./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))
+(./shared_primestofile.tex
+Instantiate object for sieving up to 999999999...
+...done (37.73749s)
+Sieving...
+...done (257.18028s)
+Outputting to file listofprimes-999999999.txt...
+50847534 primes were written to file listofprimes-999999999.txt
+...done (384.91171s)
+))
+warning  (pdf backend): no pages of output.
+Transcript written on erato_primestofile.log.
+
+real	11m21.888s
+user	11m16.473s
+sys	0m3.793s

--- a/PrimeTeX/solution_2/erato_sieve.tex
+++ b/PrimeTeX/solution_2/erato_sieve.tex
@@ -1,6 +1,6 @@
 % Prime Sieve with TeX
 % author: jfbu
-% date:   2021/07/24
+% date:   2021/07/24--2021/08/06
 %
 % This file defines syntax for a  "Sieve object" in TeX lingua with its
 % associated methods: sieve, reset, settocount, outtofile.
@@ -36,9 +36,13 @@
 % - primes are marked as 0, non-primes as 1. The array entries type is
 %   a TeX dimension, which pdftex represents (I think) as 32bits words.
 %   So more precisely primes are marked as 0sp and non-primes as 1sp.
-%   (update: using \dimen's \z@ and \onesp for significantly faster
-%    assignments; I knew this would bring some game but I did not
-%    expect it as big actually)
+%   * update on August 5: use \dimen's \z@ and \onesp for significantly
+%     faster assignments; I knew this would bring some gain but I did not
+%     expect it as big as it turned out.
+%   * update on August 6: use = sign for all assignments. Faster. Also,
+%     I tested "by" for \advance but it is definitely slower than without
+%   * I test the above with luatex as it is used for benchmark. I hope
+%     my luatex 2021 behaves as luatex 2018 from the Docker image...
 %
 % - index j stands for the number 2j+1 and starts at j=1. So the sieving
 %   array in memory represents only odd numbers, first one 3.
@@ -85,7 +89,7 @@
 \input shared_batteries.tex
 
 % this will serve to mark composites
-\newdimen\onesp \onesp 1sp
+\newdimen\onesp \onesp=1sp
 
 % additional count registers 
 \newcount\indexa
@@ -144,12 +148,12 @@
   %
   \expandafter\def\csname _svobj.#1\endcsname##1##{\csname _svobj.#1.##1\endcsname}%
   % range A
-  \cstA#2\relax
+  \cstA=#2\relax
   %  (the ##1 is only to gobble the {} from the method calling syntax)
   \expandafter\edef\csname _svobj.#1.range\endcsname##1{\the\cstA}%
   %
   % array size 2J+1<= A 
-  \cnta\cstA
+  \cnta=\cstA
   \advance\cnta-\@ne
   \divide\cnta\tw@
   %
@@ -158,7 +162,7 @@
   \expandafter\edef\csname _svobj.#1.instance\endcsname##1{\the\instance}%
   %
   % an array of font dimensions (each a 32bits word)
-  \cntb 665
+  \cntb=665
   \advance\cntb\instance
   % Initialize a font
   \font\_svobjarray=cmr10 at \cntb sp % each class instantiation via own font
@@ -215,16 +219,16 @@
     \expandafter\let\expandafter\_svobjarray\csname _svobjarray.#1\endcsname
     % Set \cstA to be the sieve range. Attention that \_svobj.<foo>.range
     % is defined to gobble a {}...
-    \cstA\csname _svobj.#1.range\endcsname{}\relax
+    \cstA=\csname _svobj.#1.range\endcsname{}\relax
     % Set \cstB to its square root
     \SetToSqrt\cstA\cstB
     %
-    \indexa\z@
+    \indexa=\z@
     %
     % Start the actual sieving
     % We need to check indices 1..J with 2J+1<=B, so increment J times
     % by 1 the index, initially with value 0.
-    \cntb\cstB
+    \cntb=\cstB
     \advance\cntb-\@ne
     \divide\cntb\tw@
     \Replicate{\the\cntb}{%
@@ -233,24 +237,24 @@
       \ifdim\fontdimen\indexa\_svobjarray=\z@ %
         % yes, so let's sieve out its multiples
         % starting with factor*factor
-        \cntc \indexa      % will hold the factor
+        \cntc=\indexa      % will hold the factor
         \advance\cntc\cntc
         \advance\cntc\@ne % \cntc = 2j+1 = odd factor
         %
-        \cntb \cntc
+        \cntb=\cntc
         \multiply \cntb \cntb % factor*factor
         %
-        \indexb \cntb
+        \indexb=\cntb
         \divide \indexb \tw@ % (odd number x) //2 gives j such that x=2j+1
         \fontdimen\indexb\_svobjarray=\onesp % factor * factor now sieved out
          %
-        \cnta \cstA % Range
+        \cnta=\cstA % Range
         \advance\cnta-\cntb % Range - factor * factor
         \divide \cnta\cntc  % how many odd numbers still to sieve out ?
         \divide \cnta\tw@   % that many
         %
         % let's work with batches of 1000 at a time
-        \cntb\cnta
+        \cntb=\cnta
         \divide\cntb\@m % \@m is 1000
         %
         \Replicate{\the\cntb}{%
@@ -277,16 +281,16 @@
     \expandafter\let\expandafter\_svobjarray\csname _svobjarray.#1\endcsname
     % Set \cstA to be the sieve range. Attention that \_svobj.<foo>.range
     % is defined to gobble a {}...
-    \cstA\csname _svobj.#1.range\endcsname{}\relax
+    \cstA=\csname _svobj.#1.range\endcsname{}\relax
     %
-    \cnta\cstA
+    \cnta=\cstA
     \advance\cnta-\@ne
     \divide\cnta\tw@
     %
-    \indexa\z@
+    \indexa=\z@
     %
         % let's work with batches of 1000 at a time
-        \cntb\cnta
+        \cntb=\cnta
         \divide\cntb\@m % \@m is 1000
         %
         \Replicate{\the\cntb}{%
@@ -311,17 +315,17 @@
     \expandafter\let\expandafter\_svobjarray\csname _svobjarray.#1\endcsname
     % Set \cstA to be the sieve range. Attention that \_svobj.<foo>.range
     % is defined to gobble a {}...
-    \cstA\csname _svobj.#1.range\endcsname{}\relax
+    \cstA=\csname _svobj.#1.range\endcsname{}\relax
     % Get the length of the fontdimen array: 2J+1<=N
-    \cnta\cstA
+    \cnta=\cstA
     \advance\cnta-\@ne
     \divide\cnta\tw@
     % index will get incremented by 1, initialize it at 0
-    \indexa \z@
+    \indexa=\z@
     % \cntc will hold the count of primes, set it to 1 as 2 is prime
-    \cntc \@ne
+    \cntc=\@ne
     % Proceed by batches of 1000 at a time
-    \cntb\cnta
+    \cntb=\cnta
     \divide\cntb\@m
     \Replicate{\the\cntb}{%
         \ReplicateM{%
@@ -359,25 +363,25 @@
     \expandafter\let\expandafter\_svobjarray\csname _svobjarray.#1\endcsname
     % Set \cstA to be the sieve range. Attention that \_svobj.<foo>.range
     % is defined to gobble a {}...
-    \cstA\csname _svobj.#1.range\endcsname{}\relax
+    \cstA=\csname _svobj.#1.range\endcsname{}\relax
     % Get the length of the fontdimen array: 2J+1<=N
-    \cnta\cstA
+    \cnta=\cstA
     \advance\cnta-\@ne
     \divide\cnta\tw@
     % index will get incremented by 1, initialize it at 0
     \indexa \z@
     % 2 is prime
   \immediate\write\out{2}%
-  \cntd\@ne
+  \cntd=\@ne
     % Proceed by batches of 1000 at a time
-    \cntb\cnta
+    \cntb=\cnta
     \divide\cntb\@m
     \Replicate{\the\cntb}{%
         \ReplicateM{%
           \advance\indexa\@ne
           \ifdim\fontdimen\indexa\_svobjarray=\z@
   % we have a prime
-  \cntc\indexa
+  \cntc=\indexa
   \advance\cntc\cntc
   \advance\cntc\@ne
   \immediate\write\out{\the\cntc}%
@@ -393,7 +397,7 @@
           \advance\indexa\@ne
           \ifdim\fontdimen\indexa\_svobjarray=\z@
   % we have a prime
-  \cntc\indexa
+  \cntc=\indexa
   \advance\cntc\cntc
   \advance\cntc\@ne
   \immediate\write\out{\the\cntc}%

--- a/PrimeTeX/solution_2/erato_sieve.tex
+++ b/PrimeTeX/solution_2/erato_sieve.tex
@@ -40,7 +40,20 @@
 %     faster assignments; I knew this would bring some gain but I did not
 %     expect it as big as it turned out.
 %   * update on August 6: use = sign for all assignments. Faster. Also,
-%     I tested "by" for \advance but it is definitely slower than without
+%     I tested "by" for \advance but it is definitely slower adding it
+%   * putting the replicated bodies in "\action" macros is also definitely
+%     slower
+%   * the \romannumeral in \Replicate is a legacy from where this macro
+%     was taken (xintkernel.sty, which itself cloned it from latex3)
+%     and serves nothing
+%     Surprisingly tests with luatex 1.13 definitely show it is advantageous.
+%     But tests with the luatex 1.07.0 from the Docker container are less
+%     conclusive... perhaps because there are less files in the texmf trees,
+%     as unexpectedly this is sensitive to whether TEXMFCNF is set or not!
+%     Weird and we are entering areas where
+%     things are more or less pronounced depending on engine (pdftex,
+%     luatex, dev version of successor of luatex...)
+%   * using \ifcase rather than \ifdim\foo=\z@ is faster (thanks to HH)
 %   * I test the above with luatex as it is used for benchmark. I hope
 %     my luatex 2021 behaves as luatex 2018 from the Docker image...
 %
@@ -234,7 +247,7 @@
     \Replicate{\the\cntb}{%
       \advance\indexa\@ne
       % do we have a prime?
-      \ifdim\fontdimen\indexa\_svobjarray=\z@ %
+      \ifcase\fontdimen\indexa\_svobjarray
         % yes, so let's sieve out its multiples
         % starting with factor*factor
         \cntc=\indexa      % will hold the factor
@@ -330,7 +343,7 @@
     \Replicate{\the\cntb}{%
         \ReplicateM{%
           \advance\indexa\@ne
-          \ifdim\fontdimen\indexa\_svobjarray=\z@
+          \ifcase\fontdimen\indexa\_svobjarray
              \advance\cntc\@ne % we have a prime
           \fi
          }%
@@ -341,7 +354,7 @@
     % and do it
     \Replicate{\the\cnta}{%
           \advance\indexa\@ne
-          \ifdim\fontdimen\indexa\_svobjarray=\z@
+          \ifcase\fontdimen\indexa\_svobjarray
              \advance\cntc\@ne % we have a prime
           \fi
          }%
@@ -379,7 +392,7 @@
     \Replicate{\the\cntb}{%
         \ReplicateM{%
           \advance\indexa\@ne
-          \ifdim\fontdimen\indexa\_svobjarray=\z@
+          \ifcase\fontdimen\indexa\_svobjarray
   % we have a prime
   \cntc=\indexa
   \advance\cntc\cntc
@@ -395,7 +408,7 @@
     % and do it
     \Replicate{\the\cnta}{%
           \advance\indexa\@ne
-          \ifdim\fontdimen\indexa\_svobjarray=\z@
+          \ifcase\fontdimen\indexa\_svobjarray
   % we have a prime
   \cntc=\indexa
   \advance\cntc\cntc

--- a/PrimeTeX/solution_2/getlistofprimes_erato.sh
+++ b/PrimeTeX/solution_2/getlistofprimes_erato.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+cd "$(dirname $0)"
+eratotimings="erato_primestofile_timings.txt"
+pleasewait="Please wait..."
+pleasewaitalot="Please wait (a lot)..."
+rm -f $eratotimings
+
+echo "Constructing $eratotimings"
+echo $pleasewait
+cat <<\EOF >>$eratotimings
+=============
+N = 1,000,000
+=============
+
+$ time tex erato_primestofile
+EOF
+echo $pleasewait
+{ time tex erato_primestofile.tex ; } >>$eratotimings 2>&1
+
+cat <<\EOF >>$eratotimings
+
+$ time pdftex erato_primestofile
+EOF
+echo $pleasewait
+{ time pdftex erato_primestofile.tex ; } >>$eratotimings 2>&1
+
+cat <<\EOF >>$eratotimings
+
+==============
+N = 10,000,000
+==============
+
+$ time tex \\def\\Range{10000000}\\input erato_primestofile
+EOF
+echo $pleasewait
+{ time tex \\def\\Range{10000000}\\input erato_primestofile.tex ; } >>$eratotimings 2>&1
+
+cat <<\EOF >>$eratotimings
+
+$ time pdftex \\def\\Range{10000000}\\input erato_primestofile
+EOF
+echo $pleasewait
+{ time pdftex \\def\\Range{10000000}\\input erato_primestofile.tex ; } >>$eratotimings 2>&1
+
+cat <<\EOF >>$eratotimings
+
+$ time luatex \\def\\Range{10000000}\\input erato_primestofile
+EOF
+echo $pleasewait
+{ time luatex \\def\\Range{10000000}\\input erato_primestofile.tex ; } >>$eratotimings 2>&1
+
+cat <<\EOF >>$eratotimings
+
+===============
+N = 100,000,000 
+===============
+
+$ time luatex \\def\\Range{100000000}\\input erato_primestofile
+EOF
+echo $pleasewait
+{ time luatex \\def\\Range{100000000}\\input erato_primestofile.tex ; } >>$eratotimings 2>&1
+
+cat <<\EOF >>$eratotimings
+
+===============
+N = 999,999,999
+===============
+
+$ time luatex \\def\\Range{999999999}\\input erato_primestofile
+EOF
+echo $pleasewaitalot
+{ time luatex \\def\\Range{999999999}\\input erato_primestofile.tex ; } >>$eratotimings 2>&1
+echo "Done"
+

--- a/PrimeTeX/solution_2/getlistofprimes_wheel.sh
+++ b/PrimeTeX/solution_2/getlistofprimes_wheel.sh
@@ -1,0 +1,74 @@
+#!/bin/sh
+cd "$(dirname $0)"
+wheeltimings="wheel_primestofile_timings.txt"
+pleasewait="Please wait..."
+pleasewaitalot="Please wait (a lot)..."
+rm -f $wheeltimings
+
+
+echo "Constructing $wheeltimings"
+cat <<\EOF >>$wheeltimings
+=============
+N = 1,000,000
+=============
+
+$ time tex wheel_primestofile
+EOF
+echo $pleasewait
+{ time tex wheel_primestofile.tex ; } >>$wheeltimings 2>&1
+
+cat <<\EOF >>$wheeltimings
+
+$ time pdftex wheel_primestofile
+EOF
+echo $pleasewait
+{ time pdftex wheel_primestofile.tex ; } >>$wheeltimings 2>&1
+
+cat <<\EOF >>$wheeltimings
+
+==============
+N = 10,000,000
+==============
+
+$ time tex \\def\\Range{10000000}\\input wheel_primestofile
+EOF
+echo $pleasewait
+{ time tex \\def\\Range{10000000}\\input wheel_primestofile.tex ; } >>$wheeltimings 2>&1
+
+cat <<\EOF >>$wheeltimings
+
+$ time pdftex \\def\\Range{10000000}\\input wheel_primestofile
+EOF
+echo $pleasewait
+{ time pdftex \\def\\Range{10000000}\\input wheel_primestofile.tex ; } >>$wheeltimings 2>&1
+
+cat <<\EOF >>$wheeltimings
+
+$ time luatex \\def\\Range{10000000}\\input wheel_primestofile
+EOF
+echo $pleasewait
+{ time luatex \\def\\Range{10000000}\\input wheel_primestofile.tex ; } >>$wheeltimings 2>&1
+
+cat <<\EOF >>$wheeltimings
+
+===============
+N = 100,000,000 
+===============
+
+$ time luatex \\def\\Range{100000000}\\input wheel_primestofile
+EOF
+echo $pleasewait
+{ time luatex \\def\\Range{100000000}\\input wheel_primestofile.tex ; } >>$wheeltimings 2>&1
+
+cat <<\EOF >>$wheeltimings
+
+===============
+N = 999,999,999
+===============
+
+$ time luatex \\def\\Range{999999999}\\input wheel_primestofile
+EOF
+echo $pleasewaitalot
+{ time luatex \\def\\Range{999999999}\\input wheel_primestofile.tex ; } >>$wheeltimings 2>&1
+echo "Done"
+

--- a/PrimeTeX/solution_2/shared_batteries.tex
+++ b/PrimeTeX/solution_2/shared_batteries.tex
@@ -72,7 +72,7 @@
     % and apply *integer* babylonian square root
     % ATTENTION: using Plain TeX's \loop here would make this macro not usable in a \loop...
     \xloop
-     \tmpcntc\tmpcnta
+     \tmpcntc=\tmpcnta
      \divide\tmpcntc\tmpcntb  % TeX's \divide truncates (like Python's // for
                               % positive)
      \advance\tmpcntb\tmpcntc
@@ -80,7 +80,7 @@
     \ifnum\tmpcntb>\tmpcntc
     \repeat
     % do the final assignment
-    #2\tmpcntb
+    #2=\tmpcntb
 }%
 
 % REPLICATION
@@ -123,9 +123,9 @@
 \long\expandafter\def\csname Repf9\endcsname #1{\z@ #1#1#1#1#1#1#1#1#1}%
 %
 % specialized variant optimized for replicating exactly 1000 times
-\long\def\ReplicateM#1{\ReplicateM_i{#1#1#1#1#1#1#1#1#1#1}}%
-\long\def\ReplicateM_i#1{\ReplicateM_ii{#1#1#1#1#1#1#1#1#1#1}}%
-\long\def\ReplicateM_ii#1{#1#1#1#1#1#1#1#1#1#1}%
+\long\def\ReplicateM#1{\ReplicateC{#1#1#1#1#1#1#1#1#1#1}}%
+\long\def\ReplicateC#1{\ReplicateX{#1#1#1#1#1#1#1#1#1#1}}%
+\long\def\ReplicateX#1{#1#1#1#1#1#1#1#1#1#1}%
 
 \endinput
 

--- a/PrimeTeX/solution_2/wheel_primestofile_timings.txt
+++ b/PrimeTeX/solution_2/wheel_primestofile_timings.txt
@@ -17,9 +17,9 @@ Outputting to file listofprimes-1000000.txt...
 No pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	0m0.539s
-user	0m0.496s
-sys	0m0.022s
+real	0m0.507s
+user	0m0.482s
+sys	0m0.019s
 
 $ time pdftex wheel_primestofile
 This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=pdftex)
@@ -28,18 +28,18 @@ entering extended mode
 (./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 1000000...
-...done (0.00241s)
+...done (0.00252s)
 Sieving...
-...done (0.11414s)
+...done (0.1192s)
 Outputting to file listofprimes-1000000.txt...
 78498 primes were written to file listofprimes-1000000.txt
-...done (0.25317s)
+...done (0.23218s)
  ) )
 No pages of output.
 Transcript written on wheel_primestofile.log.
 
 real	0m0.547s
-user	0m0.522s
+user	0m0.519s
 sys	0m0.020s
 
 ==============
@@ -61,9 +61,9 @@ Outputting to file listofprimes-10000000.txt...
 No pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	0m3.642s
-user	0m3.588s
-sys	0m0.046s
+real	0m3.598s
+user	0m3.550s
+sys	0m0.039s
 
 $ time pdftex \\def\\Range{10000000}\\input wheel_primestofile
 This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=pdftex)
@@ -72,19 +72,19 @@ entering extended mode
 (./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 10000000...
-...done (0.0224s)
+...done (0.02248s)
 Sieving...
-...done (1.3417s)
+...done (1.36235s)
 Outputting to file listofprimes-10000000.txt...
 664579 primes were written to file listofprimes-10000000.txt
-...done (2.30524s)
+...done (2.23914s)
  ) )
 No pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	0m3.853s
-user	0m3.810s
-sys	0m0.037s
+real	0m3.814s
+user	0m3.766s
+sys	0m0.040s
 
 $ time luatex \\def\\Range{10000000}\\input wheel_primestofile
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
@@ -92,23 +92,23 @@ This is LuaTeX, Version 1.13.0 (TeX Live 2021)
 (./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 10000000...
-...done (0.37071s)
+...done (0.38557s)
 Sieving...
-...done (1.44365s)
+...done (1.45987s)
 Outputting to file listofprimes-10000000.txt...
 664579 primes were written to file listofprimes-10000000.txt
-...done (2.9077s)
+...done (2.82306s)
 ))
 warning  (pdf backend): no pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	0m5.019s
-user	0m4.953s
-sys	0m0.061s
+real	0m4.989s
+user	0m4.912s
+sys	0m0.063s
 
-=============
-N=100,000,000 
-=============
+===============
+N = 100,000,000 
+===============
 
 $ time luatex \\def\\Range{100000000}\\input wheel_primestofile
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
@@ -116,19 +116,19 @@ This is LuaTeX, Version 1.13.0 (TeX Live 2021)
 (./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 100000000...
-...done (3.76106s)
+...done (3.86606s)
 Sieving...
-...done (16.31778s)
+...done (16.70625s)
 Outputting to file listofprimes-100000000.txt...
 5761455 primes were written to file listofprimes-100000000.txt
-...done (28.38948s)
+...done (26.74182s)
 ))
 warning  (pdf backend): no pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	0m48.889s
-user	0m48.349s
-sys	0m0.434s
+real	0m47.729s
+user	0m47.209s
+sys	0m0.428s
 
 ===============
 N = 999,999,999
@@ -140,16 +140,16 @@ This is LuaTeX, Version 1.13.0 (TeX Live 2021)
 (./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 999999999...
-...done (40.47682s)
+...done (41.04753s)
 Sieving...
-...done (185.54173s)
+...done (185.07123s)
 Outputting to file listofprimes-999999999.txt...
 50847534 primes were written to file listofprimes-999999999.txt
-...done (266.973s)
+...done (258.69708s)
 ))
 warning  (pdf backend): no pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	8m14.416s
-user	8m9.496s
-sys	0m3.947s
+real	8m6.683s
+user	8m1.651s
+sys	0m3.628s

--- a/PrimeTeX/solution_2/wheel_primestofile_timings.txt
+++ b/PrimeTeX/solution_2/wheel_primestofile_timings.txt
@@ -1,18 +1,3 @@
-% Prime Sieve with TeX
-% author: jfbu
-% date:   2021/07/27
-% updated timings 2021/08/05
-
-Done on a
-
-hardware: 2 GHz Intel Core i7 (1cpu, 2cores, mid-2012)
-          8 Go 1600 MHz DDR3
-OS: mac osx high sierra
-
-(tex and pdftex binaries are self-compiled from TeXLive sources at my locale,
-they are not the ones from TeXLive darwin-legacy but the luatex is from
-darwin-legacy)
-
 =============
 N = 1,000,000
 =============
@@ -32,9 +17,9 @@ Outputting to file listofprimes-1000000.txt...
 No pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	0m0.548s
-user	0m0.519s
-sys	0m0.023s
+real	0m0.539s
+user	0m0.496s
+sys	0m0.022s
 
 $ time pdftex wheel_primestofile
 This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=pdftex)
@@ -43,19 +28,19 @@ entering extended mode
 (./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 1000000...
-...done (0.00299s)
+...done (0.00241s)
 Sieving...
-...done (0.12943s)
+...done (0.11414s)
 Outputting to file listofprimes-1000000.txt...
 78498 primes were written to file listofprimes-1000000.txt
-...done (0.24924s)
+...done (0.25317s)
  ) )
 No pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	0m0.593s
-user	0m0.553s
-sys	0m0.027s
+real	0m0.547s
+user	0m0.522s
+sys	0m0.020s
 
 ==============
 N = 10,000,000
@@ -76,9 +61,9 @@ Outputting to file listofprimes-10000000.txt...
 No pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	0m4.124s
-user	0m4.048s
-sys	0m0.057s
+real	0m3.642s
+user	0m3.588s
+sys	0m0.046s
 
 $ time pdftex \\def\\Range{10000000}\\input wheel_primestofile
 This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=pdftex)
@@ -87,19 +72,19 @@ entering extended mode
 (./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 10000000...
-...done (0.02771s)
+...done (0.0224s)
 Sieving...
-...done (1.48656s)
+...done (1.3417s)
 Outputting to file listofprimes-10000000.txt...
 664579 primes were written to file listofprimes-10000000.txt
-...done (2.57507s)
+...done (2.30524s)
  ) )
 No pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	0m4.286s
-user	0m4.204s
-sys	0m0.063s
+real	0m3.853s
+user	0m3.810s
+sys	0m0.037s
 
 $ time luatex \\def\\Range{10000000}\\input wheel_primestofile
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
@@ -107,25 +92,23 @@ This is LuaTeX, Version 1.13.0 (TeX Live 2021)
 (./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 10000000...
-...done (0.38805s)
+...done (0.37071s)
 Sieving...
-...done (1.64871s)
+...done (1.44365s)
 Outputting to file listofprimes-10000000.txt...
 664579 primes were written to file listofprimes-10000000.txt
-...done (3.24814s)
+...done (2.9077s)
 ))
 warning  (pdf backend): no pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	0m5.630s
-user	0m5.520s
-sys	0m0.091s
+real	0m5.019s
+user	0m4.953s
+sys	0m0.061s
 
 =============
 N=100,000,000 
 =============
-
-(possible with pdftex if font memory is enlarged via TEXMFCNF and texmf.cnf)
 
 $ time luatex \\def\\Range{100000000}\\input wheel_primestofile
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
@@ -133,28 +116,23 @@ This is LuaTeX, Version 1.13.0 (TeX Live 2021)
 (./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 100000000...
-...done (3.81114s)
+...done (3.76106s)
 Sieving...
-...done (17.0527s)
+...done (16.31778s)
 Outputting to file listofprimes-100000000.txt...
 5761455 primes were written to file listofprimes-100000000.txt
-...done (27.75099s)
+...done (28.38948s)
 ))
 warning  (pdf backend): no pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	0m49.053s
-user	0m48.591s
-sys	0m0.392s
-
-This gives 5,761,455 primes less than 100,000,000 and the largest one is
-99,999,989. The output file has 51,099,000 bytes at my locale.
+real	0m48.889s
+user	0m48.349s
+sys	0m0.434s
 
 ===============
 N = 999,999,999
 ===============
-
-(only possible with luatex, or with a pdftex re-compiled from sources)
 
 $ time luatex \\def\\Range{999999999}\\input wheel_primestofile
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
@@ -162,19 +140,16 @@ This is LuaTeX, Version 1.13.0 (TeX Live 2021)
 (./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
 Instantiate object for sieving up to 999999999...
-...done (37.31293s)
+...done (40.47682s)
 Sieving...
-...done (192.27728s)
+...done (185.54173s)
 Outputting to file listofprimes-999999999.txt...
 50847534 primes were written to file listofprimes-999999999.txt
-...done (268.8449s)
+...done (266.973s)
 ))
 warning  (pdf backend): no pages of output.
 Transcript written on wheel_primestofile.log.
 
-real	8m19.685s
-user	8m15.340s
-sys	0m3.626s
-
-It finds 50,847,534 primes, the largest one being 999,999,937. The
-output file has 501,959,790 bytes at my locale.
+real	8m14.416s
+user	8m9.496s
+sys	0m3.947s

--- a/PrimeTeX/solution_2/wheel_sieve.tex
+++ b/PrimeTeX/solution_2/wheel_sieve.tex
@@ -147,7 +147,7 @@
 \indexb=\@ne
 \indexc=\@ne
 \Replicate{1154}{\advance\indexb\tw@
-    \ifdim\fontdimen\indexb\wheelcogids=\z@ % relatively prime to 2310
+    \ifcase\fontdimen\indexb\wheelcogids % relatively prime to 2310
       \advance\indexc\@ne
       \fontdimen\indexc\wheelcogs    =\indexb sp %
       %
@@ -358,7 +358,7 @@
       % update the iteration count
       \advance\cntf\@ne
       % do we have a prime?
-      \ifdim\fontdimen\indexa\_svobjarray=\z@ %
+      \ifcase\fontdimen\indexa\_svobjarray
         % yes, so let's sieve out its multiples
         % starting with factor*factor
         %
@@ -366,10 +366,9 @@
         \advance\cntc\cntc
         \advance\cntc\@ne % \cntc = 2j+1 = odd factor
         %
-        \cntb=\cntc
-        \multiply \cntb \cntb % factor*factor
+        \indexb=\cntc
+        \multiply \indexb \indexb % factor*factor
         %
-        \indexb=\cntb
         \divide \indexb \tw@ 
         \fontdimen\indexb\_svobjarray=\onesp % factor * factor now sieved out
         %
@@ -486,7 +485,7 @@
       % and now update the class modulo wheel modulus
       \indexc=\fontdimen\indexc\wheelcognext
       % do we have a prime?
-      \ifdim\fontdimen\indexa\_svobjarray=\z@ %
+      \ifcase\fontdimen\indexa\_svobjarray
         % we have a prime
         \advance\cntf\@ne
       \fi
@@ -502,7 +501,7 @@
       % and now update the class modulo wheel modulus
       \indexc=\fontdimen\indexc\wheelcognext
       % do we have a prime?
-      \ifdim\fontdimen\indexa\_svobjarray=\z@ %
+      \ifcase\fontdimen\indexa\_svobjarray
         % we have a prime
         \advance\cntf\@ne
       \fi
@@ -574,7 +573,7 @@
       % and now update the class modulo wheel modulus
       \indexc=\fontdimen\indexc\wheelcognext
       % do we have a prime?
-      \ifdim\fontdimen\indexa\_svobjarray=\z@ %
+      \ifcase\fontdimen\indexa\_svobjarray
         % we have a prime
         \cnta=\indexa
         \advance\cnta\cnta
@@ -594,7 +593,7 @@
       % and now update the class modulo wheel modulus
       \indexc=\fontdimen\indexc\wheelcognext
       % do we have a prime?
-      \ifdim\fontdimen\indexa\_svobjarray=\z@ %
+      \ifcase\fontdimen\indexa\_svobjarray
       % we have a prime
         \cnta=\indexa
         \advance\cnta\cnta

--- a/PrimeTeX/solution_2/wheel_sieve.tex
+++ b/PrimeTeX/solution_2/wheel_sieve.tex
@@ -1,6 +1,6 @@
 % Prime Sieve with Knuth TeX using the 2*3*5*7*11 wheel(480 cogs out of 2310)
 % author: jfbu
-% date:   2021/07/27
+% date:   2021/07/27--2021/08/06
 %
 % This file defines syntax for a  "Sieve object" in TeX lingua with its
 % associated methods: sieve, reset (not implemented), settocount, outtofile.
@@ -55,7 +55,7 @@
 \input shared_batteries.tex
 
 % this will serve to mark composites
-\newdimen\onesp \onesp 1sp
+\newdimen\onesp \onesp=1sp
 
 % additional count registers 
 \newcount\indexa
@@ -114,16 +114,16 @@
 % reserve enough space:
 \fontdimen\wheelmodulus\wheelcogids=\z@
 % sieve out multiples of three up to 2310
-\indexa-3
+\indexa=-3
 \Replicate{385}{\advance\indexa6 \fontdimen\indexa\wheelcogids=\onesp }%
 % sieve out multiples of five up to 2310
-\indexa-5
+\indexa=-5
 \Replicate{231}{\advance\indexa10 \fontdimen\indexa\wheelcogids=\onesp }%
 % sieve out multiples of seven up to 2310
-\indexa-7
+\indexa=-7
 \Replicate{165}{\advance\indexa14 \fontdimen\indexa\wheelcogids=\onesp }%
 % sieve out multiples of eleven up to 2310
-\indexa-11
+\indexa=-11
 \Replicate{105}{\advance\indexa22 \fontdimen\indexa\wheelcogids=\onesp }%
 
 % before giving to the cogids[n] their final values let's initiate
@@ -143,9 +143,9 @@
 \font\wheelcogs=cmr10 at 669sp
 \fontdimen1\wheelcogids=\onesp % 1 is first cog
 \fontdimen1\wheelcogs  =\onesp % first cog is at 1
-\indexa\@ne
-\indexb\@ne
-\indexc\@ne
+\indexa=\@ne
+\indexb=\@ne
+\indexc=\@ne
 \Replicate{1154}{\advance\indexb\tw@
     \ifdim\fontdimen\indexb\wheelcogids=\z@ % relatively prime to 2310
       \advance\indexc\@ne
@@ -154,7 +154,7 @@
       \fontdimen\indexb\wheelcogids  =\indexc sp %
       \fontdimen\indexa\wheelcognext =\indexb sp %
       %
-      \cnta\indexb\advance\cnta-\indexa
+      \cnta=\indexb\advance\cnta-\indexa
 %%% main sieving array will use j->2j+1 representation
 %%% whereas the cogwheel is represented k->k
 %%% so the deltas are divided by 2 here
@@ -162,7 +162,7 @@
 %%%
       \fontdimen\indexa\wheelcogdeltas=\cnta sp %
       %
-      \indexa\indexb
+      \indexa=\indexb
     \else
       \fontdimen\indexb\wheelcogids  =\indexc sp
     \fi
@@ -174,7 +174,7 @@
 % and useful wheel data.
 % Let's keep memory of the number of relatively prime classes.
 \newcount\wheelcogcount
-\wheelcogcount\indexc % i.e. 480
+\wheelcogcount=\indexc % i.e. 480
 
 % % debugging during code development to check we got it right
 % \indexb-\@ne
@@ -234,14 +234,14 @@
   %
   \expandafter\def\csname _svobj.#1\endcsname##1##{\csname _svobj.#1.##1\endcsname}%
   % range A
-  \cstA#2\relax
+  \cstA=#2\relax
   %  (the ##1 is only to gobble the {} from the method calling syntax)
   \expandafter\edef\csname _svobj.#1.range\endcsname##1{\the\cstA}%
   %
   % array size 2J+1<= A
   % (we don't replace A by largest number prime to 2310 and less than A
   %  but we possibly should for some -surely- limited gain)
-  \cnta\cstA
+  \cnta=\cstA
   \advance\cnta-\@ne
   \divide\cnta\tw@
   %
@@ -250,7 +250,7 @@
   \expandafter\edef\csname _svobj.#1.instance\endcsname##1{\the\instance}%
   %
   % an array of font dimensions (each a 32bits word)
-  \cntb 669 % as 666, 667, 668, 669 are already in use
+  \cntb=669 % as 666, 667, 668, 669 are already in use
   \advance\cntb\instance % instance id at least 1 so this will be 670 at least
   % Initialize a font
   \font\_svobjarray=cmr10 at \cntb sp % each class instantiation impacts memory
@@ -305,7 +305,7 @@
     \expandafter\let\expandafter\_svobjarray\csname _svobjarray.#1\endcsname
     % Set \cstA to be the sieve range. Attention that \_svobj.<foo>.range
     % is defined to gobble a {}...
-    \cstA\csname _svobj.#1.range\endcsname{}\relax
+    \cstA=\csname _svobj.#1.range\endcsname{}\relax
     % Set \cstB to its square root
     % nota bene: move this to the "init" and add corresponding attribute to
     % object data?
@@ -316,14 +316,14 @@
     % We need to precompute a priori how many elementary steps of the wheel
     % will happen until we have exhausted all potential factors up to B = isqrt(range)
     % 
-    \cntb\cstB
+    \cntb=\cstB
         % make sure we never get an even number modulo 2310 as our cogids array indices
         % start at 1 and the array entries are meaningful only for odd indices
         \ifodd\cntb\else\advance\cntb-\@ne\fi
-    \cntc\cntb
+    \cntc=\cntb
     % For the sieve range set to 1000000, this division gives zero as 1000<2310
     \divide\cntc\wheelmodulus
-    \cntd\cntc
+    \cntd=\cntc
     \multiply\cntd\wheelcogcount
     \multiply\cntc\wheelmodulus
     \advance\cntb-\cntc
@@ -346,9 +346,9 @@
     % keep information helpful to know for a given factor F
     % exactly how many F*G's will be sieved out
     %
-    \indexa\z@
-    \indexc\@ne
-    \cntf\@ne
+    \indexa=\z@
+    \indexc=\@ne
+    \cntf=\@ne
     %
     \Replicate{\the\cntd}{%
       % step indexa by suitable delta
@@ -362,29 +362,29 @@
         % yes, so let's sieve out its multiples
         % starting with factor*factor
         %
-        \cntc \indexa      % will hold the factor
+        \cntc=\indexa      % will hold the factor
         \advance\cntc\cntc
         \advance\cntc\@ne % \cntc = 2j+1 = odd factor
         %
-        \cntb \cntc
+        \cntb=\cntc
         \multiply \cntb \cntb % factor*factor
         %
-        \indexb \cntb
+        \indexb=\cntb
         \divide \indexb \tw@ 
         \fontdimen\indexb\_svobjarray=\onesp % factor * factor now sieved out
         %
         % we now need to know exactly how many iterations are needed
         % 
-        \cnta \cstA % Range
+        \cnta=\cstA % Range
         \divide\cnta\cntc % Range//factor
         % make sure we never get an even number modulo 2310 as our cogids array indices
         % start at 1 and the array entries are meaningful only for odd indices
         \ifodd\cnta\else\advance\cnta-\@ne\fi
         %
-        \cntb\cnta
-        \cntd\cntb
+        \cntb=\cnta
+        \cntd=\cntb
         \divide\cntb\wheelmodulus
-        \cnte\cntb
+        \cnte=\cntb
         \multiply\cntb\wheelmodulus
         \advance\cntd-\cntb % this is modulo modulus
         %
@@ -393,37 +393,37 @@
                                 % the left
         % get finally how many iterations must be done: cnte - cntf
         \advance\cnte-\cntf
-        \indexd\indexc %  indexd will follow modulo modulus the quantity G
+        \indexd=\indexc %  indexd will follow modulo modulus the quantity G
                        %  from F * G. Initially G = F which maps to
                        %  indexc
         % indexb will be (F * G - 1)/2, currently G = F
         % let's work with batches of 1000 at a time
-        \cntb\cnte
+        \cntb=\cnte
         \divide\cntb\@m % \@m is 1000
         %
         \Replicate{\the\cntb}{%
           \ReplicateM{%
             % step indexb by suitable delta * factor
-            \cntd\cntc % factor
+            \cntd=\cntc % factor
             \multiply\cntd\fontdimen\indexd\wheelcogdeltas
             \advance\indexb\cntd
             % and mark this index as sieved out
             \fontdimen\indexb\_svobjarray=\onesp % sieved out 
             % update the class of G modulo modulus
-            \indexd\fontdimen\indexd\wheelcognext
+            \indexd=\fontdimen\indexd\wheelcognext
            }%
          }%
         \multiply\cntb\@m
         \advance\cnte-\cntb % this is what remains to be done
         \Replicate{\the\cnte}{%
             % step indexb by suitable delta * factor
-            \cntd\cntc % factor
+            \cntd=\cntc % factor
             \multiply\cntd\fontdimen\indexd\wheelcogdeltas
             \advance\indexb\cntd
             % and mark this index as sieved out
             \fontdimen\indexb\_svobjarray=\onesp % sieved out 
             % update the class of G modulo modulus
-            \indexd\fontdimen\indexd\wheelcognext
+            \indexd=\fontdimen\indexd\wheelcognext
         }%
       \fi
     }%
@@ -440,18 +440,18 @@
     \expandafter\let\expandafter\_svobjarray\csname _svobjarray.#1\endcsname
     % Set \cstA to be the sieve range. Attention that \_svobj.<foo>.range
     % is defined to gobble a {}...
-    \cstA\csname _svobj.#1.range\endcsname{}\relax
+    \cstA=\csname _svobj.#1.range\endcsname{}\relax
     %
     % We need to precompute a priori how many elementary steps of the wheel
     % will happen until we have exhausted all potential factors up to B = isqrt(range)
     % 
-    \cnta\cstA
+    \cnta=\cstA
         % make sure we never get an even number modulo 2310 as our cogids array indices
         % start at 1 and the array entries are meaningful only for odd indices
         \ifodd\cnta\else\advance\cnta-\@ne\fi
-    \cntc\cnta
+    \cntc=\cnta
     \divide\cntc\wheelmodulus
-    \cntd\cntc
+    \cntd=\cntc
     \multiply\cntd\wheelcogcount
     \multiply\cntc\wheelmodulus
     \advance\cnta-\cntc % this is A modulo 2310 (A odd so this is odd too)
@@ -472,19 +472,19 @@
     %
     % \cntf will stepped by one each time a prime is found
     %
-    \indexa\z@
-    \indexc\@ne
-    \cntf 5 % 2, 3, 5, 7, 11
+    \indexa=\z@
+    \indexc=\@ne
+    \cntf=5 % 2, 3, 5, 7, 11
     %
     % let's proceed by batches if 1000 at a time
-    \cntb\cntd
+    \cntb=\cntd
     \divide\cntb\@m % divide by 1000
     \Replicate{\the\cntb}{%
      \ReplicateM{%
       % step indexa by suitable delta
       \advance\indexa\fontdimen\indexc\wheelcogdeltas
       % and now update the class modulo wheel modulus
-      \indexc\fontdimen\indexc\wheelcognext
+      \indexc=\fontdimen\indexc\wheelcognext
       % do we have a prime?
       \ifdim\fontdimen\indexa\_svobjarray=\z@ %
         % we have a prime
@@ -500,7 +500,7 @@
       % step indexa by suitable delta
       \advance\indexa\fontdimen\indexc\wheelcogdeltas
       % and now update the class modulo wheel modulus
-      \indexc\fontdimen\indexc\wheelcognext
+      \indexc=\fontdimen\indexc\wheelcognext
       % do we have a prime?
       \ifdim\fontdimen\indexa\_svobjarray=\z@ %
         % we have a prime
@@ -528,18 +528,18 @@
     \expandafter\let\expandafter\_svobjarray\csname _svobjarray.#1\endcsname
     % Set \cstA to be the sieve range. Attention that \_svobj.<foo>.range
     % is defined to gobble a {}...
-    \cstA\csname _svobj.#1.range\endcsname{}\relax
+    \cstA=\csname _svobj.#1.range\endcsname{}\relax
     %
     % We need to precompute a priori how many elementary steps of the wheel
     % will happen until we have exhausted all potential factors up to B = isqrt(range)
     % 
-    \cnta\cstA
+    \cnta=\cstA
         % make sure we never get an even number modulo 2310 as our cogids indices
         % start at 1 and the array entries are meaningful only for odd indices
         \ifodd\cnta\else\advance\cnta-\@ne\fi
-    \cntc\cnta
+    \cntc=\cnta
     \divide\cntc\wheelmodulus
-    \cntd\cntc
+    \cntd=\cntc
     \multiply\cntd\wheelcogcount
     \multiply\cntc\wheelmodulus
     \advance\cnta-\cntc % this is A modulo 2310 (A odd so this is odd too)
@@ -560,23 +560,23 @@
     %
     % \cntf will stepped by one each time a prime is found
     %
-    \indexa\z@
-    \indexc\@ne
+    \indexa=\z@
+    \indexc=\@ne
     \cntf 5 % 2, 3, 5, 7, 11
     %
     % let's proceed by batches if 1000 at a time
-    \cntb\cntd
+    \cntb=\cntd
     \divide\cntb\@m % divide by 1000
     \Replicate{\the\cntb}{%
      \ReplicateM{%
       % step indexa by suitable delta
       \advance\indexa\fontdimen\indexc\wheelcogdeltas
       % and now update the class modulo wheel modulus
-      \indexc\fontdimen\indexc\wheelcognext
+      \indexc=\fontdimen\indexc\wheelcognext
       % do we have a prime?
       \ifdim\fontdimen\indexa\_svobjarray=\z@ %
         % we have a prime
-        \cnta\indexa
+        \cnta=\indexa
         \advance\cnta\cnta
         \advance\cnta\@ne
         \immediate\write\out{\the\cnta}%
@@ -592,11 +592,11 @@
       % step indexa by suitable delta
       \advance\indexa\fontdimen\indexc\wheelcogdeltas
       % and now update the class modulo wheel modulus
-      \indexc\fontdimen\indexc\wheelcognext
+      \indexc=\fontdimen\indexc\wheelcognext
       % do we have a prime?
       \ifdim\fontdimen\indexa\_svobjarray=\z@ %
       % we have a prime
-        \cnta\indexa
+        \cnta=\indexa
         \advance\cnta\cnta
         \advance\cnta\@ne
         \immediate\write\out{\the\cnta}%


### PR DESCRIPTION
## Description
<!--
Add your description yere.
-->

Small speed improvement from using systematically `=` in dimen and count assignments.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
