### PR TITLE
Change Julia solution_3 to use UInt32 instead of native UInt

### DIFF
--- a/PrimeJulia/solution_3/README.md
+++ b/PrimeJulia/solution_3/README.md
@@ -16,8 +16,13 @@ recommended and is used in the Docker image.
 ## Description
 
 Instead of using Julia's native `BitVector` type, this solution
-manually implements a bit array using a `Vector{UInt}` where `UInt`
-maps to the unsigned integer type of the native word size.
+manually implements a bit array using a `Vector{UInt32}` since 32-bit
+integers seem to give the best performance. You can switch which
+unsigned integer type you want to use by changing the line:
+```
+const MainUInt = UInt32
+```
+Change `UInt32` to whichever unsigned integer type you wish to use.
 
 Manual bit shifting and bit masking is employed to both read and set
 bits in the bit array. Bitwise operations are used as much as possible


### PR DESCRIPTION
## Description
<!--
Add your description yere.
-->
This PR changes Julia/solution_3 to use UInt32 instead of the native UInt. This provides a significant speedup.

Before change:
```
PrimesFork/PrimeJulia/solution_3 on  drag-race [!⇡] via ஃ v1.6.2 took 5s 
❯ julia primes_1of2.jl
Settings: sieve_size = 1000000 | duration = 5
Number of trues: 78498
primes_1of2.jl: Passes: 9491 | Elapsed: 5.000171184539795 | Passes per second: 1898.1350137262414 | Average pass duration: 0.0005268329137645975
louie-github_port_1of2;9491;5.000171184539795;1;algorithm=base,faithful=yes,bits=1
```

After change:
```
❯ julia primes_1of2.jl
Settings: sieve_size = 1000000 | duration = 5
Number of trues: 78498
primes_1of2.jl: Passes: 10330 | Elapsed: 5.000067949295044 | Passes per second: 2065.9719237328404 | Average pass duration: 0.00048403368337802944
louie-github_port_1of2;10330;5.000067949295044;1;algorithm=base,faithful=yes,bits=1
```

This now puts it quite close to the performance of PrimeC/sieve_1of2.c, off which I based this solution:
```
PrimesFork/PrimeJulia/solution_3 on  julia-uint32 [?] via ஃ v1.6.2 
❯ ../../PrimeC/solution_2/sieve_1of2
danielspaangberg_1of2;10406;5.000306;1;algorithm=base,faithful=yes,bits=1
```

I got this idea from mike-barber and Kinematic's comments on #489. Thank you to both of them!

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [X] I read the contribution guidelines in CONTRIBUTING.md.
* [X] I placed my solution in the correct solution folder.
* [X] I added a README.md with the right badge(s).
* [X] I added a Dockerfile that builds and runs my solution.
* [X] I selected `drag-race` as the target branch.
* [X] All code herein is licensed compatible with BSD-3.
