### PR TITLE
Lisp: unroll loops, bitvector set from 2.1.8, hashdot: eval at readtime

### DIFF
--- a/PrimeLisp/solution_2/Dockerfile
+++ b/PrimeLisp/solution_2/Dockerfile
@@ -1,4 +1,4 @@
-FROM daewok/sbcl:2.1.6-alpine3.13
+FROM daewok/sbcl:2.1.7-alpine3.14
 
 WORKDIR /opt/app
 

--- a/PrimeLisp/solution_2/PrimeSievewordops.lisp
+++ b/PrimeLisp/solution_2/PrimeSievewordops.lisp
@@ -9,7 +9,6 @@
   (optimize (speed 3) (safety 0) (debug 0) (space 0))
 
   (inline shl)
-  (inline bit-pattern)
   (inline nth-bit-set-p)
   (inline set-nth-bit)
   (inline set-bits))
@@ -61,7 +60,7 @@
   (declare (fixnum maxints))
   (make-instance 'sieve-state
     :maxints maxints
-    :a (make-array (1+ (floor (floor maxints +bits-per-word+) 2))
+    :a (make-array (ceiling (ceiling maxints +bits-per-word+) 2)
          :element-type 'sieve-element-type
          :initial-element 0)))
 
@@ -91,43 +90,28 @@
          (logior #1# (expt 2 r)))) 0)
 
 
-(defun bit-pattern (n)
-  "Return a 64bit pattern where every n-th bit is 1, starting from least significant bit."
-  (declare (fixnum n))
-  (logand (1- (ash 1 +bits-per-word+))
-    (case  n
-      (2  #b0101010101010101010101010101010101010101010101010101010101010101)
-      (3  #b1001001001001001001001001001001001001001001001001001001001001001)
-      (4  #b0001000100010001000100010001000100010001000100010001000100010001)
-      (5  #b0001000010000100001000010000100001000010000100001000010000100001)
-      (6  #b0001000001000001000001000001000001000001000001000001000001000001)
-      (7  #b1000000100000010000001000000100000010000001000000100000010000001)
-      (8  #b0000000100000001000000010000000100000001000000010000000100000001)
-      (9  #b0100000001000000001000000001000000001000000001000000001000000001)
-      (10 #b0001000000000100000000010000000001000000000100000000010000000001)
-      (11 #b0000000010000000000100000000001000000000010000000000100000000001)
-      (12 #b0001000000000001000000000001000000000001000000000001000000000001)
-      (13 #b0000000000010000000000001000000000000100000000000010000000000001)
-      (14 #b0000000100000000000001000000000000010000000000000100000000000001)
-      (15 #b0001000000000000001000000000000001000000000000001000000000000001)
-      (16 #b0000000000000001000000000000000100000000000000010000000000000001)
-      (17 #b0000000000001000000000000000010000000000000000100000000000000001)
-      (18 #b0000000001000000000000000001000000000000000001000000000000000001)
-      (19 #b0000001000000000000000000100000000000000000010000000000000000001)
-      (20 #b0001000000000000000000010000000000000000000100000000000000000001)
-      (21 #b1000000000000000000001000000000000000000001000000000000000000001)
-      (22 #b0000000000000000000100000000000000000000010000000000000000000001)
-      (23 #b0000000000000000010000000000000000000000100000000000000000000001)
-      (24 #b0000000000000001000000000000000000000001000000000000000000000001)
-      (25 #b0000000000000100000000000000000000000010000000000000000000000001)
-      (26 #b0000000000010000000000000000000000000100000000000000000000000001)
-      (27 #b0000000001000000000000000000000000001000000000000000000000000001)
-      (28 #b0000000100000000000000000000000000010000000000000000000000000001)
-      (29 #b0000010000000000000000000000000000100000000000000000000000000001)
-      (30 #b0001000000000000000000000000000001000000000000000000000000000001)
-      (31 #b0100000000000000000000000000000010000000000000000000000000000001)
-      (32 #b0000000000000000000000000000000100000000000000000000000000000001)
-      )))
+(defun patterns ()
+  "Create a vector of bit-patterns."
+  (labels ((pattern (n)
+             "Return a bit pattern where every n-th bit is 1, starting from least significant bit."
+             (let ((result 0))
+               (loop for b fixnum from (1- +bits-per-word+) downto 0 do
+                 (if (zerop (mod b n))
+                       (setq result (logior (shl result 1) 1))
+                   (setq result (shl result 1))))
+               result)))
+
+    (let ((res (make-array 33 :element-type 'sieve-element-type :initial-element 0)))
+      (loop for x fixnum
+            from 2
+            to 32
+            do (setf (aref res x) (pattern x)))
+      res)))
+
+
+(defconstant +patterns+ (coerce (patterns) '(simple-array sieve-element-type 1))
+  "A vector of bit pattern where every n-th bit is 1, starting from least significant bit.
+E.g. (aref +patterns+ 7) is a bitpattern with every 7th bit set.")
 
 
 (defun set-bits (bits first-incl last-excl every-nth)
@@ -136,7 +120,7 @@
            (type sieve-array-type bits))
   (if (<= every-nth 32)
 
-        (let* ((pattern (bit-pattern every-nth)) (tmp 0) (shift 0) (total 0))
+        (let* ((pattern (aref +patterns+ every-nth)) (tmp 0) (shift 0) (total 0))
           (declare (type sieve-element-type pattern) (fixnum tmp shift total))
 
           ; set first word and prepare pattern
@@ -191,12 +175,11 @@
   (let* ((rawbits (sieve-state-a sieve-state))
          (sieve-size (sieve-state-maxints sieve-state))
          (sieve-sizeh (ceiling sieve-size 2))
+         (factor 0)
+         (factorh 1)
          (qh (ceiling (floor (sqrt sieve-size)) 2)))
-    (declare (fixnum sieve-size sieve-sizeh qh) (type sieve-array-type rawbits))
-    (do ((factor 3)
-         (factorh 1))
-        (nil)
-      (declare (fixnum factor factorh))
+    (declare (fixnum sieve-size sieve-sizeh factor factorh qh) (type sieve-array-type rawbits))
+    (loop do
 
       (loop for num of-type fixnum
             from factorh
@@ -266,10 +249,9 @@ according to the historical data in +results+."
        result)
   (declare (fixnum passes))
 
-  (do () ((>= (get-internal-real-time) end))
-    (setq result (create-sieve 1000000))
-    (run-sieve result)
-    (incf passes))
+  (loop while (<= (get-internal-real-time) end)
+        do (setq result (run-sieve (create-sieve 1000000)))
+           (incf passes))
 
   (let* ((duration  (/ (- (get-internal-real-time) start) internal-time-units-per-second))
          (avg (/ duration passes)))

--- a/PrimeLisp/solution_2/PrimeSievewordops.lisp
+++ b/PrimeLisp/solution_2/PrimeSievewordops.lisp
@@ -259,4 +259,4 @@ according to the historical data in +results+."
     (format *error-output* "Algorithm: base w/ wordops  Passes: ~d  Time: ~f Avg: ~f ms Count: ~d  Valid: ~A~%"
             passes duration (* 1000 avg) (count-primes result) (validate result))
 
-    (format t "mayerrobert-cl-words;~d;~f;1;algorithm=base,faithful=no,bits=1~%" passes duration)))
+    (format t "mayerrobert-cl-words;~d;~f;1;algorithm=other,faithful=yes,bits=1~%" passes duration)))

--- a/PrimeLisp/solution_2/README.md
+++ b/PrimeLisp/solution_2/README.md
@@ -2,8 +2,8 @@
 
 ![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
 ![Algorithm](https://img.shields.io/badge/Algorithm-wheel-yellowgreen)
+![Algorithm](https://img.shields.io/badge/Algorithm-other-yellowgreen)
 ![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
-![Faithfulness](https://img.shields.io/badge/Faithful-no-yellowgreen)
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
 ![Bit count](https://img.shields.io/badge/Bits-1-green)
 

--- a/PrimeLisp/solution_2/README.md
+++ b/PrimeLisp/solution_2/README.md
@@ -4,6 +4,7 @@
 ![Algorithm](https://img.shields.io/badge/Algorithm-wheel-yellowgreen)
 ![Algorithm](https://img.shields.io/badge/Algorithm-other-yellowgreen)
 ![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
+![Faithfulness](https://img.shields.io/badge/Faithful-no-yellowgreen)
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
 ![Bit count](https://img.shields.io/badge/Bits-1-green)
 

--- a/PrimeLisp/solution_2/README.md
+++ b/PrimeLisp/solution_2/README.md
@@ -9,37 +9,78 @@
 
 `PrimeSieve.lisp` is based on the solution by mikehw,
 with lots of type declarations to allow sbcl's optimizer do it's thing.
-Algorithm is base.
-
-The state of the sieve is stored in a Lisp class.
+Algorithm is base with 0 for primes.
 
 Uses a bit-vector (one-dimensional arrays are called vector in Lisp)
 for storage.
 
+The timed loop is run twice: the first loop is run in a faithful fashion,
+in the second loop the call to `run-sieve` is prepended with the go-fast operator `#.`
+which results in a (cough) considerable speedup.
+
+Explanation: sbcl is not a compiler but a Lisp system that contains
+a Lisp-reader (the Lisp-reader also processes reader-macros),
+a macro facility (for defmacro),
+a compiler
+and an evaluator.
+
+When using the commandline parameter `--script`
+sbcl will use it's Lisp-reader to read S-expressions from the given file
+(S-expressions are Lisp's surface representation,
+Lisp itself is not specified in terms of program text but in terms of in-memory structures).
+
+After each top-level S-expression is read (during which reader macros are expanded)
+it will be macroexpanded (note that this is another kind of macro-facility different from reader-macros!),
+compiled and run.
+
+I.e. there is *read-time* (which includes processing of reader-macros),
+*macroexpansion-time*,
+*compile-time* and
+*evaluation-time*.
+
+`#.` is processed during read-time and means "read-time evaluation",
+i.e. the form following `#.` will be evaluated at read-time
+and the result of this evaluation will replace the original form.
+
+So, to summarize: `mayerrobert-cl-hashdot` does not use compile-time evaluation,
+the evaluation happens *before* compile-time.
+
+
 `PrimeSievebitops.lisp` doesn't use a bit vector but a machine word array and some bit operations to get and set bits.
-The state of the sieve is stored in a Lisp class.
+Algorithm is base with 0 for primes.
 
 For Common Lisp bit ops see https://lispcookbook.github.io/cl-cookbook/numbers.html#bit-wise-operation
-Also it uses inverted logic, i.e. 0 for primes.
+
 
 `PrimeSievewordops.lisp` sets multiple bits at a time by copying bitpatterns (that are shifted and masked appropriately)
 into the word-array.
 
+
 `PrimeSieveWheel.lisp` is a Common Lisp port of sieve_5760of30030_only_write_read_bits.c
 by Daniel Spangberg.
-
-The state of the sieve is stored in a Lisp class.
 
 Algorithm is _wheel_, see PrimeC/solution_2/README.md for a better explanation than I would be able to give.
 
 PrimeSieveWheel.lisp stores bits in an array of `(unsigned-byte 64)`,
 much like Daniel's code uses an array of `uint64_t` when compiled with `-DCOMPILE_64_BIT`.
 
+
 `PrimeSieveWheelOpt.lisp` contains further performance improvements.
 I think the biggest improvement is using FLOOR vs AND+SHIFT
 because FLOOR does both in one step.
 
-The state of the sieve is stored in a Lisp class.
+
+`PrimeSieveWheelBitvector.lisp` is pretty much the same as `PrimeSieveWheelOpt.lisp`
+expect it uses a builtin bitvector instead on manual bit-fiddling
+because as of the upcoming SBCL 2.1.8 builtin bitvector operations are faster by a lot.
+
+
+`PrimeSieve.lisp` and `PrimeSieveWheelBitvector.lisp` load code that patches SBCL on the fly
+to get the faster bitvector-set operations from the not-yet-released SBCL 2.1.8, see `bitvector-set-*.lisp`.
+
+
+All: The state of the sieve is stored in a Lisp class.
+
 
 Re: optimizations; (compile-file "PrimeSieveWheel.lisp") will show lots of info during the compilation
 regarding inefficient code that can't be optimized.
@@ -47,6 +88,12 @@ regarding inefficient code that can't be optimized.
 ## Run instructions
 
 First install "Steel Bank Common Lisp", see http://www.sbcl.org/platform-table.html.
+
+Windows users may instead want to go to https://github.com/sbcl/sbcl -> Actions -> Windows
+and enter e.g. `branch:sbcl-2.1.7` into the "Filter workflow runs" textfield.
+This will lead you to https://github.com/sbcl/sbcl/actions/runs/1082323609.
+From there you can download a Windows installer for SBCL 2.1.7.
+
 Other Common Lisps should work as well ("Armed Bear Common Lisp" was lightly tested).
 
 Then
@@ -55,7 +102,7 @@ Then
 `sbcl --script PrimeSieveWheelOpt.lisp 2> /dev/null` (Unix)
 will do the same but only output the CSV result data.
 
-Or use `run.cmd` (Windows) or `./run.sh` (Unix) to run all files.
+Or use `run.cmd` (Windows) or `sh run.sh` (Unix) to run all files.
 
 If you can't or won't install sbcl then use `docker` or `podman` to build and run the provided dockerfile:
 
@@ -68,17 +115,47 @@ If you can't or won't install sbcl then use `docker` or `podman` to build and ru
 Using sbcl 2.0.0 on Windows 7, Pentium(R) Dual Core T4300 @ 2.10GHz I get
 
     D:\robert\projects\Primes\PrimeLisp\solution_2>run.cmd 2>nul
-    mayerrobert-cl;1987;5.007;1;algorithm=base,faithful=yes,bits=1
-    mayerrobert-clb;2209;5.007;1;algorithm=base,faithful=yes,bits=1
-    mayerrobert-cl-wheel;5490;5.007;1;algorithm=wheel,faithful=yes,bits=1
-    mayerrobert-cl-wheel-opt;6026;5.008;1;algorithm=wheel,faithful=yes,bits=1
-    mayerrobert-cl-words;4086;5.008;1;algorithm=base,faithful=no,bits=1
+    mayerrobert-cl;3324;5.008;1;algorithm=base,faithful=yes,bits=1
+    mayerrobert-cl-hashdot;160542746;5.007;1;algorithm=base,faithful=no,bits=1
+    mayerrobert-clb;2412;5.008;1;algorithm=base,faithful=yes,bits=1
+    mayerrobert-cl-wheel;5485;5.008;1;algorithm=wheel,faithful=yes,bits=1
+    mayerrobert-cl-wheel-bitvector;6882;5.007;1;algorithm=wheel,faithful=yes,bits=1
+    mayerrobert-cl-wheel-opt;6020;5.008;1;algorithm=wheel,faithful=yes,bits=1
+    mayerrobert-cl-words;4022;5.007;1;algorithm=base,faithful=no,bits=1
 
-Using sbcl 2.1.6 on Windows 10/ WSL2/ debian 10.9, 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz I get
+
+Using the provided dockerfile with podman on Fedora33, Pentium(R) Dual Core T4300 @ 2.10GHz I get
+
+    $ podman build -t lisp2 .
+    $ podman run --rm lisp2 2> /dev/null
+    mayerrobert-cl;3388;5.000176;1;algorithm=base,faithful=yes,bits=1
+    mayerrobert-cl-hashdot;174503774;5.000176;1;algorithm=base,faithful=no,bits=1
+    mayerrobert-cl-wheel;5716;5.000177;1;algorithm=wheel,faithful=yes,bits=1
+    mayerrobert-cl-wheel-bitvector;7171;5.000176;1;algorithm=wheel,faithful=yes,bits=1
+    mayerrobert-cl-wheel-opt;6213;5.000177;1;algorithm=wheel,faithful=yes,bits=1
+    mayerrobert-clb;2373;5.001176;1;algorithm=base,faithful=yes,bits=1
+    mayerrobert-cl-words;4236;5.000176;1;algorithm=base,faithful=no,bits=1
+
+
+Using sbcl 2.1.7 on Windows 10, 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz (max turbo frequency 4.2 GHz) I get
+
+    mayerrobert-cl;9320;5.000174;1;algorithm=base,faithful=yes,bits=1
+    mayerrobert-cl-hashdot;274020057;5.000001;1;algorithm=base,faithful=no,bits=1
+    mayerrobert-clb;6130;5.000712;1;algorithm=base,faithful=yes,bits=1
+    mayerrobert-cl-wheel;17894;5.000222;1;algorithm=wheel,faithful=yes,bits=1
+    mayerrobert-cl-wheel-bitvector;24388;5.000181;1;algorithm=wheel,faithful=yes,bits=1
+    mayerrobert-cl-wheel-opt;19478;5.000096;1;algorithm=wheel,faithful=yes,bits=1
+    mayerrobert-cl-words;10882;5.000439;1;algorithm=base,faithful=no,bits=1
+
+
+Using sbcl 2.1.7 on Windows 10/ WSL2/ debian 10.9, 11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz (max turbo frequency 4.2 GHz) I get
 
     $ ./run.sh 2>/dev/null
-    mayerrobert-cl;3610;5.0;1;algorithm=base,faithful=yes,bits=1
-    mayerrobert-cl-wheel;16183;5.0;1;algorithm=wheel,faithful=yes,bits=1
-    mayerrobert-cl-wheel-opt;16053;5.0;1;algorithm=wheel,faithful=yes,bits=1
-    mayerrobert-clb;5348;5.0;1;algorithm=base,faithful=yes,bits=1
-    mayerrobert-cl-words;11692;5.0;1;algorithm=base,faithful=no,bits=1
+    mayerrobert-cl;9504;5.01;1;algorithm=base,faithful=yes,bits=1
+    mayerrobert-cl-hashdot;509110305;5.01;1;algorithm=base,faithful=no,bits=1
+    mayerrobert-cl-wheel;15479;5.0;1;algorithm=wheel,faithful=yes,bits=1
+    mayerrobert-cl-wheel-bitvector;19903;5.01;1;algorithm=wheel,faithful=yes,bits=1
+    mayerrobert-cl-wheel-opt;16653;5.01;1;algorithm=wheel,faithful=yes,bits=1
+    mayerrobert-clb;6365;5.01;1;algorithm=base,faithful=yes,bits=1
+    mayerrobert-cl-words;11552;5.01;1;algorithm=base,faithful=no,bits=1
+

--- a/PrimeLisp/solution_2/bitvector-set-2.0.0-2.1.8-snap.lisp
+++ b/PrimeLisp/solution_2/bitvector-set-2.0.0-2.1.8-snap.lisp
@@ -1,0 +1,60 @@
+; change the way "simple-bitvector-set immediate" is compiled
+; uses the method of SBCL 2.1.8
+; intended for SBCL 2.0.0
+
+(in-package "SB-VM")
+
+(defun bit-base (dword-index)
+  (+ (* dword-index 4)
+     (- (* vector-data-offset n-word-bytes) other-pointer-lowtag)))
+
+(defun emit-sbit-op (inst bv index &optional word temp)
+  (cond ((integerp index)
+         (multiple-value-bind (dword-index bit) (floor index 32)
+           (let ((disp (bit-base dword-index)))
+             (cond ((typep disp '(signed-byte 32))
+                    (inst* inst :dword (ea disp bv) bit))
+                   (t                   ; excessive index, really?
+                    (inst mov temp-reg-tn index)
+                    (inst* inst (ea (bit-base 0) bv) temp-reg-tn))))))
+        (t
+         ;; mem/reg BT[SR] are really slow.
+         (inst mov word index)
+         (inst shr word (integer-length (1- n-word-bits)))
+         (inst mov temp (ea (bit-base 0) bv word n-word-bytes))
+         (if (functionp inst)
+             (funcall inst)
+             (if (eq inst 'bts)
+                   (inst bts temp index)
+               (inst btr temp index)))
+         (inst mov (ea (bit-base 0) bv word n-word-bytes) temp))))
+
+(define-vop (data-vector-set-with-offset/simple-bit-vector)
+  (:translate data-vector-set-with-offset)
+  (:policy :fast-safe)
+  ;; Arg order is (VECTOR INDEX ADDEND VALUE)
+  (:arg-types simple-bit-vector positive-fixnum (:constant (eql 0)) positive-fixnum)
+  (:args (bv :scs (descriptor-reg))
+         (index :scs (unsigned-reg))
+         (value :scs (immediate any-reg signed-reg unsigned-reg control-stack
+                                signed-stack unsigned-stack)))
+  (:temporary (:sc unsigned-reg) word temp)
+  (:info addend)
+  (:ignore addend)
+  (:generator 5
+    ;(unpoison-element bv index)
+    (if (sc-is value immediate)
+        (ecase (tn-value value)
+          (1 (emit-sbit-op 'bts bv index word temp))
+          (0 (emit-sbit-op 'btr bv index word temp)))
+        (emit-sbit-op (lambda ()
+                        (assemble ()
+                          (inst test :byte value
+                                (if (sc-is value control-stack signed-stack unsigned-stack) #xff value))
+                          (inst jmp :z ZERO)
+                          (inst bts temp index)
+                          (inst jmp OUT)
+                          ZERO
+                          (inst btr temp index)
+                          OUT))
+                      bv index word temp))))

--- a/PrimeLisp/solution_2/bitvector-set-2.1.7-2.1.8-snap.lisp
+++ b/PrimeLisp/solution_2/bitvector-set-2.1.7-2.1.8-snap.lisp
@@ -1,0 +1,54 @@
+(in-package "SB-VM")
+
+(defun bit-base (dword-index)
+  (+ (* dword-index 4)
+     (- (* vector-data-offset n-word-bytes) other-pointer-lowtag)))
+
+(defun emit-sbit-op (inst bv index &optional word temp)
+  (cond ((integerp index)
+         (multiple-value-bind (dword-index bit) (floor index 32)
+           (let ((disp (bit-base dword-index)))
+             (cond ((typep disp '(signed-byte 32))
+                    (inst* inst :dword (ea disp bv) bit))
+                   (t                   ; excessive index, really?
+                    (inst mov temp-reg-tn index)
+                    (inst* inst (ea (bit-base 0) bv) temp-reg-tn))))))
+        (t
+         ;; mem/reg BT[SR] are really slow.
+         (inst mov word index)
+         (inst shr word (integer-length (1- n-word-bits)))
+         (inst mov temp (ea (bit-base 0) bv word n-word-bytes))
+         (if (functionp inst)
+             (funcall inst)
+             (inst* inst temp index))
+         (inst mov (ea (bit-base 0) bv word n-word-bytes) temp))))
+
+(define-vop (data-vector-set-with-offset/simple-bit-vector)
+  (:translate data-vector-set-with-offset)
+  (:policy :fast-safe)
+  ;; Arg order is (VECTOR INDEX ADDEND VALUE)
+  (:arg-types simple-bit-vector positive-fixnum (:constant (eql 0)) positive-fixnum)
+  (:args (bv :scs (descriptor-reg))
+         (index :scs (unsigned-reg))
+         (value :scs (immediate any-reg signed-reg unsigned-reg control-stack
+                                signed-stack unsigned-stack)))
+  (:temporary (:sc unsigned-reg) word temp)
+  (:info addend)
+  (:ignore addend)
+  (:generator 5
+    (unpoison-element bv index)
+    (if (sc-is value immediate)
+        (ecase (tn-value value)
+          (1 (emit-sbit-op 'bts bv index word temp))
+          (0 (emit-sbit-op 'btr bv index word temp)))
+        (emit-sbit-op (lambda ()
+                        (assemble ()
+                          (inst test :byte value
+                                (if (sc-is value control-stack signed-stack unsigned-stack) #xff value))
+                          (inst jmp :z ZERO)
+                          (inst bts temp index)
+                          (inst jmp OUT)
+                          ZERO
+                          (inst btr temp index)
+                          OUT))
+                      bv index word temp))))


### PR DESCRIPTION
## Description

The biggest performance improvement (and it could be controversial regarding faithfulness) is: I nagged the SBCL maintainers into improving bitvector-set-operations, this will be included in the upcoming SBCL 2.1.8. The file bitvector-set-2.1.7-2.1.8-snap.lisp backpatches this improvement on the fly into the currently used SBCL 2.1.7.

Further improvements:
- loop unrolling in PrimeSieve.lisp and PrimeSievebitops.lisp
- PrimeSieve.lisp uses the Lisp function `position` instead of the first loop
- PrimeSieve.lisp now contains a second (unfaithful) solution that uses `#.`
- PrimeSieveWheelBitvector.lisp is based on PrimeSieveWheelBitOpt.lisp but uses the builtin bitvector instead on manual bit-fiddling
- `(1+ (floor...` was replaced by `(ceiling...` at several places
- some stricter type declarations, some single-use variables were inlined (sbcl's optimizer doesn't like assignments)

Sorry that the diff is fairly large, but I would't know what to leave out.


## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
