### PR TITLE
docs: Fix a few typos

### DIFF
--- a/PrimeBash/solution_1/README.md
+++ b/PrimeBash/solution_1/README.md
@@ -7,7 +7,7 @@
 
 Modified by rbergen as indicated in the source code. Optimizations by Braden "Blzut3" Obrzut.
 
-Contains multiple implemenations as follows:
+Contains multiple implementations as follows:
 
 1. An optimized base implementation written with natural code.
 2. A variation of the base implementation where the bit accessing functions are inlined.

--- a/PrimeCPP/solution_4/storages.hpp
+++ b/PrimeCPP/solution_4/storages.hpp
@@ -340,7 +340,7 @@ class MaskedBitStorage {
 // Bit storage that uses a stride of STORAGE_WIDTH to store consecutive bits.
 // For example using two bytes (uint8_t) to store the bits labeled 0, 1, 2, 3 looks like this using the regular bit storage:
 // 0123xxxx xxxxxxxx
-// With strided bit storage consecutive bits are 8-bits apart, looping around (and incremeneting the bit pos) at the end.
+// With strided bit storage consecutive bits are 8-bits apart, looping around (and incrementing the bit pos) at the end.
 // 02xxxxxx 13xxxxxx
 
 template<typename T, bool Invert = true>

--- a/PrimeForth/solution_1/README.md
+++ b/PrimeForth/solution_1/README.md
@@ -5,7 +5,7 @@
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
 ![Bit count](https://img.shields.io/badge/Bits-1-green)
 
-This is a straighforward port of Dave's algorithm to Forth (tested with GForth).
+This is a straightforward port of Dave's algorithm to Forth (tested with GForth).
 
 The state of the sieve is stored in dictionary-allocated memory, and allocated,
 initialized and deallocated on every iteration.

--- a/PrimeNodeJS/solution_1/README.md
+++ b/PrimeNodeJS/solution_1/README.md
@@ -16,7 +16,7 @@ This implementation is based on the logic from:
 
 **PrimeNode_cluster.js** - Multiprocessor version using cluster API, running batches of sieves on each processor.
 
-**PrimeNode_memcopy** - New algorithm in which the product of a prime is only marked until a certain block range is reached. Thereafter, a block copy algorithm takes over and the reoccuring pattern 4 bytes at a time to different offsets, carefully trying to keep using cpu cache level 1. It follows the basic rules, but is not "base", because it does not follow the rule "*When clearing non-primes in the sieve (the second operation), the algorithm clears all non-primes individually, increasing the number with 2 * factor on each cycle.*"
+**PrimeNode_memcopy** - New algorithm in which the product of a prime is only marked until a certain block range is reached. Thereafter, a block copy algorithm takes over and the recurring pattern 4 bytes at a time to different offsets, carefully trying to keep using cpu cache level 1. It follows the basic rules, but is not "base", because it does not follow the rule "*When clearing non-primes in the sieve (the second operation), the algorithm clears all non-primes individually, increasing the number with 2 * factor on each cycle.*"
 
 ## Run instructions
 Install nodeJS: <https://nodejs.org/en/download/>

--- a/PrimePython/solution_3/PrimePY.py
+++ b/PrimePython/solution_3/PrimePY.py
@@ -4,7 +4,7 @@ Python Prime Sieve using Numpy
 Based on MyFirstPython Program (tm) Dave Plummer 8/9/2018
 Adapted by Emil Sauer Lynge 08/07/2021
 
-This particular version is based on the PrimePython/solution2, whic itself is adapted from Dave Plummer original.
+This particular version is based on the PrimePython/solution2, which itself is adapted from Dave Plummer original.
 """
 import numpy as np
 from math import sqrt

--- a/PrimeScala/solution_1/README.md
+++ b/PrimeScala/solution_1/README.md
@@ -5,11 +5,11 @@
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
 ![Bit count](https://img.shields.io/badge/Bits-unknown-yellowgreen)
 
-This is a Scala implementation of the "drag race" for Scala, targetting both Scala Native (see https://scala-native.org) and the JVM (see https://scala-lang.org)
+This is a Scala implementation of the "drag race" for Scala, targeting both Scala Native (see https://scala-native.org) and the JVM (see https://scala-lang.org)
 
 # Run Instructions
 
-You may compile this scala source targetting either native or the JVM:
+You may compile this scala source targeting either native or the JVM:
 
 - JVM
 


### PR DESCRIPTION
There are small typos in:
- PrimeBash/solution_1/README.md
- PrimeCPP/solution_4/storages.hpp
- PrimeForth/solution_1/README.md
- PrimeNodeJS/solution_1/README.md
- PrimePython/solution_3/PrimePY.py
- PrimeScala/solution_1/README.md

Fixes:
- Should read `targeting` rather than `targetting`.
- Should read `which` rather than `whic`.
- Should read `straightforward` rather than `straighforward`.
- Should read `recurring` rather than `reoccuring`.
- Should read `incrementing` rather than `incremeneting`.
- Should read `implementations` rather than `implemenations`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md