### PR TITLE
C solution 3 Fixed bug in block counter and unrolled main loop

### DIFF
--- a/PrimeC/solution_3/primes_words.c
+++ b/PrimeC/solution_3/primes_words.c
@@ -113,6 +113,10 @@ static inline void block_cross_out(
     unsigned int grow;
     unsigned int end_of_block_idx;
 
+    unsigned int prime_2 = prime * 2;
+    unsigned int prime_3 = prime * 3;
+    unsigned int prime_4 = prime * 4;
+    unsigned int save_len = 0;
     if (prime < 32U) {
         // crossout so we are atleast in the next word
         while (current_word == start_word) {
@@ -149,6 +153,19 @@ static inline void block_cross_out(
                 next_start_index += prime;
             }
             // now apply this mask to all words with steps of the prime
+                        save_len = 0;
+            if (max_word_block > prime_3) {
+                save_len = max_word_block - prime_3;
+            }
+
+            while (current_word <= save_len && save_len !=0) {
+                sieve_state->bit_array[current_word] |=  current_mask;
+                sieve_state->bit_array[current_word + prime] |=  current_mask;
+                sieve_state->bit_array[current_word + prime_2] |=  current_mask;
+                sieve_state->bit_array[current_word + prime_3] |=  current_mask;
+                current_word += prime_4;
+            }
+
             while (current_word <= max_word_block) {
                 sieve_state->bit_array[current_word] |=  current_mask;
                 current_word += prime;
@@ -169,7 +186,11 @@ static inline void block_cross_out(
             current_word = next_start_index >> SHIFT;
             start_word = current_word;
         }
-        max_word_block = max_word;
+
+        max_word_block += BLOCK_SIZE;
+        if (max_word_block > max_word) {
+            max_word_block = max_word;
+        }
     }
 }
 

--- a/PrimeC/solution_3/primes_words.c
+++ b/PrimeC/solution_3/primes_words.c
@@ -153,7 +153,7 @@ static inline void block_cross_out(
                 next_start_index += prime;
             }
             // now apply this mask to all words with steps of the prime
-                        save_len = 0;
+            save_len = 0;
             if (max_word_block > prime_3) {
                 save_len = max_word_block - prime_3;
             }


### PR DESCRIPTION
## Description
Fixed bug in block counter. The code was processing first one block and after that the rest. For a sieve size of 1.000.000 and a L1 cache of 32 kb that does not matter because there are only two block. However, in case of smaller block sizes this would make one small block and then the rest.

Took the opportunity to also unroll the main loop a bit. On my hardware this gives a 15% performance improvement.

## Contributing requirements

* [X] I read the contribution guidelines in CONTRIBUTING.md.
* [X] I placed my solution in the correct solution folder.
* [X] I added a README.md with the right badge(s).
* [X] I added a Dockerfile that builds and runs my solution.
* [X] I selected `drag-race` as the target branch.
* [X] All code herein is licensed compatible with BSD-3.
