### PR TITLE
FSharp "unpeeled" solution_4 made to conform...

### DIFF
--- a/PrimeFSharp/solution_4/README.md
+++ b/PrimeFSharp/solution_4/README.md
@@ -1,11 +1,11 @@
-# F# Solution by GordonBGood
+# F# "Unpeeled" Solution by GordonBGood
 
 ![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
 ![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
 ![Bit count](https://img.shields.io/badge/Bits-1-green)
 
-Algorithm is similar to Rust "striped" version (which I call "Loop Unpeeling") but implemented functionally with recursive function loops;  no direct mutation is used other than for the contents of the sieving buffer array.
+This algorithm is similar to the Rust "striped" version, just differing in the order in which the culling/marking of composite number representation bits is done but with all marking culling done in inner "loops" as per found base prime value factors in the outer "loop" as per the `base` specification.  It is implemented functionally with recursive function loops;  no direct mutation is used other than for the contents of the sieving buffer array.
 
 ## Run instructions
 - [.NET >= 5.0](https://dotnet.microsoft.com/download/dotnet/5.0)
@@ -16,14 +16,14 @@ A Dockerfile has been provided.
 
 ## Output on Intel SkyLake i5-6500 (3.6 Ghz when single-threading as here)
 ```
-GordonBGood_unpeeling;8465;5.00028;1;algorithm=base,faithful=yes,bits=1
+Passes: 9289, Time: 5.000420, Avg: 0.000538, Limit: 1000000, Count: 78498, Valid: true
 ```
 
 ## Original Output
 
 CPU Used:  Intel SkyLake i5-6500 (3.6 Ghz when single-threading as here)
 
-### F# [Unpeeling](PrimeSieveFsharp_Unpeeling) (_this solution_)
+### F# [Unpeeled](PrimeSieveFsharp_Unpeeling) (_this solution_)
 ```
 Passes: 8543, Time: 5.00022, Avg: 0.00059, Limit: 1000000, Count: 78498, Valid: true
 ```
@@ -74,6 +74,6 @@ Passes: 18, Time: 5.09651, Avg: 0.28314, Limit: 1000000, Count: 78498, Valid: Tr
 ```
 ## Notes
 
-This version implementation is the same as the Rust "striped" version, which is categorized as `faithful base` because it has an outer loop to find the odd base prime values and (in this case) inner loops to mark the composite number representations that are multiples of the found outer loop base prime values.  These implementations are faster than the common implementations because the eight outer loops just set up the mask and start byte index for the inner loops which do all the work but with a simpler loop due to using a constant mask value and indexing by bytes rather than "bit-twiddling".
+This version implementation is similar to the Rust "striped" version, which is categorized as `faithful base` because it has an outer loop to find the odd base prime values and (in this case) inner loops to mark the composite number representations that are multiples of the found outer loop base prime values.  These implementations are faster than the common implementations because the eight outer loops just set up the mask and start byte index for the inner loops which do all the work but with a simpler loop due to using a constant mask value and indexing by bytes rather than "bit-twiddling".
 
-The F# code that implements these double loops is in lines 33 to 39.  This code also elides the normal compiler automatic array bounds check by including the array length as part of the loop limit condition at code line 37 so that the compiler realizes that the bounds check is already done as part of the loop limit.
+The F# outer loop code finding each of the base prime factor values starts at line 27 and the code that implements these double loops is in lines 33 to 41.  This code also elides the normal compiler automatic array bounds check by including the array length as part of the loop limit condition at code line 37 so that the compiler realizes that the bounds check is already done as part of the loop limit.


### PR DESCRIPTION
## Description

Rather than return a lazy sequence that contains the fully sieved composite number sieve buffer as a captured value in the included-in-the-sequence-closure's environment, this version returns the said buffer directly from the `newPrimeSieve` generator function, and a separate `primes` function can then be used to enumerate the result primes so that they can be counted by `Seq.length` for validation as part of the printing of the results outside the timing loop.

Thus, it is clear that the sieve buffer has been fully sieved inside the timing loop and only the enumeration and counting of the resulting number of primes is outside the timing.

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
