### PR TITLE
Add minified JSON formatter to benchmark tool

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -354,6 +354,7 @@ Here are the supported values:
 * chart
 * csv
 * json (this also includes the machine information data)
+* minifiedjson (same as json, but not pretty-printed)
 
 The output format can be controlled via the `FORMATTER` variable like this:
 

--- a/tools/src/formatter_factory.ts
+++ b/tools/src/formatter_factory.ts
@@ -2,6 +2,7 @@ import { IFormatter } from './formatter';
 import { TableFormatter } from './formatters/table';
 import { ChartFormatter } from './formatters/chart';
 import { JSONFormatter } from './formatters/json';
+import { MinifiedJSONFormatter } from './formatters/minifiedjson';
 import { CsvFormatter } from './formatters/text';
 
 export default class FormatterFactory {
@@ -13,6 +14,8 @@ export default class FormatterFactory {
         return new ChartFormatter();
       case 'json':
         return new JSONFormatter();
+      case 'minifiedjson':
+        return new MinifiedJSONFormatter();
       case 'csv':
         return new CsvFormatter();
       default:

--- a/tools/src/formatters/minifiedjson.ts
+++ b/tools/src/formatters/minifiedjson.ts
@@ -1,0 +1,8 @@
+import { Report } from '../models';
+import { IFormatter } from '../formatter';
+
+export class MinifiedJSONFormatter implements IFormatter {
+  render(report: Report): string {
+    return JSON.stringify(report);
+  }
+}


### PR DESCRIPTION
This adds a new formatter to the benchmark tool that outputs "minified JSON", that being JSON with all whitespace removed. It's primarily intended for use in automated benchmark runs that post their reports for consumption by/with PrimeView; it decreases the size of the report files with approximately 35%.