### PR TITLE
Increased performance of SML solution from 416 to 1252 iterations

### DIFF
--- a/PrimeStandardML/solution_1/README.md
+++ b/PrimeStandardML/solution_1/README.md
@@ -32,5 +32,5 @@ A Dockerfile has been provided.
 
 ## Output
 ```
-NotMatthewGriffin_SML;416;5.015;1;algorithm=base,faithful=yes,bits=1
+NotMatthewGriffin_SML;1252;5.003;1;algorithm=base,faithful=yes,bits=1
 ```

--- a/PrimeStandardML/solution_1/sml_primes.sml
+++ b/PrimeStandardML/solution_1/sml_primes.sml
@@ -52,8 +52,8 @@ fun create_sieve limit =
                             (* Clear prime's multiples *)
                             val clear_start = new_factor * new_factor
                             val increment = new_factor * 2
-                            val clear_indices = until (fn x => x > limit) (map (fn x => x * increment + clear_start) (count 0))
-                            val _ = app clear_bit clear_indices
+                            val clear_indices = Vector.tabulate ((limit - clear_start) div increment + 1, fn x => x*increment+clear_start)
+                            val _ = Vector.app clear_bit clear_indices
                         in
                             run (new_factor + 2)
                         end


### PR DESCRIPTION


## Description
<!--
Add your description yere.
-->

By replacing a stream being generated to clear the BitArray with a Vector I was able to increase the number of iterations run in the time limit from 416 to 1252 iterations on my machine.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
