### PR TITLE
[Julia] Add "unrolled modulo" implementation

### DIFF
--- a/PrimeJulia/solution_3/Dockerfile
+++ b/PrimeJulia/solution_3/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /opt/app
 
 COPY *.jl ./
 
-ENTRYPOINT [ "julia", "primes_1of2.jl" ]
+ENTRYPOINT [ "sh", "run.sh" ]

--- a/PrimeJulia/solution_3/Dockerfile
+++ b/PrimeJulia/solution_3/Dockerfile
@@ -2,6 +2,7 @@ FROM julia:1.6-buster
 
 WORKDIR /opt/app
 
-COPY *.jl ./
+COPY primes_*.jl ./
+COPY run.sh ./
 
 ENTRYPOINT [ "sh", "run.sh" ]

--- a/PrimeJulia/solution_3/README.md
+++ b/PrimeJulia/solution_3/README.md
@@ -77,8 +77,11 @@ machines because of the large code size from having to compile and
 inline 64 (8 \* 8) unrolled loop functions, as well as having to decide
 which one to jump to for each start index and skip value.
 
-To illustrate this, you can check the generated `unsafe_clear_factors!`
-function Expr object:
+It might also take some time to precompile the functions before running
+the benchmark proper, especially on older and/or slower machines.
+
+To better explain this implementation, we can take a look at the
+generated `unsafe_clear_factors!` function Expr object:
 
 ```
 julia> generate_final_loop_clearing_function() |> Base.remove_linenums!

--- a/PrimeJulia/solution_3/README.md
+++ b/PrimeJulia/solution_3/README.md
@@ -1,27 +1,50 @@
 # Julia solution by louie-github
+
 ![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
 ![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
 ![Bit count](https://img.shields.io/badge/Bits-1-green)
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
 
-This solution is a port of [PrimeC/solution_2/sieve_1of2.c](../../PrimeC/solution_2/sieve_1of2.c)
-by Daniel Spångberg, with a few small tweaks and Julia-specific
-optimizations. This is a sort-of "low-level" style implementation in
-Julia to get as much as speed as possible out of the language. It is
-*not* designed to be idiomatic Julia code.
+This solution contains mutiple implementations:
 
-This solution requires at least **Julia 1.5** to run. Julia 1.6 is
-recommended and is used in the Docker image.
+1.  [primes_1of2.jl](primes_1of2.jl)
 
-## Description
+- This is a port of [PrimeC/solution_2/sieve_1of2.c](../../PrimeC/solution_2/sieve_1of2.c)
+  by Daniel Spångberg, with a few small tweaks and Julia-specific
+  optimizations. This is a sort-of "low-level" style implementation in
+  Julia to get as much as speed as possible out of the language. It is
+  _not_ designed to be idiomatic Julia code.
+
+2. [primes_unrolled_modulo.jl](primes_unrolled_modulo.jl)
+
+- This implementation was inspired by [PrimeNim/solution_3](../../PrimeNim/solution_3)
+  by GordonBGood. It follows a similar method of setting bits using
+  generated bit masks based on modulo patterns, but does not follow the
+  original implementation entirely, since I can't yet fully understand
+  what's going on in the macro. I simply based this solution off the
+  solution's [README.md](../../PrimeNim/solution_3/README.md), where
+  it is mentioned that there are "eight culling operations per loop"
+  "based on modulo patterns that result from stepping within a (even
+  bits) byte array".
+
+This solution has only been tested with Julia 1.6. Lower versions of
+Julia may work, but are not guaranteed to.
+
+## Descriptions
+
+### primes_1of2.jl
+
+This is currently the simplest implementation.
 
 Instead of using Julia's native `BitVector` type, this solution
 manually implements a bit array using a `Vector{UInt32}` since 32-bit
 integers seem to give the best performance. You can switch which
 unsigned integer type you want to use by changing the line:
+
 ```
 const MainUInt = UInt32
 ```
+
 Change `UInt32` to whichever unsigned integer type you wish to use.
 
 Manual bit shifting and bit masking is employed to both read and set
@@ -35,41 +58,159 @@ does with its native `BitVector` type (see
 [bitarray.jl](https://github.com/JuliaLang/julia/blob/master/base/bitarray.jl)).
 
 This implementation only stores bits for the odd numbers above 3 in an
-"inverted" bit array, i.e., bits are set when the number is *not prime*
-and bits are unset when the number is *prime*. This simplifies the
+"inverted" bit array, i.e., bits are set when the number is _not prime_
+and bits are unset when the number is _prime_. This simplifies the
 set_bit operation slightly (`arr[i] |= mask vs. arr[i] &= ~mask`).
 
+### primes_unrolled_modulo.jl
+
+This implementation is similar to primes_1of2.jl, except that it
+pre-generates every possible bit mask for all the starting indices and
+skip values using modulo patterns.
+
+It then uses an unrolled loop to set the corresponding bits using the
+calculated bit masks. This saves some time since we don't have to do
+a modulo and bit shift each time we set a bit.
+
+To illustrate this, you can check the generated `unsafe_clear_factors!`
+function Expr object:
+
+```
+julia> generate_final_loop_clearing_function() |> Base.remove_linenums!
+quote
+    function unsafe_clear_factors!(arr::Vector{MainUInt}, start::Integer, skip::Integer, stop::Integer)
+        start_modulo = start & 7
+        skip_modulo = skip & 7
+        index = start
+        if stop > skip * 7
+            unrolled_stop = stop - skip * 7
+            if start_modulo == 0
+                if skip_modulo == 0
+                    index = _unrolled_clear_bits_start_0_skip_0(arr, start, skip, unrolled_stop)
+                elseif skip_modulo == 1
+                    index = _unrolled_clear_bits_start_0_skip_1(arr, start, skip, unrolled_stop)
+                elseif skip_modulo == 2
+                    index = _unrolled_clear_bits_start_0_skip_2(arr, start, skip, unrolled_stop)
+                elseif skip_modulo == 3
+                    index = _unrolled_clear_bits_start_0_skip_3(arr, start, skip, unrolled_stop)
+                elseif skip_modulo == 4
+                    index = _unrolled_clear_bits_start_0_skip_4(arr, start, skip, unrolled_stop)
+                elseif skip_modulo == 5
+                    index = _unrolled_clear_bits_start_0_skip_5(arr, start, skip, unrolled_stop)
+                elseif skip_modulo == 6
+                    index = _unrolled_clear_bits_start_0_skip_6(arr, start, skip, unrolled_stop)
+                elseif skip_modulo == 7
+                    index = _unrolled_clear_bits_start_0_skip_7(arr, start, skip, unrolled_stop)
+                end
+            elseif start_modulo == 1
+                if skip_modulo == 0
+                    index = _unrolled_clear_bits_start_1_skip_0(arr, start, skip, unrolled_stop)
+                ...
+```
+
+Looking at an example unrolled bit clearing function, we get:
+
+```
+julia> generate_loop_clearing_function(0, 3, get_modulo_pattern(0, 3, UINT_BIT_LENGTH)) |> Base.remove_linenums!
+quote
+    #= /home/louie/dev/PrimesTemp/PrimeJulia/solution_3/primes_unrolled_modulo.jl:91 =# @inline function _unrolled_clear_bits_start_0_skip_3(arr::Vector{MainUInt}, start::Integer, skip::Integer, unrolled_stop::Integer)
+            index = start
+            #= /home/louie/dev/PrimesTemp/PrimeJulia/solution_3/primes_unrolled_modulo.jl:95 =# @inbounds while index < unrolled_stop
+                    begin
+                        arr[(index + skip * 0) >> 3 + 1] |= 1
+                        arr[(index + skip * 1) >> 3 + 1] |= 8
+                        arr[(index + skip * 2) >> 3 + 1] |= 64
+                        arr[(index + skip * 3) >> 3 + 1] |= 2
+                        arr[(index + skip * 4) >> 3 + 1] |= 16
+                        arr[(index + skip * 5) >> 3 + 1] |= 128
+                        arr[(index + skip * 6) >> 3 + 1] |= 4
+                        arr[(index + skip * 7) >> 3 + 1] |= 32
+                    end
+                    index += skip * 8
+                end
+            return index
+        end
+end
+```
+
+As you can see, the generated functions simply end up creating an
+unrolled loop with pre-calculated bit masks based on the start index
+and the skip value.
+
+These bit masks are pre-calculated based on every possible modulo value
+of both the start index and the skip value. For a bit array using
+integers of bit length _N_, we will have to generate _N_ \* _N_
+unrolled loop functions (_N_ possible start index offsets with _N_
+possible skip value bit mask patterns for each offset).
+
+To decide which unrolled loop function to use, the generated
+`unsafe_clear_factors!` function uses a large if-elseif statement
+(since Julia does not have a switch-case statement) to calculate
+the modulo of the start index and the skip value, and then finds the
+corresponding function. This _should_ be optimized into a computed
+goto by the compiler, but I'm not entirely sure.
+
+This is why the implementation uses a `Vector{UInt8}` so we only have
+to calculate 8 \* 8 or 64 functions. If we used a `Vector{UInt32}`, for
+example, we would have to calculate 32 \* 32 or 1024 functions, each of
+which takes time for Julia to precompile. Plus, the generated code size
+from the the inlined functions would be enormous.
+
+The other parts of running the sieve, such as reading the bits in the
+array and finding the next factor index, are mostly unchanged from
+[primes_1of2.jl](primes_1of2.jl).
+
+## Suggestions and improvements
+
 If you see any room for improvement in the code or have any
-suggestions, don't hesitate to open an issue, pull request (PR), 
+suggestions, don't hesitate to open an issue, pull request (PR),
 Discussion, or the like. Don't forget to tag me at `@louie-github` so I
 can be notified if my personal input is either wanted or needed.
 I'm open to fixing stylistic issues or discussing cosmetic changes to
 the code, but for those, it might be best if you open a Discussion
 first before opening an issue or pull request.
 
-
 ## Run instructions
 
 ### Running locally
 
-First, make sure that you have installed
-[Julia 1.5 or newer](https://julialang.org/downloads/) and have
-verified that your installation works.
+First, make sure that you have installed [Julia](https://julialang.org/downloads/)
+and have verified that your installation works.
 
-To build and run the solution locally, run the following command:
+To build and run a single implementation locally, run the following
+command, replacing `primes_1of2.jl` with the filename of the
+implementation you want to run:
+
 ```
 julia primes_1of2.jl
 ```
 
 Optionally, you can specify a sieve size as an additional command line argument:
+
 ```
 julia primes_1of2.jl 1000
 ```
 
 You can also specify the duration to run the benchmark for after the
 sieve size:
+
 ```
 julia primes_1of2.jl 1000000 10
+```
+
+### Running all implementations at once locally
+
+If you want to run all implementations at once, run:
+
+```
+./run.sh
+```
+
+You can also pass in a sieve size and/or duration as additional
+arguments. These will be passed through to all implementations.
+
+```
+./run.sh 1000000 10
 ```
 
 ### Running in Docker
@@ -84,17 +225,23 @@ docker build --pull -t primejulia-3 .
 ```
 
 2. Run the `primejulia-3` image as a container.
+
 ```
 docker run -it --rm primejulia-3
 ```
+
+This will run all implementations, as it uses [run.sh](run.sh).
+
 You can also pass in a sieve size and/or a duration as additional
 arguments similar to when you run the solution locally:
+
 ```
 docker run -it --rm primejulia-3 1000
 docker run -it --rm primejulia-3 1000000 10
 ```
 
 3. If you want to remove the built Docker image, run:
+
 ```
 docker image rm primejulia-3
 ```
@@ -105,7 +252,6 @@ importantly ARM64 and x86_64. This also helps avoid any possible issues
 caused by Julia's [Tier 3 support for musl](https://julialang.org/downloads/#currently_supported_platforms),
 including Alpine Linux.
 
-
 ## Validating results
 
 The validation code has been moved to a separate file:
@@ -115,32 +261,43 @@ Since 32-bit systems cannot represent the final element of the results
 dictionary (10^10 or 10000000000) in a single `UInt32`, this number is
 skipped when running validate.jl on 32 bit systems.
 
-To validate the results given by [primes_1of2.jl](primes_1of2.jl), run:
+To validate the results given by an implementation, run the following
+command, replacing `primes_1of2.jl` with the implementation you wish
+to test:
+
 ```
-julia validate.jl
+julia validate.jl primes_1of2.jl
 ```
+
 Note that this may take a few minutes to complete.
 
-If you want to verify that primes_1of2.jl does not go out-of-bounds
-when accessing memory since it uses `@inbounds` quite liberally, run
-either primes_1of2.jl or validate.jl with `julia --check-bounds=yes`.
+If you want to verify that an implementation does not go out-of-bounds
+when accessing memory since all of them use the `@inbounds` macro quite
+liberally, run either the implementation `.jl` file or validate.jl with
+`julia --check-bounds=yes`.
+
 ```
 julia --check-bounds=yes primes_1of2.jl
 julia --check-bounds=yes validate.jl
 ```
-Note that this will make the code run a fair bit slower.
 
+Note that this will make the code run a fair bit slower.
 
 ## Output
 
-This is the output from running the solution on a machine with an Intel
-Core i5-9300H CPU and 24 GB of RAM running Windows 10 Home:
+This is an example output from running the solution on a machine with an
+Intel Core i5-9300H CPU and 24 GB of RAM running Ubuntu 20.04 LTS under
+WSL 2 on Windows 10 Home:
+
 ```
-PS D:\Office Files\Programming\Primes> julia primes_1of2.jl
+❯ ./run.sh
 Settings: sieve_size = 1000000 | duration = 5
 Number of trues: 78498
-primes_1of2.jl: Passes: 9146 | Elapsed: 5.0 | Passes per second: 1829.2 | Average pass duration: 0.0005466870763175158
-louie-github_port_1of2;9146;5.0;1;algorithm=base,faithful=yes,bits=1
+primes_1of2.jl: Passes: 10276 | Elapsed: 5.00010085105896 | Passes per second: 2055.1585470168407 | Average pass duration: 0.00048658046429145193
+louie-github_port_1of2;10276;5.00010085105896;1;algorithm=base,faithful=yes,bits=1
+
+Settings: sieve_size = 1000000 | duration = 5
+Number of trues: 78498
+primes_unrolled_modulo.jl: Passes: 15787 | Elapsed: 5.000248908996582 | Passes per second: 3157.2428267712044 | Average pass duration: 0.0003167320522579706
+louie-github_unrolled_modulo;15787;5.000248908996582;1;algorithm=base,faithful=yes,bits=1
 ```
-On said machine, when no heavy tasks are running, the number of passes
-usually ranges between 8900 and 9300.

--- a/PrimeJulia/solution_3/README.md
+++ b/PrimeJulia/solution_3/README.md
@@ -5,7 +5,7 @@
 ![Bit count](https://img.shields.io/badge/Bits-1-green)
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
 
-This solution contains mutiple implementations:
+This solution contains multiple implementations:
 
 1.  [primes_1of2.jl](primes_1of2.jl)
 
@@ -68,9 +68,14 @@ This implementation is similar to primes_1of2.jl, except that it
 pre-generates every possible bit mask for all the starting indices and
 skip values using modulo patterns.
 
-It then uses an unrolled loop to set the corresponding bits using the
-calculated bit masks. This saves some time since we don't have to do
-a modulo and bit shift each time we set a bit.
+It then uses an unrolled loop wrapped in a function to set the
+corresponding bits using the calculated bit masks. This saves some time
+since we don't have to do a modulo and bit shift each time we set a bit.
+
+This implementation will probably run a lot slower, though, on older
+machines because of the large code size from having to compile and
+inline 64 (8 \* 8) unrolled loop functions, as well as having to decide
+which one to jump to for each start index and skip value.
 
 To illustrate this, you can check the generated `unsafe_clear_factors!`
 function Expr object:

--- a/PrimeJulia/solution_3/primes_unrolled_modulo.jl
+++ b/PrimeJulia/solution_3/primes_unrolled_modulo.jl
@@ -46,11 +46,7 @@ This function calculates the modulo patterns used for the factor
 clearing loop. It takes into account both the start index and the skip.
 The modulo patterns of the skip are calculated first, and then shifted
 by the initial offset of the start index.
-
-This function should return a `Vector` of length `bit_length`, even if
-the corresponding modulo pattern is shorter than that.
 """
-
 function get_modulo_pattern(start::Integer, skip::Integer, bit_length::Integer)
     @assert (skip >= 0) "skip must not be less than 0."
     first_modulo = start % bit_length
@@ -163,18 +159,19 @@ function generate_final_loop_clearing_function()
     end
 end
 
-# eval is scary!
+# Doing this to avoid a "Possible method call error" warning in VS Code.
+function unsafe_clear_factors!(
+    arr::Vector{MainUInt}, start::Integer, skip::Integer, stop::Integer
+)
+end
+# This eval should overwrite the above method signature.
 eval(generate_final_loop_clearing_function())
 
 
-@inline function unsafe_clear_factors!(arr::Vector{<:Unsigned}, factor_index::Integer, max_index::Integer)
+@inline function unsafe_clear_factors!(arr::Vector{MainUInt}, factor_index::Integer, max_index::Integer)
     factor = _map_to_factor(factor_index)
-    # This function also uses zero-based indexing calculations similar
-    # to unsafe_find_next_factor_index.
-    zero_index = _div2(factor * factor)
-    # This thing is probably going to show up as a possible method
-    # call error.
-    unsafe_clear_factors!(arr, zero_index, factor, max_index)
+    start_index = _div2(factor * factor)
+    unsafe_clear_factors!(arr, start_index, factor, max_index)
 end
 
 function run_sieve!(sieve::PrimeSieve)

--- a/PrimeJulia/solution_3/primes_unrolled_modulo.jl
+++ b/PrimeJulia/solution_3/primes_unrolled_modulo.jl
@@ -163,6 +163,7 @@ function generate_final_loop_clearing_function()
     end
 end
 
+# eval is scary!
 eval(generate_final_loop_clearing_function())
 
 
@@ -171,6 +172,8 @@ eval(generate_final_loop_clearing_function())
     # This function also uses zero-based indexing calculations similar
     # to unsafe_find_next_factor_index.
     zero_index = _div2(factor * factor)
+    # This thing is probably going to show up as a possible method
+    # call error.
     unsafe_clear_factors!(arr, zero_index, factor, max_index)
 end
 
@@ -182,8 +185,8 @@ function run_sieve!(sieve::PrimeSieve)
     factor_index = UInt(1) # 0 => 1, 1 => 3, 1 => 5, 2 => 7, ...
     @inbounds while factor_index <= max_factor_index
         if iszero(
-            is_not_prime[_div_uint_length(factor_index) + 1] &
-            (1 << _mod_uint_length(factor_index))
+            is_not_prime[factor_index >> UINT_BIT_SHIFT + 1] &
+            (1 << (factor_index & (UINT_BIT_LENGTH - 1)))
         )
             unsafe_clear_factors!(is_not_prime, factor_index, max_bits_index)
         end

--- a/PrimeJulia/solution_3/primes_unrolled_modulo.jl
+++ b/PrimeJulia/solution_3/primes_unrolled_modulo.jl
@@ -53,11 +53,13 @@ the corresponding modulo pattern is shorter than that.
 
 function get_modulo_pattern(start::Integer, skip::Integer, bit_length::Integer)
     @assert (skip >= 0) "skip must not be less than 0."
+    first_modulo = start % bit_length
     modulo_increment = skip % bit_length
-    output = Vector{typeof(modulo_increment)}(undef, bit_length)
-    current_modulo = start % bit_length
-    for index in eachindex(output)
-        output[index] = current_modulo
+    current_modulo = (first_modulo + modulo_increment) % bit_length
+    output = Vector{promote_type(typeof(current_modulo))}()
+    push!(output, first_modulo)
+    while current_modulo != first_modulo
+        push!(output, current_modulo)
         current_modulo += modulo_increment
         current_modulo %= bit_length
     end
@@ -101,10 +103,12 @@ end
 
 # This is really hacky; we are evaluating function definitions in
 # global scope. It's better than manually creating a 700 or so line
-# function, though, I guess.
-for ((start, skip), modulo_pattern) in generate_modulo_patterns(UINT_BIT_LENGTH)
-    eval(generate_loop_clearing_function(start, skip, modulo_pattern))
-end
+# function, though, I guess. It also helps with optimization.
+(function ()
+    for ((start, skip), modulo_pattern) in generate_modulo_patterns(UINT_BIT_LENGTH)
+        eval(generate_loop_clearing_function(start, skip, modulo_pattern))
+    end
+end)()
 
 @inline function _unrolled_clear_bits_finalizer(
     arr::Vector{MainUInt}, start::Integer, skip::Integer, stop::Integer
@@ -119,7 +123,7 @@ end
 # Here we go. The main factor clearing loop. Lots of if-elseif
 # statements. Hopefully Julia can optimize this thing, somehow.
 function generate_final_loop_clearing_function()
-    current_outer_expr = main_if_expr = Expr(:if)
+    prev_outer_expr = current_outer_expr = main_if_expr = Expr(:if)
     for start_modulo in 0:UINT_BIT_LENGTH - 1
         func_prefix = Symbol("_unrolled_clear_bits_start_", start_modulo, "_skip_")
         func_name = Symbol(func_prefix, 0)
@@ -139,11 +143,10 @@ function generate_final_loop_clearing_function()
         push!(current_outer_expr.args, :(start_modulo == $start_modulo))
         push!(current_outer_expr.args, Expr(:block, inner_if_expr))
         push!(current_outer_expr.args, Expr(:elseif))
+        prev_outer_expr = current_outer_expr
         current_outer_expr = current_outer_expr.args[end]
     end
-    # This is *really* hacky. We're removing the final elseif Expr
-    # since it is empty.
-    pop!(main_if_expr.args[end].args[end].args[end].args[end].args[end].args[end].args[end].args)
+    pop!(prev_outer_expr.args)
     return quote
         function unsafe_clear_factors!(
             arr::Vector{MainUInt}, start::Integer, skip::Integer, stop::Integer
@@ -272,32 +275,4 @@ end
 
 if abspath(PROGRAM_FILE) == @__FILE__
     main()
-end
-
-function foo(a, b)
-    if x == 1
-        x * 7
-    elseif x == 2
-        x * 8
-    elseif x == 3
-        x * 9
-    elseif x == 4
-        x * 10
-    elseif x == 5
-        x * 11
-    elseif x == 6
-        x * 12
-    elseif x == 7
-        x * 13
-    elseif x == 8
-        x * 14
-    elseif x == 9
-        x * 15
-    elseif x == 10
-        x * 16
-    elseif x == 11
-        x * 17
-    else
-        x * 0
-    end
 end

--- a/PrimeJulia/solution_3/primes_unrolled_modulo.jl
+++ b/PrimeJulia/solution_3/primes_unrolled_modulo.jl
@@ -1,0 +1,165 @@
+# Solution based on PrimeNim/solution_3 by GordonBGood.
+
+const MainUInt = UInt32
+const _uint_bit_length = sizeof(MainUInt) * 8
+const _div_uint_size_shift = Int(log2(_uint_bit_length))
+
+# Functions like the ones defined below are also used in Julia's Base
+# library to speed up things such as Julia's native BitArray type.
+@inline _mul2(i::Integer) = i << 1
+@inline _div2(i::Integer) = i >> 1
+# Map factor to index (3 => 1, 5 => 2, 7 => 3, ...) and vice versa.
+@inline _map_to_index(i::Integer) = _div2(i - 1)
+@inline _map_to_factor(i::Integer) = _mul2(i) + 1
+# This function also takes inspiration from Base._mod64 (bitarray.jl).
+@inline _mod_uint_size(i::Integer) = i & (_uint_bit_length - 1)
+@inline _div_uint_size(i::Integer) = i >> _div_uint_size_shift
+
+
+struct PrimeSieve
+    sieve_size::UInt
+    is_not_prime::Vector{MainUInt}
+end
+
+# This is more accurate than _div_uint_size(_div2(i)) + 1
+@inline _get_num_uints(i::Integer) = _div_uint_size(
+    # We only store odd numbers starting from 3
+    _div2(
+        # Subtract 2 from i to account for the fact that the first
+        # index maps to 3, not 1.
+        i - 2 + (2 * _uint_bit_length - 1)
+    )
+)
+
+function PrimeSieve(sieve_size::UInt)
+    return PrimeSieve(sieve_size, zeros(MainUInt, _get_num_uints(sieve_size)))
+end
+
+# The main() function uses the UInt constructor; this is mostly useful
+# for testing in the REPL.
+PrimeSieve(sieve_size::Int) = PrimeSieve(UInt(sieve_size))
+
+
+@inline function unsafe_find_next_factor_index(arr::Vector{<:Unsigned}, start_index::Integer, max_index::Integer)
+    # This loop calculates indices as if they are zero-based then adds
+    # 1 when accessing the array since Julia uses 1-based indexing.
+    zero_index = start_index
+    @inbounds while zero_index < max_index
+        if iszero(
+            arr[_div_uint_size(zero_index) + 1] & (MainUInt(1) << _mod_uint_size(zero_index))
+        )
+            return zero_index + 1
+        end
+        zero_index += 1
+    end
+    # UNSAFE: you need to check this in the caller or make sure it
+    # never happens
+    return max_index + 1
+end
+
+@inline function unsafe_clear_factors!(arr::Vector{<:Unsigned}, factor_index::Integer, max_index::Integer)
+    factor = _map_to_factor(factor_index)
+    # This function also uses zero-based indexing calculations similar
+    # to unsafe_find_next_factor_index.
+    zero_index = _div2(factor * factor) - 1
+    @inbounds while zero_index < max_index
+        arr[_div_uint_size(zero_index) + 1] |= MainUInt(1) << _mod_uint_size(zero_index)
+        zero_index += factor
+    end
+end
+
+function run_sieve!(sieve::PrimeSieve)
+    is_not_prime = sieve.is_not_prime
+    sieve_size = sieve.sieve_size
+    max_bits_index = _map_to_index(sieve_size)
+    max_factor_index = _map_to_index(unsafe_trunc(UInt, sqrt(sieve_size)))
+    factor_index = UInt(1) # 1 => 3, 2 => 5, 3 => 7, ...
+    while factor_index <= max_factor_index
+        unsafe_clear_factors!(is_not_prime, factor_index, max_bits_index)
+        factor_index = unsafe_find_next_factor_index(is_not_prime, factor_index, max_factor_index)
+    end
+    return is_not_prime
+end
+
+
+# These functions aren't optimized, but they aren't being benchmarked,
+# so it's fine.
+
+@inline function unsafe_get_bit_at_index(arr::Vector{<:Unsigned}, index::Integer)
+    zero_index = index - 1
+    return @inbounds arr[_div_uint_size(zero_index) + 1] & (MainUInt(1) << _mod_uint_size(zero_index))
+end
+
+function count_primes(sieve::PrimeSieve)
+    arr = sieve.is_not_prime
+    max_bits_index = _map_to_index(sieve.sieve_size)
+    # Since we start clearing factors at 3, we include 2 in the count
+    # beforehand.
+    count = 1
+    for i in 1:max_bits_index
+        if iszero(unsafe_get_bit_at_index(arr, i))
+            count += 1
+        end
+    end
+    return count
+end
+
+function get_found_primes(sieve::PrimeSieve)
+    arr = sieve.is_not_prime
+    sieve_size = sieve.sieve_size
+    max_bits_index = _map_to_index(sieve_size)
+    output = [2]
+    # Int(sieve_size) may overflow if sieve_size is too large (most
+    # likely only a problem for 32-bit systems)
+    for (index, number) in zip(1:max_bits_index, 3:2:Int(sieve_size))
+        if iszero(unsafe_get_bit_at_index(arr, index))
+            push!(output, number)
+        end
+    end
+    return output
+end
+
+function main_benchmark(sieve_size::Integer, duration::Integer)
+    println(stderr, "Settings: sieve_size = $sieve_size | duration = $duration")
+    start_time = time()
+    elapsed = 0
+    passes = 0
+    # Ensure precompilation before we run the main benchmark.
+    sieve_instance = PrimeSieve(sieve_size)
+    run_sieve!(sieve_instance)
+    while elapsed < duration
+        run_sieve!(PrimeSieve(sieve_size))
+        passes += 1
+        elapsed = time() - start_time
+    end
+    println(stderr, "Number of trues: ", count_primes(sieve_instance))
+    println(
+        stderr,
+        "primes_unrolled_modulo.jl: ",
+        join(
+            [
+                "Passes: $passes",
+                "Elapsed: $elapsed",
+                "Passes per second: $(passes / elapsed)",
+                "Average pass duration: $(elapsed / passes)",
+            ],
+            " | ",
+        )
+    )
+    println("louie-github_unrolled_modulo;$passes;$elapsed;1;algorithm=base,faithful=yes,bits=1")
+end
+
+function main(args::Vector{String}=ARGS)
+    args_sieve_size = length(args) >= 1 ? tryparse(Int, args[1]) : nothing
+    args_duration = length(args) >= 2 ? tryparse(Int, args[2]) : nothing
+    # Techincally, we could just keep sieve_size as an Int since we
+    # have an Int constructor for PrimeSieve, but let's just use UInt
+    # to be consistent.
+    sieve_size = isnothing(args_sieve_size) ? UInt(1_000_000) : UInt(args_sieve_size)
+    duration = isnothing(args_duration) ? 5 : args_duration
+    main_benchmark(sieve_size, duration)
+end
+
+if abspath(PROGRAM_FILE) == @__FILE__
+    main()
+end

--- a/PrimeJulia/solution_3/run.sh
+++ b/PrimeJulia/solution_3/run.sh
@@ -1,0 +1,4 @@
+for primes_jl_f in primes_*.jl; do
+    julia $primes_jl_f "$@"
+    echo >&2
+done

--- a/PrimeJulia/solution_3/run.sh
+++ b/PrimeJulia/solution_3/run.sh
@@ -1,4 +1,4 @@
 for primes_jl_f in primes_*.jl; do
-    julia $primes_jl_f "$@"
+    julia "$primes_jl_f" "$@"
     echo >&2
 done

--- a/PrimeJulia/solution_3/test.jl
+++ b/PrimeJulia/solution_3/test.jl
@@ -1,0 +1,5 @@
+:(
+    function a(b, c, d)
+    return b + c + d
+end
+)

--- a/PrimeJulia/solution_3/validate.jl
+++ b/PrimeJulia/solution_3/validate.jl
@@ -1,4 +1,7 @@
-include("primes_1of2.jl")
+if length(ARGS) != 1
+    error("Please specify the filename of the implementation you wish to test.")
+end
+include(ARGS[1])
 
 # Taken from PrimeCPP/solution_1/PrimeCPP.cpp
 const resultsDictionary = Dict(


### PR DESCRIPTION
## Description
<!--
Add your description yere.
-->
Hello! I've decided to give up on the proposed refactor of Julia/solution_3 since I can't really see the benefits of it in retrospect, but I do still wish to add another implementation.

This "unrolled_modulo" implementation is based off [PrimeNim/solution_3](https://github.com/PlummersSoftwareLLC/Primes/tree/drag-race/PrimeNim/solution_3) by @GordonBGood, but I don't really think that I implemented exactly the same algorithm.

Rather, I read the README and noticed the line about "modulo patterns", and so I decided to try to write my own solution based on modulo patterns. I'd appreciate if they could clarify if what I'm doing is even remotely close to the "extreme loop unrolling" that they've written, but either way, I think that this is an interesting variation on the base faithful algorithm.

In short, this implementation creates 64 unrolled loop function based on every possible modulo pattern for an 8-bit array (8 for start index offset and 8 for skip value patterns), and decides which function to use through a large generated if-elseif statement inside the main factor clearing function. This speeds things up by avoiding bit shift operations, but only on CPUs which have enough speed to overcome the overhead of having to go to the correct function based on the start index and skip value.

I'm not sure whether string manipulation in this case would have been easier than mangling Julia Expr objects. It's a bit of a mess, honestly. Sorry about that.

This implementation is faster than [primes_1of2.jl](https://github.com/PlummersSoftwareLLC/Primes/blob/drag-race/PrimeJulia/solution_3/primes_1of2.jl), but not as fast as Nim/solution_3. The README contains an example output.

I wanted to write a striped solution, but I need some more time to finalize it before submitting it. I wrote this "modulo unrolled" implementation in the meantime since I felt it was a fun challenge and a fun variation, even if it's not necessarily the fastest Julia implementation. That would be the "unpeeled" [PrimeJulia/solution_4](https://github.com/PlummersSoftwareLLC/Primes/tree/drag-race/PrimeJulia/solution_4) by none other than @GordonBGood. Amazing!

On another note, I wanted to release this under the MIT License, but I don't know if this is different enough from PrimeNim/solution_3 that I could consider doing that without prior permission. I think that I could probably release primes_1of2.jl under the MIT License since each implementation is simple enough that any developer could reasonably come up with the optimizations on their own? I really don't know, but I just wanted to say that if I could, I would apply the MIT License to my code.

Thank you for your time!

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [X] I read the contribution guidelines in CONTRIBUTING.md.
* [X] I placed my solution in the correct solution folder.
* [X] I added a README.md with the right badge(s).
* [X] I added a Dockerfile that builds and runs my solution.
* [X] I selected `drag-race` as the target branch.
* [X] All code herein is licensed compatible with BSD-3.
