### PR TITLE
CI publish Docker images

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -99,5 +99,5 @@ jobs:
       - name: Scan image
         uses: anchore/scan-action@v2
         with:
-          image: ${{ steps.solution-name.outputs.normalized }}
+          image: primeimages/primes:${{ steps.solution-name.outputs.normalized }}
           severity-cutoff: critical

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -77,17 +77,6 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
-      - name: Build arm64
-        if: steps.arch-arm64.outputs.build
-        uses: docker/build-push-action@v2
-        with:
-          tags: primeimages/primes:${{ steps.solution-name.outputs.normalized }}
-          context: ${{ matrix.solution }}
-          platforms: linux/arm64
-          push: true
-          cache-from: type=registry,ref=primeimages/primes:${{ steps.solution-name.outputs.normalized }}
-          cache-to: type=inline
-
       - name: Build amd64
         if: steps.arch-amd64.outputs.build
         uses: docker/build-push-action@v2
@@ -95,6 +84,17 @@ jobs:
           tags: primeimages/primes:${{ steps.solution-name.outputs.normalized }}
           context: ${{ matrix.solution }}
           platforms: linux/amd64
-          push: true
+          push: ${{ github.ref == 'refs/heads/drag-race' }}
+          cache-from: type=registry,ref=primeimages/primes:${{ steps.solution-name.outputs.normalized }}
+          cache-to: type=inline
+      
+      - name: Build arm64
+        if: steps.arch-arm64.outputs.build
+        uses: docker/build-push-action@v2
+        with:
+          tags: primeimages/primes:${{ steps.solution-name.outputs.normalized }}
+          context: ${{ matrix.solution }}
+          platforms: linux/arm64
+          push: ${{ github.ref == 'refs/heads/drag-race' }}
           cache-from: type=registry,ref=primeimages/primes:${{ steps.solution-name.outputs.normalized }}
           cache-to: type=inline

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,13 +36,27 @@ jobs:
     steps:
       - name: "Checkout code"
         uses: actions/checkout@v2
-      
+
       - name: "Normalize solution name"
         id: solution-name
         run: |
-          NAME=$(echo "${{ matrix.solution }}" | sed -r 's/\//_/g' | tr '[:upper:]' '[:lower:]')
+          NAME=$(echo "${{ matrix.solution }}" | sed -r 's/\//-/g' | tr '[:upper:]' '[:lower:]' | sed -r 's/(prime|solution_)//g')
           echo "::set-output name=normalized::${NAME}"
-      
+
+      - name: Select arm64 build for solutions with arm64 flag file
+        id: arch-arm64
+        run: |
+          if [[ -f "${{ matrix.solution }}/arch-arm64" ]]; then
+          echo "::set-output name=build::true"
+          fi
+
+      - name: Select amd64 build for solutions with amd64 or no flag file
+        id: arch-amd64
+        run: |
+          if [[ -f "${{ matrix.solution }}/arch-amd64" || ! -f "${{ matrix.solution }}/arch-arm64" ]]; then
+          echo "::set-output name=build::true"
+          fi
+
       - name: Lint Dockerfile
         uses: jbergstroem/hadolint-gh-action@v1
         with:
@@ -57,19 +71,11 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Select arm64 build for solutions with arm64 flag file
-        id: arch-arm64
-        run: |
-          if [[ -f "${{ matrix.solution }}/arch-arm64" ]]; then 
-          echo "::set-output name=build::true"
-          fi
-
-      - name: Select amd64 build for solutions with amd64 or no flag file
-        id: arch-amd64
-        run: |
-          if [[ -f "${{ matrix.solution }}/arch-amd64" || ! -f "${{ matrix.solution }}/arch-arm64" ]]; then 
-          echo "::set-output name=build::true"
-          fi
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build arm64
         if: steps.arch-arm64.outputs.build
@@ -85,15 +91,13 @@ jobs:
         if: steps.arch-amd64.outputs.build
         uses: docker/build-push-action@v2
         with:
-          tags: ${{ steps.solution-name.outputs.normalized }}
+          tags: primeimages/primes:${{ steps.solution-name.outputs.normalized }}
           context: ${{ matrix.solution }}
           platforms: linux/amd64
-          push: false
-          load: true
-      
+          push: true
+
       - name: Scan image
         uses: anchore/scan-action@v2
         with:
           image: ${{ steps.solution-name.outputs.normalized }}
           severity-cutoff: critical
-          

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -85,6 +85,8 @@ jobs:
           context: ${{ matrix.solution }}
           platforms: linux/arm64
           push: true
+          cache-from: type=registry,ref=primeimages/primes:${{ steps.solution-name.outputs.normalized }}
+          cache-to: type=inline
 
       - name: Build amd64
         if: steps.arch-amd64.outputs.build
@@ -94,6 +96,8 @@ jobs:
           context: ${{ matrix.solution }}
           platforms: linux/amd64
           push: true
+          cache-from: type=registry,ref=primeimages/primes:${{ steps.solution-name.outputs.normalized }}
+          cache-to: type=inline
 
       - name: Scan image
         uses: anchore/scan-action@v2

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -98,9 +98,3 @@ jobs:
           push: true
           cache-from: type=registry,ref=primeimages/primes:${{ steps.solution-name.outputs.normalized }}
           cache-to: type=inline
-
-      - name: Scan image
-        uses: anchore/scan-action@v2
-        with:
-          image: primeimages/primes:${{ steps.solution-name.outputs.normalized }}
-          severity-cutoff: critical

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -81,11 +81,10 @@ jobs:
         if: steps.arch-arm64.outputs.build
         uses: docker/build-push-action@v2
         with:
-          tags: ${{ steps.solution-name.outputs.normalized }}
+          tags: primeimages/primes:${{ steps.solution-name.outputs.normalized }}
           context: ${{ matrix.solution }}
           platforms: linux/arm64
-          push: false
-          load: true
+          push: true
 
       - name: Build amd64
         if: steps.arch-amd64.outputs.build


### PR DESCRIPTION
Publishing Docker images in Docker Hub from the default branch. Also makes use of caching to speed up the builds in GitHub Actions.

Remove Docker scanning, will delegate this to Docker Hub later.