### PR TITLE
Pin PrimeCython/solution_1 base image to python:3.9.5

### DIFF
--- a/PrimeCython/solution_1/Dockerfile
+++ b/PrimeCython/solution_1/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9
+FROM python:3.9.5
 
 WORKDIR /root
 


### PR DESCRIPTION
This pins PrimeCython/solution_1/Dockerfile to base image python:3.9.5 instead of python:3.9. This fixes #651.