### PR TITLE
Fix docker push

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -30,7 +30,7 @@ jobs:
 
   build:
     env: 
-      ENABLE_DOCKER_PUSH: ${{ secrets.DOCKER_PASSWORD != '' && github.ref == 'refs/heads/drag-race' }}
+      ENABLE_DOCKER_PUSH: ${{ github.repository_owner == 'PlummersSoftwareLLC' && github.ref == 'refs/heads/drag-race' }}
 
     runs-on: "ubuntu-20.04"
 


### PR DESCRIPTION
This replaces the check in CI if `secret.DOCKER_PASSWORD` is set, with a check if the repository owner is PlummersSoftwareLLC. The reason for this is that the check on existence of a secret doesn't work, as documented in actions/runner#520. The approach I used in #649 is or has been used by many others (one example being mesonbuild/meson#8864), but doesn't work: the `secret.DOCKER_PASSWORD != ''` expression always evaluates to `true`, even when the secret isn't set at all. I found this out by CI failing in my fork when the ref was drag-race.

As I believe we effectively only want to push the images to Docker Hub when there is a push to the main repo (and drag-race branch), I think this is an acceptable alternative solution.