### PR TITLE
Rust - hybrid reset

### DIFF
--- a/PrimeRust/solution_1/README.md
+++ b/PrimeRust/solution_1/README.md
@@ -20,6 +20,37 @@ This is a somewhat Rust-idiomatic version that has the storage of prime flags ab
 
 Note that C++'s `vector<bool>` is a controversial specialisation of `vector` that `*may*` use more efficient storage than using a whole byte for 1 or 0. It's up to the compiler vendor, and is not standardised. Typically it's using individual bits for storage, within bytes or words. So the `bit storage` I have implemented closely resembles this. Rust has no such thing built in, although there are several crates available. For clarity, it's implemented manually in this solution.
 
+## Striped storage
+
+My `striped` variations have proved quite popular, and I'm very pleased to see that the approach has been successfully adopted in a number of other solutions. Given this popularity, it's worth writing a few notes about how they work.
+
+The original `striped` storage algorithm resulted from a hunch I had about the relative cost of creating a mask compared with the cost of applying it. I suspected that the cost of creating the mask, along with the cost of figuring out which address to apply it to, was quite high. So the `striped` storage solution took a slightly different approach to the storage. In the normal, linear, case, we store bits like the following. Pretend we have just two bytes of storage.
+
+```
+word0: [0   1   2   3   4   5   6   7], 
+word1: [8   9  10  11  12  13  14  15], 
+```
+
+In the `striped` storage case, we essentially _transpose_ this layout like this:
+
+```
+word0: [0   2   4   6   8  10  12  14]
+word1: [1   3   5   7   9  11  13  15]
+```
+
+This allows us to set a single mask for the first bit, then apply it with very regular `skip` factors to _all_ the words. Then proceed to calculate the mask for the second bit, and apply it to all the words again. This works really well, but it's not perfect: we're looping over all the words multiple times, and this has poor _locality_: we land up thrashing the cache, particularly on smaller processors.
+
+This brings us to the later algorithm, `striped-blocks`, that addresses this locality problem by splitting the problem into smaller chunks (blocks) of 16kB or 4kB. Instead of looping over all the words in the sieve and thrashing the cache, we apply the masks for each bit in turn to the first block. Once we're done with the first block, we proceed to the next. The compiler may be able to optimise it slightly better with known block sizes too, but I'm not sure if this is the case.
+
+Most recently, I've added an optional feature called `HYBRID` to `striped-blocks` that has a specific algorithm for resetting bits when we have smaller skip factors. The motivation for this is that we're typically touching every word in the block with small skip factors, and typically having to reset multiple bits in each word. We're not allowed to reset multiple bits in one operation, but we're definitely able to apply multiple (separate, single-bit) masks to a single word before proceeding to the next word. 
+
+This variation calculates the masks that will need to be applied: 8 of them, one for each bit, for each index. We have `SKIP` indices we need to keep track of, as the pattern repeats. So we can calculate all these masks before we loop through the words, then apply them in a very mechanical way with very little calculation required. Because the method is generic over the `SKIP` factor, the compiler can be quite aggressive with the loop optimisation. This seems to result in a 10-20% improvement in performance. And I think it's quite a fun application of const generics in Rust. 
+
+Part of the inspiration for this hybrid algorithm comes from the work of two people, whom I gratefully acknowledge here: 
+
+- @ItalyToast for the novel approach to resetting bits in a dense way in the traditional linear sieve in `PrimeCSharp/solution_4`. It got me thinking about how I could potentially apply a similar technique to the `striped-blocks`, although it required a bit of thinking.
+- @GordonBGood for his really interesting `PrimeNim/solution_3` implementation. I definitely had a good think about how I could apply a similar code-gen approach in Rust, and there's some interesting stuff I could potentially do with procedural macros. Before trying that, I decided to see what I could do with const generics and calculating masks, and that path led me to the hybrid algorithm.
+
 ## Run instructions
 
 - using Docker is the easiest way to get started without installing Rust:

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -241,8 +241,8 @@ pub mod primes {
     /// There is a computation / memory bandwidth tradeoff here. This works well
     /// only for sieves that fit inside the processor cache. For processors with
     /// smaller caches or larger sieves, this algorithm will result in a lot of
-    /// cache thrashing due to multiple passes. It really doesn't work well on something 
-    /// like a raspberry pi. 
+    /// cache thrashing due to multiple passes. It really doesn't work well on something
+    /// like a raspberry pi.
     ///
     /// [`FlagStorageBitVectorStripedBlocks`] takes a more cache-friendly approach.
     pub struct FlagStorageBitVectorStriped {
@@ -319,7 +319,7 @@ pub mod primes {
     /// This is a variation of [`FlagStorageBitVectorStriped`] that has better locality.
     /// The striped storage is divided up into smaller blocks, and we do multiple
     /// passes over the smaller block rather than the entire sieve.
-    pub struct FlagStorageBitVectorStripedBlocks<const N: usize> {
+    pub struct FlagStorageBitVectorStripedBlocks<const N: usize, const HYBRID: bool> {
         blocks: Vec<[u8; N]>,
         length_bits: usize,
     }
@@ -333,27 +333,97 @@ pub mod primes {
     /// in parallel.
     pub const BLOCK_SIZE_SMALL: usize = 4 * 1024;
 
-    impl<const N: usize> FlagStorageBitVectorStripedBlocks<N> {
-        const BLOCK_SIZE: usize = N;
-        const BLOCK_SIZE_BITS: usize = Self::BLOCK_SIZE * U8_BITS;
-    }
+    impl<const BLOCK_SIZE: usize, const HYBRID: bool>
+        FlagStorageBitVectorStripedBlocks<BLOCK_SIZE, HYBRID>
+    {
+        const BLOCK_SIZE_BITS: usize = BLOCK_SIZE * U8_BITS;
 
-    impl<const N: usize> FlagStorage for FlagStorageBitVectorStripedBlocks<N> {
-        fn create_true(size: usize) -> Self {
-            let num_blocks = size / Self::BLOCK_SIZE_BITS + (size % Self::BLOCK_SIZE_BITS).min(1);
-            Self {
-                length_bits: size,
-                blocks: vec![[u8::MAX; N]; num_blocks],
+        fn should_reset(index: usize, start: usize, skip: usize) -> u8 {
+            let rel = index as isize - start as isize;
+            if rel % skip as isize == 0 {
+                1
+            } else {
+                0
             }
         }
 
         #[inline(always)]
-        fn reset_flags(&mut self, start: usize, skip: usize) {
+        fn reset_flags_dense<const SKIP: usize>(&mut self) {
+            // earliest start to avoid resetting the factor itself
+            let start = SKIP / 2 + SKIP;
+            debug_assert!(
+                start < BLOCK_SIZE,
+                "algorithm only correct for small skip factors"
+            );
+            for (block_idx, block) in self.blocks.iter_mut().enumerate() {
+                // Preserve the first bit of one word we know we're going to overwrite
+                // with the masks. Its cheaper to put it back afterwards than break the loop
+                // into two sections with different rules. Only applicable on the first block:
+                // this is the factor itself, and we don't want to reset that flag.
+                let preserved_word_mask = if block_idx == 0 {
+                    block[SKIP / 2] & 1
+                } else {
+                    0
+                };
+
+                // Calculate the masks we're going to apply first.
+                // Note that we _could_ calculate a single mask word and apply it,
+                // but I believe that would be against the rules of the competition as
+                // we would be resetting multiple bits in one operation if we did that.
+                let mut mask_set = [[0u8; U8_BITS]; SKIP];
+                for word_idx in 0..SKIP {
+                    for bit in 0..8 {
+                        let block_index_offset = block_idx * BLOCK_SIZE * U8_BITS;
+                        let bit_index_offset = bit * BLOCK_SIZE;
+                        let index = block_index_offset + bit_index_offset + word_idx;
+                        mask_set[word_idx][bit] = !(Self::should_reset(index, start, SKIP) << bit);
+                    }
+                }
+                // rebind as immutable
+                let mask_set = mask_set;
+
+                /// apply all 8 masks - one for each bit - using a fold, mostly
+                /// because folds are fun
+                fn apply_masks(word: &mut u8, masks: &[u8; U8_BITS]) {
+                    *word = masks.iter().fold(*word, |w, mask| w & mask);
+                }
+
+                // run through all exact size chunks; compiler loves to optimise
+                // known sizes
+                block.chunks_exact_mut(SKIP).for_each(|words| {
+                    words
+                        .iter_mut()
+                        .zip(mask_set.iter().copied())
+                        .for_each(|(word, masks)| {
+                            apply_masks(word, &masks);
+                        });
+                });
+
+                // run through the last stub of fewer than SKIP items
+                block
+                    .chunks_exact_mut(SKIP)
+                    .into_remainder()
+                    .iter_mut()
+                    .zip(mask_set.iter().copied())
+                    .for_each(|(word, masks)| {
+                        apply_masks(word, &masks);
+                    });
+
+                // restore the first bit on the preserved word in the first block,
+                // as noted above
+                if block_idx == 0 {
+                    block[SKIP / 2] |= preserved_word_mask;
+                }
+            }
+        }
+
+        #[inline(always)]
+        fn reset_flags_general(&mut self, start: usize, skip: usize) {
             // determine first block, start bit, and first word
             let block_idx_start = start / Self::BLOCK_SIZE_BITS;
             let offset_idx = start % Self::BLOCK_SIZE_BITS;
-            let mut bit_idx = offset_idx / Self::BLOCK_SIZE;
-            let mut word_idx = offset_idx % Self::BLOCK_SIZE;
+            let mut bit_idx = offset_idx / BLOCK_SIZE;
+            let mut word_idx = offset_idx % BLOCK_SIZE;
 
             for block_idx in block_idx_start..self.blocks.len() {
                 // Safety: we have ensured the block_idx < length
@@ -361,9 +431,8 @@ pub mod primes {
                 while bit_idx < U8_BITS {
                     // calculate effective end position: we might have a shorter stripe on the last iteration
                     let stripe_start_position =
-                        block_idx * Self::BLOCK_SIZE_BITS + bit_idx * Self::BLOCK_SIZE;
-                    let effective_len =
-                        Self::BLOCK_SIZE.min(self.length_bits - stripe_start_position);
+                        block_idx * Self::BLOCK_SIZE_BITS + bit_idx * BLOCK_SIZE;
+                    let effective_len = BLOCK_SIZE.min(self.length_bits - stripe_start_position);
 
                     // get mask for this bit position
                     let mask = !(1 << bit_idx);
@@ -390,17 +459,52 @@ pub mod primes {
                     }
 
                     // early termination: this is the last stripe
-                    if effective_len != Self::BLOCK_SIZE {
+                    if effective_len != BLOCK_SIZE {
                         return;
                     }
 
                     // bit/stripe complete; advance to next bit
                     bit_idx += 1;
-                    word_idx -= Self::BLOCK_SIZE;
+                    word_idx -= BLOCK_SIZE;
                 }
 
                 // block complete; reset bit index and proceed with the next block
                 bit_idx = 0;
+            }
+        }
+    }
+
+    impl<const BLOCK_SIZE: usize, const HYBRID: bool> FlagStorage
+        for FlagStorageBitVectorStripedBlocks<BLOCK_SIZE, HYBRID>
+    {
+        fn create_true(size: usize) -> Self {
+            let num_blocks = size / Self::BLOCK_SIZE_BITS + (size % Self::BLOCK_SIZE_BITS).min(1);
+            Self {
+                length_bits: size,
+                blocks: vec![[u8::MAX; BLOCK_SIZE]; num_blocks],
+            }
+        }
+
+        #[inline(always)]
+        fn reset_flags(&mut self, start: usize, skip: usize) {
+            // Reset flags using the dense reset approach if HYBRID
+            // is enabled. Otherwise use the general approach for
+            // all skip factors.
+            if HYBRID {
+                match skip {
+                    // We only really gain an advantage from dense
+                    // resetting up to skip factors under 8, as after
+                    // that, we're expecting the resets to be sparse.
+                    // We only get called for skip factors, so there's
+                    // no point adding cases for even numbers.
+                    1 => self.reset_flags_dense::<1>(),
+                    3 => self.reset_flags_dense::<3>(),
+                    5 => self.reset_flags_dense::<5>(),
+                    7 => self.reset_flags_dense::<7>(),
+                    _ => self.reset_flags_general(start, skip),
+                }
+            } else {
+                self.reset_flags_general(start, skip);
             }
         }
 
@@ -411,8 +515,8 @@ pub mod primes {
             }
             let block = index / Self::BLOCK_SIZE_BITS;
             let offset = index % Self::BLOCK_SIZE_BITS;
-            let bit_index = offset / Self::BLOCK_SIZE;
-            let word_index = offset % Self::BLOCK_SIZE;
+            let bit_index = offset / BLOCK_SIZE;
+            let word_index = offset % BLOCK_SIZE;
             let word = self.blocks.get(block).unwrap().get(word_index).unwrap();
             *word & (1 << bit_index) != 0
         }
@@ -581,6 +685,11 @@ struct CommandLineOptions {
     #[structopt(long)]
     bits_striped_blocks: bool,
 
+    /// Run variant that uses bit-level storage, using striped storage in blocks with
+    /// hybrid dense resets for smaller skip factors
+    #[structopt(long)]
+    bits_striped_hybrid: bool,
+
     /// Run variant that uses byte-level storage
     #[structopt(long)]
     bytes: bool,
@@ -606,6 +715,7 @@ fn main() {
         opt.bits_rotate,
         opt.bits_striped,
         opt.bits_striped_blocks,
+        opt.bits_striped_hybrid,
         opt.bytes,
     ]
     .iter()
@@ -676,7 +786,7 @@ fn main() {
             thread::sleep(Duration::from_secs(1));
             print_header(threads, limit, run_duration);
             for _ in 0..repetitions {
-                run_implementation::<FlagStorageBitVectorStripedBlocks<BLOCK_SIZE_DEFAULT>>(
+                run_implementation::<FlagStorageBitVectorStripedBlocks<BLOCK_SIZE_DEFAULT, false>>(
                     "bit-storage-striped-blocks",
                     1,
                     run_duration,
@@ -687,8 +797,34 @@ fn main() {
             }
 
             for _ in 0..repetitions {
-                run_implementation::<FlagStorageBitVectorStripedBlocks<BLOCK_SIZE_SMALL>>(
+                run_implementation::<FlagStorageBitVectorStripedBlocks<BLOCK_SIZE_SMALL, false>>(
                     "bit-storage-striped-blocks-small",
+                    1,
+                    run_duration,
+                    threads,
+                    limit,
+                    opt.print,
+                );
+            }
+        }
+
+        if opt.bits_striped_hybrid || run_all {
+            thread::sleep(Duration::from_secs(1));
+            print_header(threads, limit, run_duration);
+            for _ in 0..repetitions {
+                run_implementation::<FlagStorageBitVectorStripedBlocks<BLOCK_SIZE_DEFAULT, true>>(
+                    "bit-storage-striped-hybrid",
+                    1,
+                    run_duration,
+                    threads,
+                    limit,
+                    opt.print,
+                );
+            }
+
+            for _ in 0..repetitions {
+                run_implementation::<FlagStorageBitVectorStripedBlocks<BLOCK_SIZE_SMALL, true>>(
+                    "bit-storage-striped-hybrid-small",
                     1,
                     run_duration,
                     threads,
@@ -758,7 +894,7 @@ fn run_implementation<T: 'static + FlagStorage + Send>(
         // print results to stderr for convenience
         print_results_stderr(
             label,
-            &sieve,
+            sieve,
             print_primes,
             duration,
             total_passes,
@@ -791,10 +927,17 @@ mod tests {
     }
 
     #[test]
-    fn sieve_known_correct_bits_striped_blocks() {
+    fn sieve_known_correct_bits_striped_blocks_general() {
         // check both sizes
-        sieve_known_correct::<FlagStorageBitVectorStripedBlocks<BLOCK_SIZE_DEFAULT>>();
-        sieve_known_correct::<FlagStorageBitVectorStripedBlocks<BLOCK_SIZE_SMALL>>();
+        sieve_known_correct::<FlagStorageBitVectorStripedBlocks<BLOCK_SIZE_DEFAULT, false>>();
+        sieve_known_correct::<FlagStorageBitVectorStripedBlocks<BLOCK_SIZE_SMALL, false>>();
+    }
+
+    #[test]
+    fn sieve_known_correct_bits_striped_blocks_hybrid() {
+        // check both sizes
+        sieve_known_correct::<FlagStorageBitVectorStripedBlocks<BLOCK_SIZE_DEFAULT, true>>();
+        sieve_known_correct::<FlagStorageBitVectorStripedBlocks<BLOCK_SIZE_SMALL, true>>();
     }
 
     #[test]
@@ -837,12 +980,21 @@ mod tests {
     }
 
     #[test]
-    fn storage_bit_striped_block_correct() {
+    fn storage_bit_striped_block_general_correct() {
         // test small as well as default block sizes
-        basic_storage_correct::<FlagStorageBitVectorStripedBlocks<7>>();
-        basic_storage_correct::<FlagStorageBitVectorStripedBlocks<1024>>();
-        basic_storage_correct::<FlagStorageBitVectorStripedBlocks<BLOCK_SIZE_SMALL>>();
-        basic_storage_correct::<FlagStorageBitVectorStripedBlocks<BLOCK_SIZE_DEFAULT>>();
+        basic_storage_correct::<FlagStorageBitVectorStripedBlocks<7, false>>();
+        basic_storage_correct::<FlagStorageBitVectorStripedBlocks<1024, false>>();
+        basic_storage_correct::<FlagStorageBitVectorStripedBlocks<BLOCK_SIZE_SMALL, false>>();
+        basic_storage_correct::<FlagStorageBitVectorStripedBlocks<BLOCK_SIZE_DEFAULT, false>>();
+    }
+
+    #[test]
+    fn storage_bit_striped_block_hybrid_correct() {
+        // test small as well as default block sizes
+        basic_storage_correct::<FlagStorageBitVectorStripedBlocks<50, true>>();
+        basic_storage_correct::<FlagStorageBitVectorStripedBlocks<1024, true>>();
+        basic_storage_correct::<FlagStorageBitVectorStripedBlocks<BLOCK_SIZE_SMALL, true>>();
+        basic_storage_correct::<FlagStorageBitVectorStripedBlocks<BLOCK_SIZE_DEFAULT, true>>();
     }
 
     fn basic_storage_correct<T: FlagStorage>() {
@@ -852,10 +1004,11 @@ mod tests {
             assert!(storage.get(i), "expected initially true for index {}", i);
         }
 
-        // not primes; we're just checking the storage works
-        storage.reset_flags(30, 7);
+        // use realistic start values, as hybrid storage makes assumptions
+        // about where to start resetting
+        storage.reset_flags(7, 5);
         for i in 0..size {
-            let expected_inv = (i >= 30) && ((i - 30) % 7 == 0);
+            let expected_inv = (i >= 7) && ((i - 7) % 5 == 0);
             assert_eq!(
                 storage.get(i),
                 !expected_inv,
@@ -864,10 +1017,10 @@ mod tests {
             );
         }
 
-        storage.reset_flags(72, 100);
+        storage.reset_flags(19, 13);
         for i in 0..size {
-            let first = (i >= 30) && ((i - 30) % 7 == 0);
-            let second = (i >= 72) && ((i - 72) % 100 == 0);
+            let first = (i >= 7) && ((i - 7) % 5 == 0);
+            let second = (i >= 19) && ((i - 19) % 13 == 0);
             let expected_inv = first || second;
             assert_eq!(
                 storage.get(i),

--- a/PrimeRust/solution_1/src/main.rs
+++ b/PrimeRust/solution_1/src/main.rs
@@ -532,7 +532,7 @@ pub mod primes {
                     // We only really gain an advantage from dense
                     // resetting up to skip factors under 8, as after
                     // that, we're expecting the resets to be sparse.
-                    // We only get called for skip factors, so there's
+                    // We only get called for odd skip factors, so there's
                     // no point adding cases for even numbers.
                     1 => self.reset_flags_dense::<1>(),
                     3 => self.reset_flags_dense::<3>(),


### PR DESCRIPTION
## Description
I've added a new algorithm (`hybrid`) that is a variation on the `striped-blocks`. Essentially, it's a specific reset algorithm used for small skip factors (under 8) that tackles each word and applies all masks for that word before proceeding to the next.

It can get a bit complicated, so I've added pretty extensive comments in the code, and added a bit of a writeup about the `striped` algorithms to the README, since they're being used in several other solutions now. 

I'm tagging @GordonBGood and @ItalyToast on this change. Hope you don't mind me mentioning you in the README, but your work definitely sparked this latest addition. I don't think it's quite the same as either of your solutions, but there are definitely some common themes. 

Apologies again @rbergen for another complex PR. I think this one is kind of fun though. I think it should be acceptable within the rules, but I'm happy to tweak a few things if you're concerned about any parts of it.

## Contributing requirements
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
