### PR TITLE
Upgraded StandardML solution1 dockerfile to use most recent mlton compiler release

### DIFF
--- a/PrimeStandardML/solution_1/Dockerfile
+++ b/PrimeStandardML/solution_1/Dockerfile
@@ -1,9 +1,20 @@
-FROM ubuntu:20.04
+FROM silkeh/clang:12
+# download libgmp-dev for mlton
+# download/extract mlton release
+# configure mlton to use clang
 RUN apt-get update -y && \
-    apt-get install mlton -y
+    apt-get install libgmp-dev -y && \
+    wget https://github.com/MLton/mlton/releases/download/on-20210117-release/mlton-20210117-1.amd64-linux-glibc2.31.tgz && \
+    tar -zxf mlton-20210117-1.amd64-linux-glibc2.31.tgz && \
+    cp -fpR "/mlton-20210117-1.amd64-linux-glibc2.31/bin/mlton" "/mlton-20210117-1.amd64-linux-glibc2.31/bin/mlton.bak" && \
+    sed \
+        -e "s;^CC=.*;CC=\"clang\";" \
+        < "/mlton-20210117-1.amd64-linux-glibc2.31/bin/mlton.bak" > "/mlton-20210117-1.amd64-linux-glibc2.31/bin/mlton" && \
+    chmod a+x "/mlton-20210117-1.amd64-linux-glibc2.31/bin/mlton" && \
+    rm -rf "/mlton-20210117-1.amd64-linux-glibc2.31/bin/mlton.bak"
 WORKDIR /app
 COPY sml_primes.sml sml_primes.sml
 COPY primes.mlb primes.mlb
 COPY run.sml run.sml
-RUN mlton -link-opt '-static' primes.mlb
+RUN /mlton-20210117-1.amd64-linux-glibc2.31/bin/mlton -link-opt '-static' -codegen llvm primes.mlb
 CMD ["./primes"]

--- a/PrimeStandardML/solution_1/README.md
+++ b/PrimeStandardML/solution_1/README.md
@@ -27,10 +27,21 @@ mlton -link-opt '-static' primes.mlb
 ./primes
 ```
 
+### MLTON with llvm
+
+With a recent enough version of the mlton compiler (since release 20180207) llvm can be used for code generation. If the tools `llvm-as`, `opt`, `llc` are available in the compilation environment then this option can be used to compile a faster sieve program.
+
+Execute the following from this directory:
+
+```
+mlton -link-opt '-static' -codegen llvm primes.mlb
+./primes
+```
+
 ### Docker
 A Dockerfile has been provided.
 
 ## Output
 ```
-NotMatthewGriffin_SML;1492;5.003;1;algorithm=base,faithful=yes,bits=1
+NotMatthewGriffin_SML;2181;5.001;1;algorithm=base,faithful=yes,bits=1
 ```


### PR DESCRIPTION
## Description

By upgrading the docker file to use the most recent release of the mlton compiler and using the llvm codgen option I was able to increase the number of iterations run in the time limit on my system from 1492 to 2181.


## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
