### PR TITLE
Improvements to PrimePHP/solution_1

### DIFF
--- a/PrimePHP/solution_1/PrimePHP.php
+++ b/PrimePHP/solution_1/PrimePHP.php
@@ -53,8 +53,8 @@ class PrimeSieve
             }
 
             $ft2 = $factor;
-            $start = $factor * $factor * 0.5;
-            for ($i = $start; $i <= $rawBitsSize; $i += $ft2) {
+            $start = (int)($factor * $factor * 0.5);
+            for ($i = $start; $i < $rawBitsSize; $i += $ft2) {
                 $rb[$i] = 1;
             }
 

--- a/PrimePHP/solution_1/opcache.ini
+++ b/PrimePHP/solution_1/opcache.ini
@@ -1,5 +1,5 @@
 zend_extension=opcache.so
 opcache.enable=1
 opcache.enable_cli=1
-opcache.jit_buffer_size=32M
-opcache.jit=1255
+;opcache.jit_buffer_size=32M
+;opcache.jit=1255


### PR DESCRIPTION
## Description
This PR contains the following two separate changes that experimentally appear to increase the performance of the existing PHP solution by @DennisdeBest :

- Disabling the JIT Compiler Functionality
- Ensuring the use of integer array indices

Both of these changes are discussed bellow. Please let me know if you'd prefer that I split these into two separate PRs

### Disabling JIT
While experimenting, I notice that running the existing solution directly with the official `php:8.0-cli-alpine3.13` docker image resulted in significantly better performance than with an image built with the included Dockerfile.

As the only major differences in the Dockerfile are the *opcache* settings, I built and tested the following tree images with different *opcache* setting and found that while Opcache does improve performance, the new JIT functionality does not.

An `original` image with the settings as they stand on the upstream branch:
```
$ docker build --tag=php-solution-1:original .
```

A `no-jit` image with the JIT Compiler disabled:
```
$ cat opcache.ini
zend_extension=opcache.so
opcache.enable=1
opcache.enable_cli=1
;opcache.jit_buffer_size=32M
;opcache.jit=1255

$ docker build --tag=php-solution-1:no-jit .
```

And a `no-opcache` version with the opcache extension not loaded (which is the case with the official alpine image)
```
$ cat opcache.ini
zend_extension=opcache.so
opcache.enable=1
opcache.enable_cli=1
;opcache.jit_buffer_size=32M
;opcache.jit=1255

$ docker build --tag=php-solution-1:no-opcache .
```

I then used the following short bash script to run each version 5 times, each in a new docker container (as would be the case when the benchmark is run)
```
#!/usr/bin/env bash

runContainer(){
  echo "Running 5 iterations of tag: ${1}"
  echo "-----------------------------------------------------------------"
  for (( i=0; i<5; i++ )); do
    docker run --rm -it php-solution-1:${1}
  done
  echo "-----------------------------------------------------------------"
}

runContainer original
runContainer no-jit
runContainer no-opcache
```
And got the following results which demonstrate that Opcache without JIT is the best option on my machine:
```
$ ./testOpcache.sh 
Running 5 iterations of tag: original
-----------------------------------------------------------------
Passes: 209, Time: 5017ms, Avg: 24ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;209;5.017898;1;algorithm=base,faithful=yes
Passes: 204, Time: 5037ms, Avg: 24ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;204;5.037290;1;algorithm=base,faithful=yes
Passes: 204, Time: 5025ms, Avg: 24ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;204;5.025343;1;algorithm=base,faithful=yes
Passes: 204, Time: 5029ms, Avg: 24ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;204;5.029472;1;algorithm=base,faithful=yes
Passes: 206, Time: 5023ms, Avg: 24ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;206;5.023519;1;algorithm=base,faithful=yes
-----------------------------------------------------------------
Running 5 iterations of tag: no-jit
-----------------------------------------------------------------
Passes: 271, Time: 5018ms, Avg: 18ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;271;5.018587;1;algorithm=base,faithful=yes
Passes: 266, Time: 5019ms, Avg: 18ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;266;5.019279;1;algorithm=base,faithful=yes
Passes: 263, Time: 5025ms, Avg: 19ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;263;5.025756;1;algorithm=base,faithful=yes
Passes: 259, Time: 5029ms, Avg: 19ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;259;5.029457;1;algorithm=base,faithful=yes
Passes: 263, Time: 5027ms, Avg: 19ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;263;5.027703;1;algorithm=base,faithful=yes
-----------------------------------------------------------------
Running 5 iterations of tag: no-opcache
-----------------------------------------------------------------
Passes: 237, Time: 5018ms, Avg: 21ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;237;5.018804;1;algorithm=base,faithful=yes
Passes: 215, Time: 5015ms, Avg: 23ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;215;5.015974;1;algorithm=base,faithful=yes
Passes: 226, Time: 5031ms, Avg: 22ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;226;5.031796;1;algorithm=base,faithful=yes
Passes: 227, Time: 5025ms, Avg: 22ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;227;5.025461;1;algorithm=base,faithful=yes
Passes: 226, Time: 5020ms, Avg: 22ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;226;5.020446;1;algorithm=base,faithful=yes
-----------------------------------------------------------------
```

My guess is that some of the benefit of the JIT is lost by there only being a single execution in fresh container. But I havent looked to far into this.
I did also attempt increasing the `jit_buffer_size` to `128M` (which only gave a small increase which is inside the variation of my other tests) and the `JIT trigger` value to `0 - JIT all functions on first script load` (which made no difference)

### Integer Array Indicies
I noticed that indexes being calculated for the main `$rb` array were floats. If you look at the underlying PHP Internals HashTable implementation (https://www.phpinternalsbook.com/php5/hashtables/hash_algorithm.html#index-collisions), non-integer keys are first hashed into an integer that is then modded by the size of the wrapped C array. If you use an integer key, this additional hashing step is avoided. With the number of array accesses in the algorithm, this minor difference adds up.

Here is a comparison between the `original` and `no-jit` versions described above and the non-jit version with this 'integer optimization' added:

```
$ ./testOpcache.sh 
Running 5 iterations of tag: original
-----------------------------------------------------------------
Passes: 208, Time: 5029ms, Avg: 24ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;208;5.029545;1;algorithm=base,faithful=yes
Passes: 207, Time: 5034ms, Avg: 24ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;207;5.034515;1;algorithm=base,faithful=yes
Passes: 195, Time: 5021ms, Avg: 25ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;195;5.021165;1;algorithm=base,faithful=yes
Passes: 200, Time: 5019ms, Avg: 25ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;200;5.019364;1;algorithm=base,faithful=yes
Passes: 188, Time: 5021ms, Avg: 26ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;188;5.021926;1;algorithm=base,faithful=yes
-----------------------------------------------------------------
Running 5 iterations of tag: no-jit
-----------------------------------------------------------------
Passes: 255, Time: 5031ms, Avg: 19ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;255;5.031937;1;algorithm=base,faithful=yes
Passes: 257, Time: 5032ms, Avg: 19ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;257;5.032655;1;algorithm=base,faithful=yes
Passes: 259, Time: 5017ms, Avg: 19ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;259;5.017213;1;algorithm=base,faithful=yes
Passes: 246, Time: 5019ms, Avg: 20ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;246;5.019859;1;algorithm=base,faithful=yes
Passes: 264, Time: 5029ms, Avg: 19ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;264;5.029359;1;algorithm=base,faithful=yes
-----------------------------------------------------------------
Running 5 iterations of tag: int-array-access
-----------------------------------------------------------------
Passes: 290, Time: 5020ms, Avg: 17ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;290;5.020703;1;algorithm=base,faithful=yes
Passes: 288, Time: 5026ms, Avg: 17ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;288;5.026960;1;algorithm=base,faithful=yes
Passes: 298, Time: 5030ms, Avg: 16ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;298;5.030781;1;algorithm=base,faithful=yes
Passes: 280, Time: 5019ms, Avg: 17ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;280;5.019532;1;algorithm=base,faithful=yes
Passes: 292, Time: 5018ms, Avg: 17ms, Limit: 1000000, Count: 78498, Valid: True

DennisdeBest;292;5.018872;1;algorithm=base,faithful=yes
-----------------------------------------------------------------
```
This consistently gains around an additional 30 passes

## Contributing requirements
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
