### PR TITLE
TeX solution_2: execute Dockerfile benchmark with pdftex not luatex

### DIFF
--- a/PrimeTeX/solution_2/Dockerfile
+++ b/PrimeTeX/solution_2/Dockerfile
@@ -2,6 +2,6 @@ FROM phipsgabler/texlive-minimal@sha256:f1e37453ef11783e582033adc07ba908839c0088
 
 WORKDIR /opt/app
 
-COPY shared_batteries.tex shared_benchmark.tex *_sieve.tex *_benchmark.tex run.sh ./
+COPY shared_batteries.tex *_sieve.tex *_benchmark.tex runpdftex.sh texmf.cnf ./
 
-ENTRYPOINT [ "sh", "run.sh" ]
+ENTRYPOINT [ "sh", "runpdftex.sh" ]

--- a/PrimeTeX/solution_2/README.md
+++ b/PrimeTeX/solution_2/README.md
@@ -11,11 +11,14 @@ requires the timing extensions of `pdftex` or `luatex` and also uses
 `\dimexpr` and other e-TeX extensions as incorporated in `pdftex` and `luatex`
 anyhow.
 
-TeX has no native array type.  The storage technique is via "font dimension
+TeX has no native array type. The storage technique is via "font dimension
 parameters": instantiating a Sieve object loads in TeX memory a font at a size
-indexed on the instantiation number.  The minimal non-zero font dimension (`1sp`, stored as a `1` on a 32bits word) will serve to mark
-the non-primes, the `0sp` signals primes: one full font dimension per number as there is no native TeX
-interface to bitwise operations.  Each font dimension occupies 32bits in memory.
+indexed on the instantiation number. The minimal non-zero font dimension will
+serve to mark the non-primes (i.e. `1sp`, where `sp` is the "scaled point" TeX
+dimensional unit, and it is stored as a `1` on a 32bits word), the `0sp`
+signals primes: one full font dimension per number as there is no native TeX
+interface to bitwise operations. Each font dimension occupies 32bits in
+memory.
 
 *faithfulness*: No, as the memory footprint is unavoidably global and can not
 be released.  For the author amusement with TeX the user interface mimicks
@@ -32,21 +35,34 @@ and going by steps of `2 * factor`,
 relatively prime to respectively `2*3*5`, `2*3*5*7` or `2*3*5*7*11`.
 
 The longest wheel is implemented less efficiently than the other two as the
-straightforward extension of the coding is impeded by the TeX maximal number
-of 255 count registers.
+straightforward extension of the coding as used for the shorter wheels is
+impeded by the limitation of TeX to at most 256 count registers. This is a bit
+rhetorical as the `pdftex` binary incorporates extensions to TeX allowing more
+such count registers, but I had decided from the start not to use extensions
+of TeX original syntax.
 
-The Dockerfile is configured to run the benchmark using `luatex`, as it has
-dynamic memory allocation. In contrast `pdftex` has static memory, and even
-configuring it to its maximal TeXLive memory setting, a maximum of `294`
-passes can be done with it for the sieving range of `1,000,000`, as each pass
-consumes about `500,000` words of font memory which can not be released (the
-memory could be re-used, but for fairness of the benchmark each pass re-allocates new
-memory).
+`pdftex` has static memory, and even configuring it to its maximal TeXLive
+memory setting, a maximum of `294` passes can be done with it for the sieving
+range of `1,000,000`, as each pass consumes about `500,000` words of font
+memory which can not be released (the memory could be re-used, but for
+fairness of the benchmark each pass re-allocates new memory).
 
-As at my locale I achieve with `pdftex` about `77` passes for the `wheel48of210`
-implementation, so a computer about `4` times faster than mine would exhaust
-the `pdftex` maximal font memory if the benchmark was done with `pdftex`, even
-configured to use the maximal possibly memory setting.
+As at my locale I achieve with `pdftex` about `77` passes for the
+`wheel48of210` implementation, a computer about `4` times faster than mine
+would exhaust the `pdftex` maximal font memory during the benchmark, even with
+`pdftex` configured to use the maximal possibly font memory setting, as is
+done via the `runpdftex.sh` script used by the Dockerfile.
+
+The provided Dockerfile does nevertheless use `pdftex`. The alternative, as
+applied in earlier versions of this TeX solution, is to benefit from
+`luatex`'s dynamic memory allocation. But using this `luatex`'s feature also
+revealed some problems of efficiency with it (which have been reported
+upstream and are particularly visible on Windows platform), and gave runs
+slightly slower than with `pdftex`.
+
+For people with very fast hardware which will cause `pdftex` to try to do more
+than `294` passes in `5s`, hence abort with a fatal error of exhausted memory,
+a script to execute the benchmark with `luatex` rather is provided.
 
 
 ## Run instructions with Docker
@@ -64,7 +80,7 @@ With `luatex`:
 /bin/sh run.sh
 ```
 
-With `pdftex`:
+With `pdftex` (as used by Dockerfile):
 
 ```bash
 /bin/sh runpdftex.sh
@@ -72,15 +88,24 @@ With `pdftex`:
 
 If `295` or more passes are executed during the benchmark,
 the `pdftex` run will fail due to exhausted memory.
-`pdftex` has no dynamic memory management. Output will be empty.
+Output will be empty.
 
 
 ## Output
 
 Hardware: 2 GHz Intel Core i7 (one processor, two cores) with 8 Go 1600 MHz
-DDR3 of memory (mid-2012 machine, native OS: max osx high sierra).
+DDR3 of memory (mid-2012 machine, native OS: mac osx high sierra).
 
-Docker run:
+Docker run with `pdftex`:
+
+```
+jfbu-tex;24;5.20622;1;algorithm=base,faithful=no,bits=32
+jfbu-tex-8of30;62;5.07578;1;algorithm=wheel,faithful=no,bits=32
+jfbu-tex-48of210;71;5.04659;1;algorithm=wheel,faithful=no,bits=32
+jfbu-tex-480of2310;40;5.11597;1;algorithm=wheel,faithful=no,bits=32
+```
+
+Docker run, when Dockerfile was using `luatex` (via `run.sh`):
 
 ```
 jfbu-tex;22;5.02206;1;algorithm=base,faithful=no,bits=32
@@ -92,13 +117,8 @@ jfbu-tex-480of2310;35;5.09851;1;algorithm=wheel,faithful=no,bits=32
 The reason why the 480-of-2310 wheel is significantly slower than the two
 shorter wheels is due to the latter using optimized ways of making assignments
 in a rolled-out loop. The straightforward extension of this to the 480-of-2310
-wheel would need `480` count registers, but Knuth TeX has in total only `255`
+wheel would need `480` count registers, but Knuth TeX has in total only `256`
 at most.
-
-As the benchmark is actually done using the `luatex` binary, we could obtain
-a significant speed-up of the 480-of-2310 wheel implementation if we
-actually dropped the requirement of a pure Knuth TeX solution and
-extended the techniques as already applied to the 8-of-30 and 48-of-210 cases.
 
 Native runs:
 
@@ -121,14 +141,15 @@ Native runs:
   ```
 
 The native `luatex` is `1.13` from
-TeXLive 2021, the one of the Dockerfile is `1.07.0` from TeXLive 2018.
+TeXLive 2021.
+
 The native `pdftex` is compiled
 locally from sources with compiler flags for speed.
 
+The Dockerfile is based on a minimal TeXLive 2018 install.
+
 I don't know why the speed ratio wheel/base is higher with `pdftex`, or with
-the `luatex` from the Docker run, than with native `luatex`. It may be that
-the size of the texmf trees impacts the speed of the `luatex` memory access
-(?? only an uninformed guess).
+the `luatex` in a Docker container, than with the native `luatex`.
 
 ## Information on some of the files
 
@@ -141,15 +162,12 @@ RUN tlmgr update --repository http://ftp.math.utah.edu/pub/tex/historic/systems/
 RUN tlmgr install --repository http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2018/tlnet-final/ <whatever>
 ```
 
-I wanted to do this with `pdftexcmds.sty` to have `\pdfresettimer` with
-`luatex` but this turned out to be complicated as this meant installing the
-whole `oberdiek` bundle and then I encountered a problem, having spent enough
-time on this I finally copied over directly the relevant lua code for timing
-into the benchmark TeX files, rather than experiment with Docker TeXLive
-difficulties.
-
-`texmf.cnf` is a file which instructs `pdftex` to use more memory, once
-the `TEXMFCNF` environment variable is suitably set, as done by `runpdftex.sh`.
+`texmf.cnf` is a file which instructs `pdftex` to use more memory, once the
+`TEXMFCNF` environment variable is suitably set, as done by `runpdftex.sh`. It
+also shows (commented-out) how to extend another part of `pdftex` memory,
+which is not needed for sieving up to `1,000,000`, but would be needed for sieving
+up to a bit less than `295,000,000` which is maximum compatible with maximal
+font memory.
 
 `erato_sieve.tex` is the core library providing the Sieve object and its
 methods. It has `shared_batteries.tex` as dependency.
@@ -181,7 +199,7 @@ version and from top to bottom for the `v` version.
 
 `timelistofprimes.sh` is to be executed with `/bin/sh` and an additional
 argument which must be one of `erato`, `wheel`, `wheel8of30`, or
-`wheel48of210` (no error check is done):
+`wheel48of210`:
 
 ```bash
 /bin/sh timelistofprimes.sh erato
@@ -192,17 +210,37 @@ argument which must be one of `erato`, `wheel`, `wheel8of30`, or
 
 These scripts test the production of files `listofprimes-<range>.txt` for
 `<range>` varying from `1,000,000` to `999,999,999` via the chosen algorithm.
+Regarding `pdftex` they require a relatively recent version as it must
+understand the `-cnf-line` option.
+
 The costliest part is (by far) not the sieving but the creation of the text
 files, one prime per line; I have not tried seriously to boost this as it is
-not topic of the drag-race. See files
-`{erato,wheel,wheel8of30,wheel48of210,wheel}_primestofile_timings.txt` for the typical timings
-seen on my hardware.
+not topic of the drag-race.
 
-For example, the `wheel8of30` sieve will sieve up to `999,999,999` with luatex
-in about `2mn20s` at my locale (and it would probably be faster in a Docker
-container with less many files in `texmf` trees), but it then takes an
-additional `3mn50s` to produce the file with the `50,847,534` primes, one per
-line.
+For example (notice the command line options to enlarge `pdftex` static memory):
+
+```
+time pdftex -cnf-line font_mem_size=51000000 -cnf-line extra_mem_top=10000000 "\def\Range{100000000}\input wheel48of210_primestofile"
+```
+
+sieves up to `100,000,000` in about `7s` at my locale, but then needs
+an additional `18s` to produce the file with the `5,761,455` primes
+`<100,000,000`, one per line.
+
+Even with maximal font memory, `pdftex` will not allow sieving up to about `295,000,000` and beyond. With `luatex` we can go up to `999,999,999`:
+
+```
+time luatex "\def\Range{999999999}\input wheel48of210_primestofile"
+```
+
+Again, it takes more time (about four minutes at my locale) to create the file
+with the `50,847,534` primes `<999,999,999` than to actually sieve the prime
+array (about two minutes).
+
+See files `{erato,wheel8of30,wheel48of210,wheel}_primestofile_timings.txt` for
+some further typical timings as seen on my hardware. These files contain the
+console commands needed to execute the various runs in a syntax which I am
+told is Windows-compatible, apart from the usage of `time` utility.
 
 
 ## More info on native runs with pdftex
@@ -210,7 +248,7 @@ line.
 Executing
 
 ```
-pdftex erato_benchmark && cat erato_benchmark-out.txt
+pdftex erato_benchmark
 ```
 
 will certainly fail as `pdftex`'s font memory is per default only
@@ -220,9 +258,11 @@ relatively slow hardware, already more than `25` passes are done.
 
 To enlarge the `pdftex` static memory, make sure that the repertory contains
 the contributed file `texmf.cnf` and do `export TEXMFCNF="$(pwd):"` and then
-try again.
+the run should succeed.
 
-As a shortcut, use `/bin/sh runpdftex.sh` rather which avoids leaving
-`TEXMFCNF` set in the environment (which `context` does not like).
+Or, with a recent `pdftex` one can use the `-cnf-line` option rather than lines in `texmf.cnf`.
+
+As a further shortcut, one can use `/bin/sh runpdftex.sh` rather which avoids
+leaving `TEXMFCNF` set in the environment (which `context` does not like).
 
 See `texmf.cnf` for additional information.

--- a/PrimeTeX/solution_2/erato_primestofile_timings.txt
+++ b/PrimeTeX/solution_2/erato_primestofile_timings.txt
@@ -46,7 +46,7 @@ sys	0m0.021s
 N = 10,000,000
 ==============
 
-$ time tex \\def\\Range{10000000}\\input erato_primestofile
+$ time tex "\def\Range{10000000}\input erato_primestofile"
 This is TeX, Version 3.141592653 (TeX Live 2021) (preloaded format=tex)
 (./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
@@ -65,7 +65,7 @@ real	0m5.147s
 user	0m5.087s
 sys	0m0.050s
 
-$ time pdftex \\def\\Range{10000000}\\input erato_primestofile
+$ time pdftex "\def\Range{10000000}\input erato_primestofile"
 This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=pdftex)
  restricted \write18 enabled.
 entering extended mode
@@ -86,7 +86,7 @@ real	0m5.445s
 user	0m5.396s
 sys	0m0.040s
 
-$ time luatex \\def\\Range{10000000}\\input erato_primestofile
+$ time luatex "\def\Range{10000000}\input erato_primestofile"
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
  restricted system commands enabled.
 (./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))
@@ -110,7 +110,28 @@ sys	0m0.066s
 N = 100,000,000 
 ===============
 
-$ time luatex \\def\\Range{100000000}\\input erato_primestofile
+$ time pdftex -cnf-line font_mem_size=51000000 -cnf-line extra_mem_top=10000000 "\def\Range{100000000}\input erato_primestofile"
+This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=pdftex)
+ restricted \write18 enabled.
+entering extended mode
+(./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))
+(./shared_primestofile.tex
+Instantiate object for sieving up to 100000000...
+...done (0.228s)
+Sieving...
+...done (23.0767s)
+Outputting to file listofprimes-100000000.txt...
+5761455 primes were written to file listofprimes-100000000.txt
+...done (30.0577s)
+ ) )
+No pages of output.
+Transcript written on erato_primestofile.log.
+
+real	0m53.558s
+user	0m53.219s
+sys	0m0.253s
+
+$ time luatex "\def\Range{100000000}\input erato_primestofile"
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
  restricted system commands enabled.
 (./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))
@@ -134,7 +155,7 @@ sys	0m0.423s
 N = 999,999,999
 ===============
 
-$ time luatex \\def\\Range{999999999}\\input erato_primestofile
+$ time luatex "\def\Range{999999999}\input erato_primestofile"
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
  restricted system commands enabled.
 (./erato_primestofile.tex (./erato_sieve.tex (./shared_batteries.tex))

--- a/PrimeTeX/solution_2/texmf.cnf
+++ b/PrimeTeX/solution_2/texmf.cnf
@@ -16,3 +16,7 @@
 % luatex has dynamic memory allocation and does not need this.
 %
 font_mem_size = 147483647
+% the following is not needed for benchmark, but is sufficient to allow
+% sieving with pdftex up to the maximum authorized by max font_mem_size
+% i.e. a bit less than 295,000,000 sieving range.
+% extra_mem_top = 10000000

--- a/PrimeTeX/solution_2/timelistofprimes.sh
+++ b/PrimeTeX/solution_2/timelistofprimes.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 cd "$(dirname $0)"
-algo="$1"
+algo="${1:?'missing algo name'}"
 timings="${algo}_primestofile_timings.txt"
 
 pleasewait="Please wait..."
@@ -19,9 +19,7 @@ echo "$ time tex ${algo}_primestofile" >>$timings
 echo "$pleasewait (tex 1,000,000)"
 { time tex ${algo}_primestofile.tex ; } >>$timings 2>&1
 
-cat <<\EOF >>$timings
-
-EOF
+echo '' >>$timings
 echo "$ time pdftex ${algo}_primestofile" >>$timings
 echo "$pleasewait (pdftex 1,000,000)"
 { time pdftex ${algo}_primestofile.tex ; } >>$timings 2>&1
@@ -33,21 +31,19 @@ N = 10,000,000
 ==============
 
 EOF
-echo "$ time tex \\\\\\\\def\\\\\\\\Range{10000000}\\\\\\\\input ${algo}_primestofile" >>$timings
+echo '$ time tex "\def\Range{10000000}\input '"${algo}"'_primestofile"' >>$timings
 echo "$pleasewait (tex 10,000,000)"
 { time tex \\def\\Range{10000000}\\input ${algo}_primestofile.tex ; } >>$timings 2>&1
 
-cat <<\EOF >>$timings
-
-EOF
-echo "$ time pdftex \\\\\\\\def\\\\\\\\Range{10000000}\\\\\\\\input ${algo}_primestofile" >>$timings
+echo '' >>$timings
+echo '$ time pdftex "\def\Range{10000000}\input '"${algo}"'_primestofile"' >>$timings
 echo "$pleasewait (pdftex 10,000,000)"
 { time pdftex \\def\\Range{10000000}\\input ${algo}_primestofile.tex ; } >>$timings 2>&1
 
 cat <<\EOF >>$timings
 
 EOF
-echo "$ time luatex \\\\\\\\def\\\\\\\\Range{10000000}\\\\\\\\input ${algo}_primestofile" >>$timings
+echo '$ time luatex "\def\Range{10000000}\input '"${algo}"'_primestofile"' >>$timings
 echo "$pleasewait (luatex 10,000,000)"
 { time luatex \\def\\Range{10000000}\\input ${algo}_primestofile.tex ; } >>$timings 2>&1
 
@@ -58,7 +54,12 @@ N = 100,000,000
 ===============
 
 EOF
-echo "$ time luatex \\\\\\\\def\\\\\\\\Range{100000000}\\\\\\\\input ${algo}_primestofile" >>$timings
+echo '$ time pdftex -cnf-line font_mem_size=51000000 -cnf-line extra_mem_top=10000000 "\def\Range{100000000}\input '"${algo}"'_primestofile"' >>$timings
+echo "$pleasewait (pdftex 100,000,000) (enlarged font and main memory)"
+{ time pdftex -cnf-line font_mem_size=51000000 -cnf-line extra_mem_top=10000000 \\def\\Range{100000000}\\input ${algo}_primestofile.tex ; } >>$timings 2>&1
+
+echo '' >>$timings
+echo '$ time luatex "\def\Range{100000000}\input '"${algo}"'_primestofile"' >>$timings
 echo "$pleasewait (luatex 100,000,000)"
 { time luatex \\def\\Range{100000000}\\input ${algo}_primestofile.tex ; } >>$timings 2>&1
 
@@ -69,7 +70,7 @@ N = 999,999,999
 ===============
 
 EOF
-echo "$ time luatex \\\\\\\\def\\\\\\\\Range{999999999}\\\\\\\\input ${algo}_primestofile" >>$timings
+echo '$ time luatex "\def\Range{999999999}\input '"${algo}"'_primestofile"' >>$timings
 echo "$pleasewaitalot (luatex 999,999,999)"
 { time luatex \\def\\Range{999999999}\\input ${algo}_primestofile.tex ; } >>$timings 2>&1
 echo "Done"

--- a/PrimeTeX/solution_2/wheel48of210_primestofile_timings.txt
+++ b/PrimeTeX/solution_2/wheel48of210_primestofile_timings.txt
@@ -46,7 +46,7 @@ sys	0m0.021s
 N = 10,000,000
 ==============
 
-$ time tex \\def\\Range{10000000}\\input wheel48of210_primestofile
+$ time tex "\def\Range{10000000}\input wheel48of210_primestofile"
 This is TeX, Version 3.141592653 (TeX Live 2021) (preloaded format=tex)
 (./wheel48of210_primestofile.tex (./wheel48of210_sieve.tex
 (./shared_batteries.tex)) (./shared_primestofile.tex
@@ -65,7 +65,7 @@ real	0m2.561s
 user	0m2.506s
 sys	0m0.046s
 
-$ time pdftex \\def\\Range{10000000}\\input wheel48of210_primestofile
+$ time pdftex "\def\Range{10000000}\input wheel48of210_primestofile"
 This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=pdftex)
  restricted \write18 enabled.
 entering extended mode
@@ -86,7 +86,7 @@ real	0m2.687s
 user	0m2.605s
 sys	0m0.049s
 
-$ time luatex \\def\\Range{10000000}\\input wheel48of210_primestofile
+$ time luatex "\def\Range{10000000}\input wheel48of210_primestofile"
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
  restricted system commands enabled.
 (./wheel48of210_primestofile.tex (./wheel48of210_sieve.tex
@@ -110,7 +110,28 @@ sys	0m0.069s
 N = 100,000,000 
 ===============
 
-$ time luatex \\def\\Range{100000000}\\input wheel48of210_primestofile
+$ time pdftex -cnf-line font_mem_size=51000000 -cnf-line extra_mem_top=10000000 "\def\Range{100000000}\input wheel48of210_primestofile"
+This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=pdftex)
+ restricted \write18 enabled.
+entering extended mode
+(./wheel48of210_primestofile.tex (./wheel48of210_sieve.tex
+(./shared_batteries.tex)) (./shared_primestofile.tex
+Instantiate object for sieving up to 100000000...
+...done (0.22339s)
+Sieving...
+...done (6.83368s)
+Outputting to file listofprimes-100000000.txt...
+5761455 primes were written to file listofprimes-100000000.txt
+...done (17.56383s)
+ ) )
+No pages of output.
+Transcript written on wheel48of210_primestofile.log.
+
+real	0m24.828s
+user	0m24.539s
+sys	0m0.269s
+
+$ time luatex "\def\Range{100000000}\input wheel48of210_primestofile"
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
  restricted system commands enabled.
 (./wheel48of210_primestofile.tex (./wheel48of210_sieve.tex
@@ -134,7 +155,7 @@ sys	0m0.450s
 N = 999,999,999
 ===============
 
-$ time luatex \\def\\Range{999999999}\\input wheel48of210_primestofile
+$ time luatex "\def\Range{999999999}\input wheel48of210_primestofile"
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
  restricted system commands enabled.
 (./wheel48of210_primestofile.tex (./wheel48of210_sieve.tex

--- a/PrimeTeX/solution_2/wheel8of30_primestofile_timings.txt
+++ b/PrimeTeX/solution_2/wheel8of30_primestofile_timings.txt
@@ -46,7 +46,7 @@ sys	0m0.022s
 N = 10,000,000
 ==============
 
-$ time tex \\def\\Range{10000000}\\input wheel8of30_primestofile
+$ time tex "\def\Range{10000000}\input wheel8of30_primestofile"
 This is TeX, Version 3.141592653 (TeX Live 2021) (preloaded format=tex)
 (./wheel8of30_primestofile.tex (./wheel8of30_sieve.tex (./shared_batteries.tex)
 ) (./shared_primestofile.tex
@@ -65,7 +65,7 @@ real	0m2.787s
 user	0m2.698s
 sys	0m0.051s
 
-$ time pdftex \\def\\Range{10000000}\\input wheel8of30_primestofile
+$ time pdftex "\def\Range{10000000}\input wheel8of30_primestofile"
 This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=pdftex)
  restricted \write18 enabled.
 entering extended mode
@@ -86,7 +86,7 @@ real	0m2.908s
 user	0m2.859s
 sys	0m0.041s
 
-$ time luatex \\def\\Range{10000000}\\input wheel8of30_primestofile
+$ time luatex "\def\Range{10000000}\input wheel8of30_primestofile"
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
  restricted system commands enabled.
 (./wheel8of30_primestofile.tex (./wheel8of30_sieve.tex (./shared_batteries.tex)
@@ -110,7 +110,28 @@ sys	0m0.066s
 N = 100,000,000 
 ===============
 
-$ time luatex \\def\\Range{100000000}\\input wheel8of30_primestofile
+$ time pdftex -cnf-line font_mem_size=51000000 -cnf-line extra_mem_top=10000000 "\def\Range{100000000}\input wheel8of30_primestofile"
+This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=pdftex)
+ restricted \write18 enabled.
+entering extended mode
+(./wheel8of30_primestofile.tex (./wheel8of30_sieve.tex (./shared_batteries.tex)
+) (./shared_primestofile.tex
+Instantiate object for sieving up to 100000000...
+...done (0.2214s)
+Sieving...
+...done (8.5427s)
+Outputting to file listofprimes-100000000.txt...
+5761455 primes were written to file listofprimes-100000000.txt
+...done (18.53345s)
+ ) )
+No pages of output.
+Transcript written on wheel8of30_primestofile.log.
+
+real	0m27.496s
+user	0m27.238s
+sys	0m0.236s
+
+$ time luatex "\def\Range{100000000}\input wheel8of30_primestofile"
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
  restricted system commands enabled.
 (./wheel8of30_primestofile.tex (./wheel8of30_sieve.tex (./shared_batteries.tex)
@@ -134,7 +155,7 @@ sys	0m0.346s
 N = 999,999,999
 ===============
 
-$ time luatex \\def\\Range{999999999}\\input wheel8of30_primestofile
+$ time luatex "\def\Range{999999999}\input wheel8of30_primestofile"
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
  restricted system commands enabled.
 (./wheel8of30_primestofile.tex (./wheel8of30_sieve.tex (./shared_batteries.tex)

--- a/PrimeTeX/solution_2/wheel_primestofile_timings.txt
+++ b/PrimeTeX/solution_2/wheel_primestofile_timings.txt
@@ -46,7 +46,7 @@ sys	0m0.020s
 N = 10,000,000
 ==============
 
-$ time tex \\def\\Range{10000000}\\input wheel_primestofile
+$ time tex "\def\Range{10000000}\input wheel_primestofile"
 This is TeX, Version 3.141592653 (TeX Live 2021) (preloaded format=tex)
 (./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))
 (./shared_primestofile.tex
@@ -65,7 +65,7 @@ real	0m3.598s
 user	0m3.550s
 sys	0m0.039s
 
-$ time pdftex \\def\\Range{10000000}\\input wheel_primestofile
+$ time pdftex "\def\Range{10000000}\input wheel_primestofile"
 This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=pdftex)
  restricted \write18 enabled.
 entering extended mode
@@ -86,7 +86,7 @@ real	0m3.814s
 user	0m3.766s
 sys	0m0.040s
 
-$ time luatex \\def\\Range{10000000}\\input wheel_primestofile
+$ time luatex "\def\Range{10000000}\input wheel_primestofile"
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
  restricted system commands enabled.
 (./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))
@@ -110,7 +110,28 @@ sys	0m0.063s
 N = 100,000,000 
 ===============
 
-$ time luatex \\def\\Range{100000000}\\input wheel_primestofile
+$ time pdftex -cnf-line font_mem_size=51000000 -cnf-line extra_mem_top=10000000 "\def\Range{100000000}\input wheel_primestofile"
+This is pdfTeX, Version 3.141592653-2.6-1.40.22 (TeX Live 2021) (preloaded format=pdftex)
+ restricted \write18 enabled.
+entering extended mode
+(./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))
+(./shared_primestofile.tex
+Instantiate object for sieving up to 100000000...
+...done (0.22472s)
+Sieving...
+...done (15.31071s)
+Outputting to file listofprimes-100000000.txt...
+5761455 primes were written to file listofprimes-100000000.txt
+...done (21.66245s)
+ ) )
+No pages of output.
+Transcript written on wheel_primestofile.log.
+
+real	0m37.416s
+user	0m37.070s
+sys	0m0.243s
+
+$ time luatex "\def\Range{100000000}\input wheel_primestofile"
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
  restricted system commands enabled.
 (./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))


### PR DESCRIPTION
## Description
<!--
Add your description yere.
-->

As explained in the [discussion](https://github.com/PlummersSoftwareLLC/Primes/discussions/662) I feel more and more the benchmark should use the canonical `pdftex` rather than  more recent `luatex`, despite the problem than on very fast hardware the `pdftex` will abort due to exhausted memory. Thus this PR accomplishes this. The algorithms and TeX coding have not changed. (I would even prefer to use Knuth `tex` not `pdftex` but the former does not have the needed timing facilities for the benchmark).

Experimenting with `luatex` was good but it distorts too much the comparison between "base" and "wheel" algorithms. The natural expected time boost is seen with pdftex but in a diminished form (for unknown reasons) with luatex, with the exact same TeX sources.

Another problem is that using `luatex`  on Windows platform seems to reveal a great time penalty when initially allocating the number array. I reported the problem upstream after I got reports from correspondants on Windows. The problem exists also on Linux/Mac but is much less noticeable.


## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
