### PR TITLE
[C#-4]Adding new solutions "stride8-blocks"

### DIFF
--- a/PrimeCSharp/solution_4/PrimeCS.cs
+++ b/PrimeCSharp/solution_4/PrimeCS.cs
@@ -13,6 +13,10 @@ namespace PrimeSieveCS
         IEnumerable<uint> EnumeratePrimes();
     }
 
+    /// <summary>
+    /// This is just a workaround to avoid an indirect function call to construct the sieve.
+    /// This can be replaced with a static function call when we get statics in interfaces.
+    /// </summary>
     interface ISieveRunner
     {
         ISieve RunSieve(uint sieveSize);
@@ -46,7 +50,9 @@ namespace PrimeSieveCS
 
             RunSieve(default(SieveDenseAndSparseRunner), sieveSize);
             RunSieve(default(SieveStride8Runner), sieveSize);
-            RunSieve(default(SieveStride8BlocksRunner), sieveSize);
+            RunSieve(default(SieveStride8Blocks16kRunner), sieveSize);
+            RunSieve(default(SieveStride8Blocks32kRunner), sieveSize);
+            RunSieve(default(SieveStride8Blocks64kRunner), sieveSize);
         }
 
         static void RunSieve<TRunner>(TRunner runner, uint sieveSize) where TRunner : ISieveRunner

--- a/PrimeCSharp/solution_4/PrimeCS.cs
+++ b/PrimeCSharp/solution_4/PrimeCS.cs
@@ -45,7 +45,8 @@ namespace PrimeSieveCS
             const int sieveSize = 1_000_000;
 
             RunSieve(default(SieveDenseAndSparseRunner), sieveSize);
-            RunSieve(default(SieveStripedRunner), sieveSize);
+            RunSieve(default(SieveStride8Runner), sieveSize);
+            RunSieve(default(SieveStride8BlocksRunner), sieveSize);
         }
 
         static void RunSieve<TRunner>(TRunner runner, uint sieveSize) where TRunner : ISieveRunner

--- a/PrimeCSharp/solution_4/SieveDenseAndSparse.cs
+++ b/PrimeCSharp/solution_4/SieveDenseAndSparse.cs
@@ -8,17 +8,12 @@ namespace PrimeSieveCS
 {
     readonly struct SieveDenseAndSparseRunner : ISieveRunner
     {
-        public ISieve RunSieve(uint sieveSize)
-        {
-            var sieve = new SieveDenseAndSparse(sieveSize);
-            sieve.RunSieve();
-            return sieve;
-        }
+        public ISieve RunSieve(uint sieveSize) => new SieveDenseAndSparse(sieveSize).RunSieve();
     }
 
     class SieveDenseAndSparse : ISieve
     {
-        public readonly uint sieveSize;
+        readonly uint sieveSize;
         readonly uint halfLimit;
         readonly ulong[] bits;
 
@@ -127,7 +122,7 @@ namespace PrimeSieveCS
         /// Calculate the primes up to the specified limit
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        unsafe public void RunSieve()
+        unsafe public SieveDenseAndSparse RunSieve()
         {
             uint factor = 3;
             uint halfFactor = factor >> 1;
@@ -168,6 +163,7 @@ namespace PrimeSieveCS
                         ClearBitsSparseUnrolled4Rev(ptr, (factor * factor) / 2, factor, halfLimit);
                     }
                 }
+            return this;
         }
     }
 }

--- a/PrimeCSharp/solution_4/SieveStride8.cs
+++ b/PrimeCSharp/solution_4/SieveStride8.cs
@@ -7,13 +7,9 @@ namespace PrimeSieveCS
 {
     readonly struct SieveStride8Runner : ISieveRunner
     {
-        public ISieve RunSieve(uint sieveSize)
-        {
-            var sieve = new SieveStride8(sieveSize);
-            sieve.RunSieve();
-            return sieve;
-        }
+        public ISieve RunSieve(uint sieveSize) => new SieveStride8(sieveSize).RunSieve();
     }
+
 
     /// <summary>
     /// A simplified version of the striped algorithm used by rust solution_1.
@@ -25,7 +21,7 @@ namespace PrimeSieveCS
     /// </summary>
     class SieveStride8 : ISieve
     {
-        public readonly uint sieveSize;
+        readonly uint sieveSize;
         readonly uint halfLimit;
         readonly ulong[] bits;
 
@@ -75,7 +71,7 @@ namespace PrimeSieveCS
         /// Calculate the primes up to the specified limit
         /// </summary>
         [MethodImpl(MethodImplOptions.AggressiveOptimization)]
-        unsafe public void RunSieve()
+        unsafe public SieveStride8 RunSieve()
         {
             uint factor = 3;
             uint halfFactor = factor >> 1;
@@ -107,6 +103,7 @@ namespace PrimeSieveCS
 
                     ClearBitsStriped((byte*)ptr, (factor * factor) / 2, factor, halfLimit);
                 }
+            return this;
         }
     }
 }

--- a/PrimeCSharp/solution_4/SieveStride8.cs
+++ b/PrimeCSharp/solution_4/SieveStride8.cs
@@ -29,7 +29,7 @@ namespace PrimeSieveCS
         readonly uint halfLimit;
         readonly ulong[] bits;
 
-        public string Name => "italytoast-striped";
+        public string Name => "italytoast-stride8";
 
         public uint SieveSize => sieveSize;
 

--- a/PrimeCSharp/solution_4/SieveStride8.cs
+++ b/PrimeCSharp/solution_4/SieveStride8.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Numerics;
+using System.Runtime.CompilerServices;
+
+namespace PrimeSieveCS
+{
+    readonly struct SieveStride8Runner : ISieveRunner
+    {
+        public ISieve RunSieve(uint sieveSize)
+        {
+            var sieve = new SieveStride8(sieveSize);
+            sieve.RunSieve();
+            return sieve;
+        }
+    }
+
+    /// <summary>
+    /// A simplified version of the striped algorithm used by rust solution_1.
+    /// Instead of having the sieve oriented "vertically", we keep the normal bit array representaion.
+    /// What we do instead is create the mask and push the pointer by factor. 
+    /// That way we effectively mark every 8th factor. 
+    /// 
+    /// This simplifies the code a whole lot.
+    /// </summary>
+    class SieveStride8 : ISieve
+    {
+        public readonly uint sieveSize;
+        readonly uint halfLimit;
+        readonly ulong[] bits;
+
+        public string Name => "italytoast-striped";
+
+        public uint SieveSize => sieveSize;
+
+        public SieveStride8(uint size)
+        {
+            const int wordBits = sizeof(ulong) * 8;
+
+            sieveSize = size;
+            halfLimit = (size + 1) / 2;
+            bits = new ulong[(int)(halfLimit / wordBits + 1)];
+        }
+
+        public IEnumerable<uint> EnumeratePrimes()
+        {
+            yield return 2;
+            for (uint num = 3; num <= sieveSize; num += 2)
+                if ((bits[(num / 2) / 64] & (1UL << (int)(num / 2))) == 0)
+                    yield return num;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        unsafe static void ClearBitsStriped(byte* ptr, uint start, uint factor, uint limit)
+        {
+            var stripedMask = 0;
+            var count = limit / 8;
+            while (true)
+            {
+                var index = start / 8;
+                byte mask = (byte)(1 << (int)(start % 8));
+
+                if ((mask & stripedMask) != 0) break;//checks if we have cleared the stripe already. If so we are finnished.
+
+                for (uint i = index; i < count; i += factor)
+                {
+                    ptr[i] |= mask;
+                }
+                start += factor;// push start forward by factor so we start in the next stripe.
+                stripedMask |= mask;
+            }
+        }
+
+        /// <summary>
+        /// Calculate the primes up to the specified limit
+        /// </summary>
+        [MethodImpl(MethodImplOptions.AggressiveOptimization)]
+        unsafe public void RunSieve()
+        {
+            uint factor = 3;
+            uint halfFactor = factor >> 1;
+            uint halfRoot = ((uint)(Math.Sqrt(sieveSize) + 1)) >> 1;
+
+            // We ignore even numbers by using values that track half of the actuals, and the only
+            // number we keep in original form is the prime factor we're walking through the sieve
+            fixed (ulong* ptr = bits)
+                while (true)
+                {
+                    // Scan for the next unset bit which means it is a prime factor
+                    var segment = ptr[halfFactor / 64];
+                    var offset = halfFactor % 64;
+                    segment = ~segment; //since we only have access to TrailingZeroCount, we have to flip all the bits
+                    segment >>= (int)offset;
+                    var jump = BitOperations.TrailingZeroCount(segment);
+                    if (jump == 64)
+                    {
+                        halfFactor += 64 - offset;
+                        continue;
+                    }
+
+                    //scan finnished - restoring factor
+                    halfFactor += (uint)jump;
+                    factor = (halfFactor << 1) + 1;
+                    halfFactor++;
+
+                    if (halfFactor > halfRoot) break;
+
+                    ClearBitsStriped((byte*)ptr, (factor * factor) / 2, factor, halfLimit);
+                }
+        }
+    }
+}

--- a/PrimeCSharp/solution_4/SieveStride8Blocks.cs
+++ b/PrimeCSharp/solution_4/SieveStride8Blocks.cs
@@ -1,19 +1,22 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
+using System.Text;
 
 namespace PrimeSieveCS
 {
-    readonly struct SieveStripedRunner : ISieveRunner
+    readonly struct SieveStride8BlocksRunner : ISieveRunner
     {
         public ISieve RunSieve(uint sieveSize)
         {
-            var sieve = new SieveStriped(sieveSize);
+            var sieve = new SieveStride8Blocks(sieveSize);
             sieve.RunSieve();
             return sieve;
         }
     }
+
 
     /// <summary>
     /// A simplified version of the striped algorithm used by rust solution_1.
@@ -23,17 +26,18 @@ namespace PrimeSieveCS
     /// 
     /// This simplifies the code a whole lot.
     /// </summary>
-    class SieveStriped : ISieve
+    class SieveStride8Blocks : ISieve
     {
-        public readonly uint sieveSize;
+        const int blocksize = 0x4000; //16k blocksize in bytes, that should fit in most processors L1 cache
+        readonly uint sieveSize = 0;
         readonly uint halfLimit;
         readonly ulong[] bits;
 
-        public string Name => "italytoast-striped";
+        public string Name => "italytoast-stride8-blocks16k";
 
         public uint SieveSize => sieveSize;
 
-        public SieveStriped(uint size)
+        public SieveStride8Blocks(uint size)
         {
             const int wordBits = sizeof(ulong) * 8;
 
@@ -51,23 +55,54 @@ namespace PrimeSieveCS
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        unsafe static void ClearBitsStriped(byte* ptr, uint start, uint factor, uint limit)
+        unsafe static void ClearBitsStride8BlocksUnrolled(byte* ptr, uint start, uint factor, uint limit)
         {
-            var stripedMask = 0;
-            var count = limit / 8;
-            while (true)
+            Span<(uint, byte)> strides = stackalloc (uint, byte)[8];
+            for (uint i = 0; i < 8; i++)
             {
-                var index = start / 8;
-                byte mask = (byte)(1 << (int)(start % 8));
+                var s = start + factor * i;
+                strides[(int)i] = (s / 8, (byte)(1 << ((int)s % 8)));
+            }
 
-                if ((mask & stripedMask) != 0) break;//checks if we have cleared the stripe already. If so we are finnished.
+            var bytecount = limit / 8;
+            var blockStart = start / 8;
 
-                for (uint i = index; i < count; i += factor)
+            while (blockStart <= bytecount)
+            {
+                for (int stride = 0; stride < 8; stride++)
                 {
-                    ptr[i] |= mask;
+                    var (index, mask) = strides[stride];
+                    var blockEnd = Math.Min(bytecount + 1, index + blocksize);
+                    var blockEndPtr = ptr + blockEnd;
+
+                    var i0 = ptr + index;
+                    var i1 = ptr + index + factor;
+                    var i2 = ptr + index + factor * 2;
+                    var i3 = ptr + index + factor * 3;
+
+                    uint factor4 = factor * 4; 
+                    for (; i3 < blockEndPtr;)
+                    {
+                        i0[0] |= mask;
+                        i1[0] |= mask;
+                        i2[0] |= mask;
+                        i3[0] |= mask;
+
+                        i0 += factor4;
+                        i1 += factor4;
+                        i2 += factor4;
+                        i3 += factor4;
+                    }
+
+                    for (; i0 < blockEndPtr; i0 += factor)
+                    {
+                        i0[0] |= mask;
+                    }
+
+                    strides[stride] = ((uint)(i0 - ptr), mask);
                 }
-                start += factor;// push start forward by factor so we start in the next stripe.
-                stripedMask |= mask;
+
+                blockStart += blocksize;
             }
         }
 
@@ -105,7 +140,7 @@ namespace PrimeSieveCS
 
                     if (halfFactor > halfRoot) break;
 
-                    ClearBitsStriped((byte*)ptr, (factor * factor) / 2, factor, halfLimit);
+                    ClearBitsStride8BlocksUnrolled((byte*)ptr, (factor * factor) / 2, factor, halfLimit);
                 }
         }
     }


### PR DESCRIPTION
## Description
Adding new solutions:

- italytoast-stride8-blocks16k
- italytoast-stride8-blocks32k
- italytoast-stride8-blocks64k

By processing the sieve in segments we reduce the L1 cache misses and in turn increase the performance by ~48%.

Renaming the existing solution "italytoast-striped" -> "italytoast-stride8" to make a distinction between this algorithm and mikes striped algorithm. This algorithm doesnt change the order of the bits, its very similar to Haskell/Solution2 in that regard. (I can name it unpeeled and unpeeled-blocks respectively if that is preferred).

I also change the RunSieve() function to return the sieve itself to reduce the code required in the SieveRunners.

# Performance numbers 
```
italytoast-dense-and-sparse;7222;5.00011;1;algorithm=base,faithful=yes,bits=1
italytoast-stride8;8706;5.00016;1;algorithm=base,faithful=yes,bits=1
italytoast-stride8-blocks16k;12912;5.00038;1;algorithm=base,faithful=yes,bits=1
italytoast-stride8-blocks32k;13204;5.00031;1;algorithm=base,faithful=yes,bits=1
italytoast-stride8-blocks64k;9341;5.00015;1;algorithm=base,faithful=yes,bits=1
```

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
