### PR TITLE
Add dense base primes to Chapel solution_1...

### DIFF
--- a/PrimeChapel/solution_1/README.md
+++ b/PrimeChapel/solution_1/README.md
@@ -1,4 +1,4 @@
-# Chapel implementation by GordonBGood
+# Chapel implementations by GordonBGood
 
 ![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
 ![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
@@ -29,10 +29,11 @@ The Dockerfile uses an official Debian image and then builds and installs Chapel
 
 ## Output
 ```
-GordonBGood_1of2;7798;5.00044;1;algorithm=base,faithful=yes,bits=1
-GordonBGood_unpeeled;8969;5.00027;1;algorithm=base,faithful=yes,bits=1
-GordonBGood_unpeeled_block;10487;5.00019;1;algorithm=base,faithful=yes,bits=1
-GordonBGood_unrolled;16356;5.00022;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_bittwiddle;7776;5.00044;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_unpeeled;9838;5.00047;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_unpeeled_block;10319;5.00005;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_unrolled;15865;5.0002;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_unrolled_hybrid;28818;5.00012;1;algorithm=base,faithful=yes,bits=1
 ```
 
 ## Benchmarks
@@ -40,23 +41,25 @@ GordonBGood_unrolled;16356;5.00022;1;algorithm=base,faithful=yes,bits=1
 Running locally on my Intel SkyLake i5-6500 at 3.6 GHz when single threaded, I get some astounding numbers:
 
 ```
-GordonBGood_1of2;7770;5.0003;1;algorithm=base,faithful=yes,bits=1
-GordonBGood_unpeeled;9964;5.00015;1;algorithm=base,faithful=yes,bits=1
-GordonBGood_unpeeled_block;10439;5.0004;1;algorithm=base,faithful=yes,bits=1
-GordonBGood_unrolled;16446;5.00014;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_bittwiddle;7803;5.00046;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_unpeeled;9768;5.00028;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_unpeeled_block;10356;5.00035;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_unrolled;16259;5.00009;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_unrolled_hybrid;28948;5.00005;1;algorithm=base,faithful=yes,bits=1
 ```
 Which matches the results when run with Docker on the same machine as follows:
 
 ```
-                                                               Single-threaded                                                                
-┌───────┬────────────────┬──────────┬────────────────────────────┬────────┬──────────┬─────────┬───────────┬──────────┬──────┬───────────────┐
-│ Index │ Implementation │ Solution │ Label                      │ Passes │ Duration │ Threads │ Algorithm │ Faithful │ Bits │ Passes/Second │
-├───────┼────────────────┼──────────┼────────────────────────────┼────────┼──────────┼─────────┼───────────┼──────────┼──────┼───────────────┤
-│   1   │ chapel         │ 1        │ GordonBGood_unrolled       │ 16525  │ 5.00017  │    1    │   base    │   yes    │ 1    │  3304.88763   │
-│   2   │ chapel         │ 1        │ GordonBGood_unpeeled_block │ 10448  │ 5.00006  │    1    │   base    │   yes    │ 1    │  2089.57493   │
-│   3   │ chapel         │ 1        │ GordonBGood_unpeeled       │  9932  │ 5.00035  │    1    │   base    │   yes    │ 1    │  1986.26096   │
-│   4   │ chapel         │ 1        │ GordonBGood_1of2           │  7676  │ 5.00061  │    1    │   base    │   yes    │ 1    │  1535.01273   │
-└───────┴────────────────┴──────────┴────────────────────────────┴────────┴──────────┴─────────┴───────────┴──────────┴──────┴───────────────┘
+                                                                Single-threaded                                                                
+┌───────┬────────────────┬──────────┬─────────────────────────────┬────────┬──────────┬─────────┬───────────┬──────────┬──────┬───────────────┐
+│ Index │ Implementation │ Solution │ Label                       │ Passes │ Duration │ Threads │ Algorithm │ Faithful │ Bits │ Passes/Second │
+├───────┼────────────────┼──────────┼─────────────────────────────┼────────┼──────────┼─────────┼───────────┼──────────┼──────┼───────────────┤
+│   1   │ chapel         │ 1        │ GordonBGood_unrolled_hybrid │ 29556  │ 5.00014  │    1    │   base    │   yes    │ 1    │  5911.03449   │
+│   2   │ chapel         │ 1        │ GordonBGood_unrolled        │ 16499  │ 5.00002  │    1    │   base    │   yes    │ 1    │  3299.78680   │
+│   3   │ chapel         │ 1        │ GordonBGood_unpeeled_block  │ 10499  │ 5.00003  │    1    │   base    │   yes    │ 1    │  2099.78740   │
+│   4   │ chapel         │ 1        │ GordonBGood_unpeeled        │  9969  │ 5.00005  │    1    │   base    │   yes    │ 1    │  1993.78006   │
+│   5   │ chapel         │ 1        │ GordonBGood_bittwiddle      │  7851  │ 5.00032  │    1    │   base    │   yes    │ 1    │  1570.09951   │
+└───────┴────────────────┴──────────┴─────────────────────────────┴────────┴──────────┴─────────┴───────────┴──────────┴──────┴───────────────┘
 ```
 
 ## Notes
@@ -67,5 +70,8 @@ The techniques used are as follows:
 2. Loop "unpeeling" where the culling marking loops are simplified by recognizing that modulo math means every eighth culling/marking position is at the same bit index per byte with the byte indexes separated by the base prime value span so that are eight loops culling/marking with each using a different fixed byte mask.  This is faster because the simple non-"bit-twiddling" masking operations can be very simple, but meaning that there is more loop overhead (eight loops per base prime value instead of one) and there is still "cache thrashing" as each loop culls/marks across the entire sieve buffer which spans several CPU caches in the case of common CPU's.
 3. Loop "unpeeling" by cache sized blocks, which reduces the "cache thrashing" by running the above eight loops across each block in turn, saving the next marking/culling index in an array for use on the next block.  As full page segmentation isn't allowed (determining all base prime values as a separate process), this reduces but can't eliminate "cache thrashing".
 4. Extreme loop unrolling, which combines the eight loops above into a single loop running across the entire sieve buffer; since the eight loops are combined and as page segmentation is not allowed, there is no advantage (and an increased overhead) to culling by cache-sized blocks.  Since Chapel does not have computed goto's, this feature is emulated manually by creating an array containing "functions" that cull by each of the possible 64 culling patterns, which patterns depend on the modulo eight of the span (the base prime value) and the modulo eight of the starting bit index (eight times eight is 64 elements), of which not all are used for this program.  Since only odd base prime values are used, there are only four base prime modulo eight entries for span value, and since we are starting all of them at the index of the base prime squared, then each base prime modulo creates a constant start bit index modulo eight; thus, there are only four out of the 64 entries used for this program, but the rest are kept for completeness in other applications.
+5. A hybrid approach where extreme loop unrolling as per the above is used for larger base prime values above a threshold and a dense algorithm for those base prime values below.  For this implementation the threshold is chosen so dense base primes are considered to be nineteen and below; larger values up to about 31 would likely make the code even slightly faster, but as Chapel does not have macros, a code generator must be used for the cases handling each odd value up to the threshold and the source could becomes rather long for only a small extra benefit.  Instead of addressing the sieve buffer array by byte indices as for extreme loop unrolling, the dense processing addresses the buffer by 64-bit words so that the maximum number of small-span composites are contained in each word.  There have been solutions that correctly haven't been accepted as `faithful to base` because in addressing by words they cleared all the dense composites in the word with a single instruction using a mask, but this implementation clears them bit by bit with individual operations in a manner similar to the technique used in the Rust "striped hybrid reset" technique but using larger words instead of bytes; thus this version should be accepted as `faithful to base`.  As well, as it is expected that we don't use any knowledge of base primes other than the only even prime of two, the implementation covers all of the odd value possibilities and thus includes the values of nine and fifteen even thought these are not prime and the code will never be used.
 
-In implementing the above "Extreme Loop Unrolling", since Chapel does not have general-use first class functions (the current implementation can only access global and local (inside the scope of the function) variables, these are emulated using a class hierarchy, which classes can emulate closures by using the class fields to capture variables from the environment (not used here) and the default `this` method as the "apply" method of a Functor class.  Chapel's parameterized generic classes act as class/Functor templates for this application.  This class "template" is then instantiated once for each of the 64 "goto" table entries.  The use of this table is then structured to look like a call to a "setbit(array, start, limit, step)" function to make it clear that there is one operation per composite number culling/marking.
+In implementing "Extreme Loop Unrolling", since Chapel does not have general-use first class functions (the current implementation can only access global and local (inside the scope of the function) variables, these are emulated using a class hierarchy, which classes can emulate closures by using the class fields to capture variables from the environment (not used here) and the default `this` method as the "apply" method of a Functor class.  Chapel's parameterized generic classes act as class/Functor templates for this application.  This class "template" is then instantiated once for each of the 64 "goto" table entries.  The use of this table is then structured to look like a call to a "setbit(array, start, limit, step)" function to make it clear that there is one operation per composite number culling/marking.
+
+For the dense hybrid technique add-on, the same general form using an array of classes-representing-functions is used, but these can't be generated automatically from a single parameterized generic class/template as the code varies per step value and thus code generation had to be used.  In another language that had true macros and not just templates, the code could all be generated in just a few lines of code, possibly inline to the source.  For languages with this facility, the threshold of dense base prime values could be extended to include 31 for an extra at least perceptible speed increase.

--- a/PrimeChapel/solution_1/primes.chpl
+++ b/PrimeChapel/solution_1/primes.chpl
@@ -12,7 +12,7 @@ type Prime = uint(64);
 
 const RANGE: Prime = 1000000;
 
-enum Techniques { OddsOnly, Unpeeled, UnpeeledBlock, Unrolled }
+enum Techniques { BitTwiddle, Unpeeled, UnpeeledBlock, Unrolled, UnrolledHybrid }
 
 const CPUL1CACHE: int = 16384; // in bytes
 
@@ -38,7 +38,7 @@ class UR {
     return 42; }
 }
 
-// each different generic parame instantiation makes a different sub class...
+// each different generic param instantiation makes a different sub class...
 class URr: UR {
   param ndx: uint(8);
   param pp = (ndx >> 3) & 7;
@@ -87,9 +87,9 @@ class URr: UR {
   }
 }
 
-// a computed goto jump table using closure classes...
+// a computed goto jump table using modulo pattern closure classes...
 type OUR = owned UR; // shorten it up!
-const unrollr = [
+const unrollr = [ // note that only cases 15, 27, 43, and 63 are used!
   new URr(0): OUR, new URr(1): OUR, new URr(2): OUR, new URr(3): OUR,
   new URr(4): OUR, new URr(5): OUR, new URr(6): OUR, new URr(7): OUR,
   new URr(8): OUR, new URr(9): OUR, new URr(10): OUR, new URr(11): OUR,
@@ -107,6 +107,756 @@ const unrollr = [
   new URr(56): OUR, new URr(57): OUR, new URr(58): OUR, new URr(59): OUR,
   new URr(60): OUR, new URr(61): OUR, new URr(62): OUR, new URr(63): OUR ];
 
+// each different generic param instantiation makes a different sub class...
+// don't have macros, so must generate code by hand or with generator...
+
+class URh3: UR {
+  // hybrid bit setting by densely packed uint64's...
+  override proc this(arrp: c_ptr(uint(8)), si: int, lmti: int, stp: int): int {
+    const ilmt = si | 63; // make stop limit to next 64-bit boundary
+    var biti = si;
+    while biti <= ilmt { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
+    const rlmtp =
+      c_ptrTo(arrp(((lmti >> 3) & (-8)) - 8 * (stp - 1))): c_ptr(uint(64));
+    var rp = c_ptrTo(arrp((biti >> 3) & (-8))): c_ptr(uint(64));
+    while rp: int(64) <= rlmtp: int(64) {
+      var v = rp(0) | 0x0000000000000004: uint(64);
+      v = v | 0x0000000000000020: uint(64);
+      v = v | 0x0000000000000100: uint(64);
+      v = v | 0x0000000000000800: uint(64);
+      v = v | 0x0000000000004000: uint(64);
+      v = v | 0x0000000000020000: uint(64);
+      v = v | 0x0000000000100000: uint(64);
+      v = v | 0x0000000000800000: uint(64);
+      v = v | 0x0000000004000000: uint(64);
+      v = v | 0x0000000020000000: uint(64);
+      v = v | 0x0000000100000000: uint(64);
+      v = v | 0x0000000800000000: uint(64);
+      v = v | 0x0000004000000000: uint(64);
+      v = v | 0x0000020000000000: uint(64);
+      v = v | 0x0000100000000000: uint(64);
+      v = v | 0x0000800000000000: uint(64);
+      v = v | 0x0004000000000000: uint(64);
+      v = v | 0x0020000000000000: uint(64);
+      v = v | 0x0100000000000000: uint(64);
+      v = v | 0x0800000000000000: uint(64);
+      rp(0) = v | 0x4000000000000000: uint(64);
+      v = rp(1) | 0x0000000000000002: uint(64);
+      v = v | 0x0000000000000010: uint(64);
+      v = v | 0x0000000000000080: uint(64);
+      v = v | 0x0000000000000400: uint(64);
+      v = v | 0x0000000000002000: uint(64);
+      v = v | 0x0000000000010000: uint(64);
+      v = v | 0x0000000000080000: uint(64);
+      v = v | 0x0000000000400000: uint(64);
+      v = v | 0x0000000002000000: uint(64);
+      v = v | 0x0000000010000000: uint(64);
+      v = v | 0x0000000080000000: uint(64);
+      v = v | 0x0000000400000000: uint(64);
+      v = v | 0x0000002000000000: uint(64);
+      v = v | 0x0000010000000000: uint(64);
+      v = v | 0x0000080000000000: uint(64);
+      v = v | 0x0000400000000000: uint(64);
+      v = v | 0x0002000000000000: uint(64);
+      v = v | 0x0010000000000000: uint(64);
+      v = v | 0x0080000000000000: uint(64);
+      v = v | 0x0400000000000000: uint(64);
+      rp(1) = v | 0x2000000000000000: uint(64);
+      v = rp(2) | 0x0000000000000001: uint(64);
+      v = v | 0x0000000000000008: uint(64);
+      v = v | 0x0000000000000040: uint(64);
+      v = v | 0x0000000000000200: uint(64);
+      v = v | 0x0000000000001000: uint(64);
+      v = v | 0x0000000000008000: uint(64);
+      v = v | 0x0000000000040000: uint(64);
+      v = v | 0x0000000000200000: uint(64);
+      v = v | 0x0000000001000000: uint(64);
+      v = v | 0x0000000008000000: uint(64);
+      v = v | 0x0000000040000000: uint(64);
+      v = v | 0x0000000200000000: uint(64);
+      v = v | 0x0000001000000000: uint(64);
+      v = v | 0x0000008000000000: uint(64);
+      v = v | 0x0000040000000000: uint(64);
+      v = v | 0x0000200000000000: uint(64);
+      v = v | 0x0001000000000000: uint(64);
+      v = v | 0x0008000000000000: uint(64);
+      v = v | 0x0040000000000000: uint(64);
+      v = v | 0x0200000000000000: uint(64);
+      v = v | 0x1000000000000000: uint(64);
+      rp(2) = v | 0x8000000000000000: uint(64);
+      rp += stp;
+    }
+    biti = ((rp: int(64) - arrp: int(64)) << 3) + (biti & 63);
+    while biti <= lmti { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
+    return biti;
+  }
+}
+
+class URh5: UR {
+  // hybrid bit setting by densely packed uint64's...
+  override proc this(arrp: c_ptr(uint(8)), si: int, lmti: int, stp: int): int {
+    const ilmt = si | 63; // make stop limit to next 64-bit boundary
+    var biti = si;
+    while biti <= ilmt { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
+    const rlmtp =
+      c_ptrTo(arrp(((lmti >> 3) & (-8)) - 8 * (stp - 1))): c_ptr(uint(64));
+    var rp = c_ptrTo(arrp((biti >> 3) & (-8))): c_ptr(uint(64));
+    while rp: int(64) <= rlmtp: int(64) {
+      var v = rp(0) | 0x0000000000000004: uint(64);
+      v = v | 0x0000000000000080: uint(64);
+      v = v | 0x0000000000001000: uint(64);
+      v = v | 0x0000000000020000: uint(64);
+      v = v | 0x0000000000400000: uint(64);
+      v = v | 0x0000000008000000: uint(64);
+      v = v | 0x0000000100000000: uint(64);
+      v = v | 0x0000002000000000: uint(64);
+      v = v | 0x0000040000000000: uint(64);
+      v = v | 0x0000800000000000: uint(64);
+      v = v | 0x0010000000000000: uint(64);
+      v = v | 0x0200000000000000: uint(64);
+      rp(0) = v | 0x4000000000000000: uint(64);
+      v = rp(1) | 0x0000000000000008: uint(64);
+      v = v | 0x0000000000000100: uint(64);
+      v = v | 0x0000000000002000: uint(64);
+      v = v | 0x0000000000040000: uint(64);
+      v = v | 0x0000000000800000: uint(64);
+      v = v | 0x0000000010000000: uint(64);
+      v = v | 0x0000000200000000: uint(64);
+      v = v | 0x0000004000000000: uint(64);
+      v = v | 0x0000080000000000: uint(64);
+      v = v | 0x0001000000000000: uint(64);
+      v = v | 0x0020000000000000: uint(64);
+      v = v | 0x0400000000000000: uint(64);
+      rp(1) = v | 0x8000000000000000: uint(64);
+      v = rp(2) | 0x0000000000000010: uint(64);
+      v = v | 0x0000000000000200: uint(64);
+      v = v | 0x0000000000004000: uint(64);
+      v = v | 0x0000000000080000: uint(64);
+      v = v | 0x0000000001000000: uint(64);
+      v = v | 0x0000000020000000: uint(64);
+      v = v | 0x0000000400000000: uint(64);
+      v = v | 0x0000008000000000: uint(64);
+      v = v | 0x0000100000000000: uint(64);
+      v = v | 0x0002000000000000: uint(64);
+      v = v | 0x0040000000000000: uint(64);
+      rp(2) = v | 0x0800000000000000: uint(64);
+      v = rp(3) | 0x0000000000000001: uint(64);
+      v = v | 0x0000000000000020: uint(64);
+      v = v | 0x0000000000000400: uint(64);
+      v = v | 0x0000000000008000: uint(64);
+      v = v | 0x0000000000100000: uint(64);
+      v = v | 0x0000000002000000: uint(64);
+      v = v | 0x0000000040000000: uint(64);
+      v = v | 0x0000000800000000: uint(64);
+      v = v | 0x0000010000000000: uint(64);
+      v = v | 0x0000200000000000: uint(64);
+      v = v | 0x0004000000000000: uint(64);
+      v = v | 0x0080000000000000: uint(64);
+      rp(3) = v | 0x1000000000000000: uint(64);
+      v = rp(4) | 0x0000000000000002: uint(64);
+      v = v | 0x0000000000000040: uint(64);
+      v = v | 0x0000000000000800: uint(64);
+      v = v | 0x0000000000010000: uint(64);
+      v = v | 0x0000000000200000: uint(64);
+      v = v | 0x0000000004000000: uint(64);
+      v = v | 0x0000000080000000: uint(64);
+      v = v | 0x0000001000000000: uint(64);
+      v = v | 0x0000020000000000: uint(64);
+      v = v | 0x0000400000000000: uint(64);
+      v = v | 0x0008000000000000: uint(64);
+      v = v | 0x0100000000000000: uint(64);
+      rp(4) = v | 0x2000000000000000: uint(64);
+      rp += stp;
+    }
+    biti = ((rp: int(64) - arrp: int(64)) << 3) + (biti & 63);
+    while biti <= lmti { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
+    return biti;
+  }
+}
+
+class URh7: UR {
+  // hybrid bit setting by densely packed uint64's...
+  override proc this(arrp: c_ptr(uint(8)), si: int, lmti: int, stp: int): int {
+    const ilmt = si | 63; // make stop limit to next 64-bit boundary
+    var biti = si;
+    while biti <= ilmt { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
+    const rlmtp =
+      c_ptrTo(arrp(((lmti >> 3) & (-8)) - 8 * (stp - 1))): c_ptr(uint(64));
+    var rp = c_ptrTo(arrp((biti >> 3) & (-8))): c_ptr(uint(64));
+    while rp: int(64) <= rlmtp: int(64) {
+      var v = rp(0) | 0x0000000000000002: uint(64);
+      v = v | 0x0000000000000100: uint(64);
+      v = v | 0x0000000000008000: uint(64);
+      v = v | 0x0000000000400000: uint(64);
+      v = v | 0x0000000020000000: uint(64);
+      v = v | 0x0000001000000000: uint(64);
+      v = v | 0x0000080000000000: uint(64);
+      v = v | 0x0004000000000000: uint(64);
+      rp(0) = v | 0x0200000000000000: uint(64);
+      v = rp(1) | 0x0000000000000001: uint(64);
+      v = v | 0x0000000000000080: uint(64);
+      v = v | 0x0000000000004000: uint(64);
+      v = v | 0x0000000000200000: uint(64);
+      v = v | 0x0000000010000000: uint(64);
+      v = v | 0x0000000800000000: uint(64);
+      v = v | 0x0000040000000000: uint(64);
+      v = v | 0x0002000000000000: uint(64);
+      v = v | 0x0100000000000000: uint(64);
+      rp(1) = v | 0x8000000000000000: uint(64);
+      v = rp(2) | 0x0000000000000040: uint(64);
+      v = v | 0x0000000000002000: uint(64);
+      v = v | 0x0000000000100000: uint(64);
+      v = v | 0x0000000008000000: uint(64);
+      v = v | 0x0000000400000000: uint(64);
+      v = v | 0x0000020000000000: uint(64);
+      v = v | 0x0001000000000000: uint(64);
+      v = v | 0x0080000000000000: uint(64);
+      rp(2) = v | 0x4000000000000000: uint(64);
+      v = rp(3) | 0x0000000000000020: uint(64);
+      v = v | 0x0000000000001000: uint(64);
+      v = v | 0x0000000000080000: uint(64);
+      v = v | 0x0000000004000000: uint(64);
+      v = v | 0x0000000200000000: uint(64);
+      v = v | 0x0000010000000000: uint(64);
+      v = v | 0x0000800000000000: uint(64);
+      v = v | 0x0040000000000000: uint(64);
+      rp(3) = v | 0x2000000000000000: uint(64);
+      v = rp(4) | 0x0000000000000010: uint(64);
+      v = v | 0x0000000000000800: uint(64);
+      v = v | 0x0000000000040000: uint(64);
+      v = v | 0x0000000002000000: uint(64);
+      v = v | 0x0000000100000000: uint(64);
+      v = v | 0x0000008000000000: uint(64);
+      v = v | 0x0000400000000000: uint(64);
+      v = v | 0x0020000000000000: uint(64);
+      rp(4) = v | 0x1000000000000000: uint(64);
+      v = rp(5) | 0x0000000000000008: uint(64);
+      v = v | 0x0000000000000400: uint(64);
+      v = v | 0x0000000000020000: uint(64);
+      v = v | 0x0000000001000000: uint(64);
+      v = v | 0x0000000080000000: uint(64);
+      v = v | 0x0000004000000000: uint(64);
+      v = v | 0x0000200000000000: uint(64);
+      v = v | 0x0010000000000000: uint(64);
+      rp(5) = v | 0x0800000000000000: uint(64);
+      v = rp(6) | 0x0000000000000004: uint(64);
+      v = v | 0x0000000000000200: uint(64);
+      v = v | 0x0000000000010000: uint(64);
+      v = v | 0x0000000000800000: uint(64);
+      v = v | 0x0000000040000000: uint(64);
+      v = v | 0x0000002000000000: uint(64);
+      v = v | 0x0000100000000000: uint(64);
+      v = v | 0x0008000000000000: uint(64);
+      rp(6) = v | 0x0400000000000000: uint(64);
+      rp += stp;
+    }
+    biti = ((rp: int(64) - arrp: int(64)) << 3) + (biti & 63);
+    while biti <= lmti { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
+    return biti;
+  }
+}
+
+class URh9: UR {
+  // hybrid bit setting by densely packed uint64's...
+  override proc this(arrp: c_ptr(uint(8)), si: int, lmti: int, stp: int): int {
+    const ilmt = si | 63; // make stop limit to next 64-bit boundary
+    var biti = si;
+    while biti <= ilmt { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
+    const rlmtp =
+      c_ptrTo(arrp(((lmti >> 3) & (-8)) - 8 * (stp - 1))): c_ptr(uint(64));
+    var rp = c_ptrTo(arrp((biti >> 3) & (-8))): c_ptr(uint(64));
+    while rp: int(64) <= rlmtp: int(64) {
+      var v = rp(0) | 0x0000000000000004: uint(64);
+      v = v | 0x0000000000000800: uint(64);
+      v = v | 0x0000000000100000: uint(64);
+      v = v | 0x0000000020000000: uint(64);
+      v = v | 0x0000004000000000: uint(64);
+      v = v | 0x0000800000000000: uint(64);
+      rp(0) = v | 0x0100000000000000: uint(64);
+      v = rp(1) | 0x0000000000000002: uint(64);
+      v = v | 0x0000000000000400: uint(64);
+      v = v | 0x0000000000080000: uint(64);
+      v = v | 0x0000000010000000: uint(64);
+      v = v | 0x0000002000000000: uint(64);
+      v = v | 0x0000400000000000: uint(64);
+      rp(1) = v | 0x0080000000000000: uint(64);
+      v = rp(2) | 0x0000000000000001: uint(64);
+      v = v | 0x0000000000000200: uint(64);
+      v = v | 0x0000000000040000: uint(64);
+      v = v | 0x0000000008000000: uint(64);
+      v = v | 0x0000001000000000: uint(64);
+      v = v | 0x0000200000000000: uint(64);
+      v = v | 0x0040000000000000: uint(64);
+      rp(2) = v | 0x8000000000000000: uint(64);
+      v = rp(3) | 0x0000000000000100: uint(64);
+      v = v | 0x0000000000020000: uint(64);
+      v = v | 0x0000000004000000: uint(64);
+      v = v | 0x0000000800000000: uint(64);
+      v = v | 0x0000100000000000: uint(64);
+      v = v | 0x0020000000000000: uint(64);
+      rp(3) = v | 0x4000000000000000: uint(64);
+      v = rp(4) | 0x0000000000000080: uint(64);
+      v = v | 0x0000000000010000: uint(64);
+      v = v | 0x0000000002000000: uint(64);
+      v = v | 0x0000000400000000: uint(64);
+      v = v | 0x0000080000000000: uint(64);
+      v = v | 0x0010000000000000: uint(64);
+      rp(4) = v | 0x2000000000000000: uint(64);
+      v = rp(5) | 0x0000000000000040: uint(64);
+      v = v | 0x0000000000008000: uint(64);
+      v = v | 0x0000000001000000: uint(64);
+      v = v | 0x0000000200000000: uint(64);
+      v = v | 0x0000040000000000: uint(64);
+      v = v | 0x0008000000000000: uint(64);
+      rp(5) = v | 0x1000000000000000: uint(64);
+      v = rp(6) | 0x0000000000000020: uint(64);
+      v = v | 0x0000000000004000: uint(64);
+      v = v | 0x0000000000800000: uint(64);
+      v = v | 0x0000000100000000: uint(64);
+      v = v | 0x0000020000000000: uint(64);
+      v = v | 0x0004000000000000: uint(64);
+      rp(6) = v | 0x0800000000000000: uint(64);
+      v = rp(7) | 0x0000000000000010: uint(64);
+      v = v | 0x0000000000002000: uint(64);
+      v = v | 0x0000000000400000: uint(64);
+      v = v | 0x0000000080000000: uint(64);
+      v = v | 0x0000010000000000: uint(64);
+      v = v | 0x0002000000000000: uint(64);
+      rp(7) = v | 0x0400000000000000: uint(64);
+      v = rp(8) | 0x0000000000000008: uint(64);
+      v = v | 0x0000000000001000: uint(64);
+      v = v | 0x0000000000200000: uint(64);
+      v = v | 0x0000000040000000: uint(64);
+      v = v | 0x0000008000000000: uint(64);
+      v = v | 0x0001000000000000: uint(64);
+      rp(8) = v | 0x0200000000000000: uint(64);
+      rp += stp;
+    }
+    biti = ((rp: int(64) - arrp: int(64)) << 3) + (biti & 63);
+    while biti <= lmti { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
+    return biti;
+  }
+}
+
+class URh11: UR {
+  // hybrid bit setting by densely packed uint64's...
+  override proc this(arrp: c_ptr(uint(8)), si: int, lmti: int, stp: int): int {
+    const ilmt = si | 63; // make stop limit to next 64-bit boundary
+    var biti = si;
+    while biti <= ilmt { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
+    const rlmtp =
+      c_ptrTo(arrp(((lmti >> 3) & (-8)) - 8 * (stp - 1))): c_ptr(uint(64));
+    var rp = c_ptrTo(arrp((biti >> 3) & (-8))): c_ptr(uint(64));
+    while rp: int(64) <= rlmtp: int(64) {
+      var v = rp(0) | 0x0000000000000040: uint(64);
+      v = v | 0x0000000000020000: uint(64);
+      v = v | 0x0000000010000000: uint(64);
+      v = v | 0x0000008000000000: uint(64);
+      v = v | 0x0004000000000000: uint(64);
+      rp(0) = v | 0x2000000000000000: uint(64);
+      v = rp(1) | 0x0000000000000100: uint(64);
+      v = v | 0x0000000000080000: uint(64);
+      v = v | 0x0000000040000000: uint(64);
+      v = v | 0x0000020000000000: uint(64);
+      v = v | 0x0010000000000000: uint(64);
+      rp(1) = v | 0x8000000000000000: uint(64);
+      v = rp(2) | 0x0000000000000400: uint(64);
+      v = v | 0x0000000000200000: uint(64);
+      v = v | 0x0000000100000000: uint(64);
+      v = v | 0x0000080000000000: uint(64);
+      rp(2) = v | 0x0040000000000000: uint(64);
+      v = rp(3) | 0x0000000000000002: uint(64);
+      v = v | 0x0000000000001000: uint(64);
+      v = v | 0x0000000000800000: uint(64);
+      v = v | 0x0000000400000000: uint(64);
+      v = v | 0x0000200000000000: uint(64);
+      rp(3) = v | 0x0100000000000000: uint(64);
+      v = rp(4) | 0x0000000000000008: uint(64);
+      v = v | 0x0000000000004000: uint(64);
+      v = v | 0x0000000002000000: uint(64);
+      v = v | 0x0000001000000000: uint(64);
+      v = v | 0x0000800000000000: uint(64);
+      rp(4) = v | 0x0400000000000000: uint(64);
+      v = rp(5) | 0x0000000000000020: uint(64);
+      v = v | 0x0000000000010000: uint(64);
+      v = v | 0x0000000008000000: uint(64);
+      v = v | 0x0000004000000000: uint(64);
+      v = v | 0x0002000000000000: uint(64);
+      rp(5) = v | 0x1000000000000000: uint(64);
+      v = rp(6) | 0x0000000000000080: uint(64);
+      v = v | 0x0000000000040000: uint(64);
+      v = v | 0x0000000020000000: uint(64);
+      v = v | 0x0000010000000000: uint(64);
+      v = v | 0x0008000000000000: uint(64);
+      rp(6) = v | 0x4000000000000000: uint(64);
+      v = rp(7) | 0x0000000000000200: uint(64);
+      v = v | 0x0000000000100000: uint(64);
+      v = v | 0x0000000080000000: uint(64);
+      v = v | 0x0000040000000000: uint(64);
+      rp(7) = v | 0x0020000000000000: uint(64);
+      v = rp(8) | 0x0000000000000001: uint(64);
+      v = v | 0x0000000000000800: uint(64);
+      v = v | 0x0000000000400000: uint(64);
+      v = v | 0x0000000200000000: uint(64);
+      v = v | 0x0000100000000000: uint(64);
+      rp(8) = v | 0x0080000000000000: uint(64);
+      v = rp(9) | 0x0000000000000004: uint(64);
+      v = v | 0x0000000000002000: uint(64);
+      v = v | 0x0000000001000000: uint(64);
+      v = v | 0x0000000800000000: uint(64);
+      v = v | 0x0000400000000000: uint(64);
+      rp(9) = v | 0x0200000000000000: uint(64);
+      v = rp(10) | 0x0000000000000010: uint(64);
+      v = v | 0x0000000000008000: uint(64);
+      v = v | 0x0000000004000000: uint(64);
+      v = v | 0x0000002000000000: uint(64);
+      v = v | 0x0001000000000000: uint(64);
+      rp(10) = v | 0x0800000000000000: uint(64);
+      rp += stp;
+    }
+    biti = ((rp: int(64) - arrp: int(64)) << 3) + (biti & 63);
+    while biti <= lmti { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
+    return biti;
+  }
+}
+
+class URh13: UR {
+  // hybrid bit setting by densely packed uint64's...
+  override proc this(arrp: c_ptr(uint(8)), si: int, lmti: int, stp: int): int {
+    const ilmt = si | 63; // make stop limit to next 64-bit boundary
+    var biti = si;
+    while biti <= ilmt { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
+    const rlmtp =
+      c_ptrTo(arrp(((lmti >> 3) & (-8)) - 8 * (stp - 1))): c_ptr(uint(64));
+    var rp = c_ptrTo(arrp((biti >> 3) & (-8))): c_ptr(uint(64));
+    while rp: int(64) <= rlmtp: int(64) {
+      var v = rp(0) | 0x0000000000000080: uint(64);
+      v = v | 0x0000000000100000: uint(64);
+      v = v | 0x0000000200000000: uint(64);
+      v = v | 0x0000400000000000: uint(64);
+      rp(0) = v | 0x0800000000000000: uint(64);
+      v = rp(1) | 0x0000000000000100: uint(64);
+      v = v | 0x0000000000200000: uint(64);
+      v = v | 0x0000000400000000: uint(64);
+      v = v | 0x0000800000000000: uint(64);
+      rp(1) = v | 0x1000000000000000: uint(64);
+      v = rp(2) | 0x0000000000000200: uint(64);
+      v = v | 0x0000000000400000: uint(64);
+      v = v | 0x0000000800000000: uint(64);
+      v = v | 0x0001000000000000: uint(64);
+      rp(2) = v | 0x2000000000000000: uint(64);
+      v = rp(3) | 0x0000000000000400: uint(64);
+      v = v | 0x0000000000800000: uint(64);
+      v = v | 0x0000001000000000: uint(64);
+      v = v | 0x0002000000000000: uint(64);
+      rp(3) = v | 0x4000000000000000: uint(64);
+      v = rp(4) | 0x0000000000000800: uint(64);
+      v = v | 0x0000000001000000: uint(64);
+      v = v | 0x0000002000000000: uint(64);
+      v = v | 0x0004000000000000: uint(64);
+      rp(4) = v | 0x8000000000000000: uint(64);
+      v = rp(5) | 0x0000000000001000: uint(64);
+      v = v | 0x0000000002000000: uint(64);
+      v = v | 0x0000004000000000: uint(64);
+      rp(5) = v | 0x0008000000000000: uint(64);
+      v = rp(6) | 0x0000000000000001: uint(64);
+      v = v | 0x0000000000002000: uint(64);
+      v = v | 0x0000000004000000: uint(64);
+      v = v | 0x0000008000000000: uint(64);
+      rp(6) = v | 0x0010000000000000: uint(64);
+      v = rp(7) | 0x0000000000000002: uint(64);
+      v = v | 0x0000000000004000: uint(64);
+      v = v | 0x0000000008000000: uint(64);
+      v = v | 0x0000010000000000: uint(64);
+      rp(7) = v | 0x0020000000000000: uint(64);
+      v = rp(8) | 0x0000000000000004: uint(64);
+      v = v | 0x0000000000008000: uint(64);
+      v = v | 0x0000000010000000: uint(64);
+      v = v | 0x0000020000000000: uint(64);
+      rp(8) = v | 0x0040000000000000: uint(64);
+      v = rp(9) | 0x0000000000000008: uint(64);
+      v = v | 0x0000000000010000: uint(64);
+      v = v | 0x0000000020000000: uint(64);
+      v = v | 0x0000040000000000: uint(64);
+      rp(9) = v | 0x0080000000000000: uint(64);
+      v = rp(10) | 0x0000000000000010: uint(64);
+      v = v | 0x0000000000020000: uint(64);
+      v = v | 0x0000000040000000: uint(64);
+      v = v | 0x0000080000000000: uint(64);
+      rp(10) = v | 0x0100000000000000: uint(64);
+      v = rp(11) | 0x0000000000000020: uint(64);
+      v = v | 0x0000000000040000: uint(64);
+      v = v | 0x0000000080000000: uint(64);
+      v = v | 0x0000100000000000: uint(64);
+      rp(11) = v | 0x0200000000000000: uint(64);
+      v = rp(12) | 0x0000000000000040: uint(64);
+      v = v | 0x0000000000080000: uint(64);
+      v = v | 0x0000000100000000: uint(64);
+      v = v | 0x0000200000000000: uint(64);
+      rp(12) = v | 0x0400000000000000: uint(64);
+      rp += stp;
+    }
+    biti = ((rp: int(64) - arrp: int(64)) << 3) + (biti & 63);
+    while biti <= lmti { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
+    return biti;
+  }
+}
+
+class URh15: UR {
+  // hybrid bit setting by densely packed uint64's...
+  override proc this(arrp: c_ptr(uint(8)), si: int, lmti: int, stp: int): int {
+    const ilmt = si | 63; // make stop limit to next 64-bit boundary
+    var biti = si;
+    while biti <= ilmt { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
+    const rlmtp =
+      c_ptrTo(arrp(((lmti >> 3) & (-8)) - 8 * (stp - 1))): c_ptr(uint(64));
+    var rp = c_ptrTo(arrp((biti >> 3) & (-8))): c_ptr(uint(64));
+    while rp: int(64) <= rlmtp: int(64) {
+      var v = rp(0) | 0x0000000000002000: uint(64);
+      v = v | 0x0000000010000000: uint(64);
+      v = v | 0x0000080000000000: uint(64);
+      rp(0) = v | 0x0400000000000000: uint(64);
+      v = rp(1) | 0x0000000000000200: uint(64);
+      v = v | 0x0000000001000000: uint(64);
+      v = v | 0x0000008000000000: uint(64);
+      rp(1) = v | 0x0040000000000000: uint(64);
+      v = rp(2) | 0x0000000000000020: uint(64);
+      v = v | 0x0000000000100000: uint(64);
+      v = v | 0x0000000800000000: uint(64);
+      rp(2) = v | 0x0004000000000000: uint(64);
+      v = rp(3) | 0x0000000000000002: uint(64);
+      v = v | 0x0000000000010000: uint(64);
+      v = v | 0x0000000080000000: uint(64);
+      v = v | 0x0000400000000000: uint(64);
+      rp(3) = v | 0x2000000000000000: uint(64);
+      v = rp(4) | 0x0000000000001000: uint(64);
+      v = v | 0x0000000008000000: uint(64);
+      v = v | 0x0000040000000000: uint(64);
+      rp(4) = v | 0x0200000000000000: uint(64);
+      v = rp(5) | 0x0000000000000100: uint(64);
+      v = v | 0x0000000000800000: uint(64);
+      v = v | 0x0000004000000000: uint(64);
+      rp(5) = v | 0x0020000000000000: uint(64);
+      v = rp(6) | 0x0000000000000010: uint(64);
+      v = v | 0x0000000000080000: uint(64);
+      v = v | 0x0000000400000000: uint(64);
+      rp(6) = v | 0x0002000000000000: uint(64);
+      v = rp(7) | 0x0000000000000001: uint(64);
+      v = v | 0x0000000000008000: uint(64);
+      v = v | 0x0000000040000000: uint(64);
+      v = v | 0x0000200000000000: uint(64);
+      rp(7) = v | 0x1000000000000000: uint(64);
+      v = rp(8) | 0x0000000000000800: uint(64);
+      v = v | 0x0000000004000000: uint(64);
+      v = v | 0x0000020000000000: uint(64);
+      rp(8) = v | 0x0100000000000000: uint(64);
+      v = rp(9) | 0x0000000000000080: uint(64);
+      v = v | 0x0000000000400000: uint(64);
+      v = v | 0x0000002000000000: uint(64);
+      rp(9) = v | 0x0010000000000000: uint(64);
+      v = rp(10) | 0x0000000000000008: uint(64);
+      v = v | 0x0000000000040000: uint(64);
+      v = v | 0x0000000200000000: uint(64);
+      v = v | 0x0001000000000000: uint(64);
+      rp(10) = v | 0x8000000000000000: uint(64);
+      v = rp(11) | 0x0000000000004000: uint(64);
+      v = v | 0x0000000020000000: uint(64);
+      v = v | 0x0000100000000000: uint(64);
+      rp(11) = v | 0x0800000000000000: uint(64);
+      v = rp(12) | 0x0000000000000400: uint(64);
+      v = v | 0x0000000002000000: uint(64);
+      v = v | 0x0000010000000000: uint(64);
+      rp(12) = v | 0x0080000000000000: uint(64);
+      v = rp(13) | 0x0000000000000040: uint(64);
+      v = v | 0x0000000000200000: uint(64);
+      v = v | 0x0000001000000000: uint(64);
+      rp(13) = v | 0x0008000000000000: uint(64);
+      v = rp(14) | 0x0000000000000004: uint(64);
+      v = v | 0x0000000000020000: uint(64);
+      v = v | 0x0000000100000000: uint(64);
+      v = v | 0x0000800000000000: uint(64);
+      rp(14) = v | 0x4000000000000000: uint(64);
+      rp += stp;
+    }
+    biti = ((rp: int(64) - arrp: int(64)) << 3) + (biti & 63);
+    while biti <= lmti { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
+    return biti;
+  }
+}
+
+class URh17: UR {
+  // hybrid bit setting by densely packed uint64's...
+  override proc this(arrp: c_ptr(uint(8)), si: int, lmti: int, stp: int): int {
+    const ilmt = si | 63; // make stop limit to next 64-bit boundary
+    var biti = si;
+    while biti <= ilmt { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
+    const rlmtp =
+      c_ptrTo(arrp(((lmti >> 3) & (-8)) - 8 * (stp - 1))): c_ptr(uint(64));
+    var rp = c_ptrTo(arrp((biti >> 3) & (-8))): c_ptr(uint(64));
+    while rp: int(64) <= rlmtp: int(64) {
+     var v = rp(0) | 0x0000000000000004: uint(64);
+      v = v | 0x0000000000080000: uint(64);
+      v = v | 0x0000001000000000: uint(64);
+      rp(0) = v | 0x0020000000000000: uint(64);
+      v = rp(1) | 0x0000000000000040: uint(64);
+      v = v | 0x0000000000800000: uint(64);
+      v = v | 0x0000010000000000: uint(64);
+      rp(1) = v | 0x0200000000000000: uint(64);
+      v = rp(2) | 0x0000000000000400: uint(64);
+      v = v | 0x0000000008000000: uint(64);
+      v = v | 0x0000100000000000: uint(64);
+      rp(2) = v | 0x2000000000000000: uint(64);
+      v = rp(3) | 0x0000000000004000: uint(64);
+      v = v | 0x0000000080000000: uint(64);
+      rp(3) = v | 0x0001000000000000: uint(64);
+      v = rp(4) | 0x0000000000000002: uint(64);
+      v = v | 0x0000000000040000: uint(64);
+      v = v | 0x0000000800000000: uint(64);
+      rp(4) = v | 0x0010000000000000: uint(64);
+      v = rp(5) | 0x0000000000000020: uint(64);
+      v = v | 0x0000000000400000: uint(64);
+      v = v | 0x0000008000000000: uint(64);
+      rp(5) = v | 0x0100000000000000: uint(64);
+      v = rp(6) | 0x0000000000000200: uint(64);
+      v = v | 0x0000000004000000: uint(64);
+      v = v | 0x0000080000000000: uint(64);
+      rp(6) = v | 0x1000000000000000: uint(64);
+      v = rp(7) | 0x0000000000002000: uint(64);
+      v = v | 0x0000000040000000: uint(64);
+      rp(7) = v | 0x0000800000000000: uint(64);
+      v = rp(8) | 0x0000000000000001: uint(64);
+      v = v | 0x0000000000020000: uint(64);
+      v = v | 0x0000000400000000: uint(64);
+      rp(8) = v | 0x0008000000000000: uint(64);
+      v = rp(9) | 0x0000000000000010: uint(64);
+      v = v | 0x0000000000200000: uint(64);
+      v = v | 0x0000004000000000: uint(64);
+      rp(9) = v | 0x0080000000000000: uint(64);
+      v = rp(10) | 0x0000000000000100: uint(64);
+      v = v | 0x0000000002000000: uint(64);
+      v = v | 0x0000040000000000: uint(64);
+      rp(10) = v | 0x0800000000000000: uint(64);
+      v = rp(11) | 0x0000000000001000: uint(64);
+      v = v | 0x0000000020000000: uint(64);
+      v = v | 0x0000400000000000: uint(64);
+      rp(11) = v | 0x8000000000000000: uint(64);
+      v = rp(12) | 0x0000000000010000: uint(64);
+      v = v | 0x0000000200000000: uint(64);
+      rp(12) = v | 0x0004000000000000: uint(64);
+      v = rp(13) | 0x0000000000000008: uint(64);
+      v = v | 0x0000000000100000: uint(64);
+      v = v | 0x0000002000000000: uint(64);
+      rp(13) = v | 0x0040000000000000: uint(64);
+      v = rp(14) | 0x0000000000000080: uint(64);
+      v = v | 0x0000000001000000: uint(64);
+      v = v | 0x0000020000000000: uint(64);
+      rp(14) = v | 0x0400000000000000: uint(64);
+      v = rp(15) | 0x0000000000000800: uint(64);
+      v = v | 0x0000000010000000: uint(64);
+      v = v | 0x0000200000000000: uint(64);
+      rp(15) = v | 0x4000000000000000: uint(64);
+      v = rp(16) | 0x0000000000008000: uint(64);
+      v = v | 0x0000000100000000: uint(64);
+      rp(16) = v | 0x0002000000000000: uint(64);
+      rp += stp;
+    }
+    biti = ((rp: int(64) - arrp: int(64)) << 3) + (biti & 63);
+    while biti <= lmti { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
+    return biti;
+  }
+}
+
+class URh19: UR {
+  // hybrid bit setting by densely packed uint64's...
+  override proc this(arrp: c_ptr(uint(8)), si: int, lmti: int, stp: int): int {
+    const ilmt = si | 63; // make stop limit to next 64-bit boundary
+    var biti = si;
+    while biti <= ilmt { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
+    const rlmtp =
+      c_ptrTo(arrp(((lmti >> 3) & (-8)) - 8 * (stp - 1))): c_ptr(uint(64));
+    var rp = c_ptrTo(arrp((biti >> 3) & (-8))): c_ptr(uint(64));
+    while rp: int(64) <= rlmtp: int(64) {
+      var v = rp(0) | 0x0000000000000040: uint(64);
+      v = v | 0x0000000002000000: uint(64);
+      v = v | 0x0000100000000000: uint(64);
+      rp(0) = v | 0x8000000000000000: uint(64);
+      v = rp(1) | 0x0000000000040000: uint(64);
+      v = v | 0x0000002000000000: uint(64);
+      rp(1) = v | 0x0100000000000000: uint(64);
+      v = rp(2) | 0x0000000000000800: uint(64);
+      v = v | 0x0000000040000000: uint(64);
+      rp(2) = v | 0x0002000000000000: uint(64);
+      v = rp(3) | 0x0000000000000010: uint(64);
+      v = v | 0x0000000000800000: uint(64);
+      v = v | 0x0000040000000000: uint(64);
+      rp(3) = v | 0x2000000000000000: uint(64);
+      v = rp(4) | 0x0000000000010000: uint(64);
+      v = v | 0x0000000800000000: uint(64);
+      rp(4) = v | 0x0040000000000000: uint(64);
+      v = rp(5) | 0x0000000000000200: uint(64);
+      v = v | 0x0000000010000000: uint(64);
+      rp(5) = v | 0x0000800000000000: uint(64);
+      v = rp(6) | 0x0000000000000004: uint(64);
+      v = v | 0x0000000000200000: uint(64);
+      v = v | 0x0000010000000000: uint(64);
+      rp(6) = v | 0x0800000000000000: uint(64);
+      v = rp(7) | 0x0000000000004000: uint(64);
+      v = v | 0x0000000200000000: uint(64);
+      rp(7) = v | 0x0010000000000000: uint(64);
+      v = rp(8) | 0x0000000000000080: uint(64);
+      v = v | 0x0000000004000000: uint(64);
+      rp(8) = v | 0x0000200000000000: uint(64);
+      v = rp(9) | 0x0000000000000001: uint(64);
+      v = v | 0x0000000000080000: uint(64);
+      v = v | 0x0000004000000000: uint(64);
+      rp(9) = v | 0x0200000000000000: uint(64);
+      v = rp(10) | 0x0000000000001000: uint(64);
+      v = v | 0x0000000080000000: uint(64);
+      rp(10) = v | 0x0004000000000000: uint(64);
+      v = rp(11) | 0x0000000000000020: uint(64);
+      v = v | 0x0000000001000000: uint(64);
+      v = v | 0x0000080000000000: uint(64);
+      rp(11) = v | 0x4000000000000000: uint(64);
+      v = rp(12) | 0x0000000000020000: uint(64);
+      v = v | 0x0000001000000000: uint(64);
+      rp(12) = v | 0x0080000000000000: uint(64);
+      v = rp(13) | 0x0000000000000400: uint(64);
+      v = v | 0x0000000020000000: uint(64);
+      rp(13) = v | 0x0001000000000000: uint(64);
+      v = rp(14) | 0x0000000000000008: uint(64);
+      v = v | 0x0000000000400000: uint(64);
+      v = v | 0x0000020000000000: uint(64);
+      rp(14) = v | 0x1000000000000000: uint(64);
+      v = rp(15) | 0x0000000000008000: uint(64);
+      v = v | 0x0000000400000000: uint(64);
+      rp(15) = v | 0x0020000000000000: uint(64);
+      v = rp(16) | 0x0000000000000100: uint(64);
+      v = v | 0x0000000008000000: uint(64);
+      rp(16) = v | 0x0000400000000000: uint(64);
+      v = rp(17) | 0x0000000000000002: uint(64);
+      v = v | 0x0000000000100000: uint(64);
+      v = v | 0x0000008000000000: uint(64);
+      rp(17) = v | 0x0400000000000000: uint(64);
+      v = rp(18) | 0x0000000000002000: uint(64);
+      v = v | 0x0000000100000000: uint(64);
+      rp(18) = v | 0x0008000000000000: uint(64);
+      rp += stp;
+    }
+    biti = ((rp: int(64) - arrp: int(64)) << 3) + (biti & 63);
+    while biti <= lmti { arrp(biti >> 3) |= BITMASK(biti & 7); biti += stp; }
+    return biti;
+  }
+}
+
+// a computed goto jump table using modulo pattern closure classes...
+const hybrid = [ // note only cases 3, 5, 7 .. 19 are used; 9 and 15 never hit!
+  new URr(0): OUR, new URr(1): OUR, new URr(2): OUR, new URh3(): OUR,
+  new URr(4): OUR, new URh5(): OUR, new URr(6): OUR, new URh7(): OUR,
+  new URr(8): OUR, new URh9(): OUR, new URr(10): OUR, new URh11(): OUR,
+  new URr(12): OUR, new URh13(): OUR, new URr(14): OUR, new URh15(): OUR,
+  new URr(16): OUR, new URh17(): OUR, new URr(18): OUR, new URh19(): OUR,
+  new URr(20): OUR, new URr(21): OUR, new URr(22): OUR, new URr(23): OUR ];
+
 class PrimeSieve {
   const limit: Prime;
   const size: int = 0;
@@ -119,7 +869,7 @@ class PrimeSieve {
     this.buffer = 0;
     const bufferp = c_ptrTo(this.buffer[0]);
     select tec {
-      when Techniques.OddsOnly do
+      when Techniques.BitTwiddle do
         for i in 0 .. bitlmt {
           if bufferp[i >> 3] & BITMASK[i & 7] == 0 {
             var startndx = (i + i) * (i + 3) + 3;
@@ -179,7 +929,19 @@ class PrimeSieve {
             var startndx = (i + i) * (i + 3) + 3;
             if startndx > bitlmt then break;
             const bp = i + i + 3;
-            unrollr[((bp & 7) << 3) | (startndx & 7)](bufferp, startndx, bitlmt, bp);
+            unrollr[((bp & 7) << 3) | (startndx & 7)]
+              (bufferp, startndx, bitlmt, bp);
+          }
+        }
+      when Techniques.UnrolledHybrid do
+        for i in 0 .. bitlmt {
+          if bufferp[i >> 3] & BITMASK[i & 7] == 0 {
+            var startndx = (i + i) * (i + 3) + 3;
+            if startndx > bitlmt then break;
+            const bp = i + i + 3;
+            if bp <= 19 then hybrid[bp](bufferp, startndx, bitlmt, bp);
+            else unrollr[((bp & 7) << 3) | (startndx & 7)]
+                   (bufferp, startndx, bitlmt, bp);
           }
         }
     }
@@ -214,13 +976,15 @@ proc benchmark(tech: Techniques) {
   if count == EXPECTED {
     const lbl: string =
       "GordonBGood_" +
-        if tech == Techniques.OddsOnly then "1of2;"
+        if tech == Techniques.BitTwiddle then "bittwiddle;"
         else if tech == Techniques.Unpeeled then "unpeeled;"
         else if tech == Techniques.UnpeeledBlock then "unpeeled_block;"
-        else "unrolled;";
+        else if tech == Techniques.Unrolled then "unrolled;"
+        else "unrolled_hybrid;";
     writeln(lbl, passes, ";", duration, ";1;algorithm=base,faithful=yes,bits=1");
   }
   else { writeln("Invalid result!"); }  
 }
 
 for t in Techniques do benchmark(t);
+


### PR DESCRIPTION
## Description

This adds a dense base prime value technique which handles base prime values up to and including nineteen; base prime values above that point use the same extreme loop unrolling technique as before.

It speeds up the extreme loop unrolling in two ways:  it reduces "cache thrashing" due to accessing memory less frequently and by larger spans closer to the cache line size, and it reduces a large proportion of the dense culling/marking operations to register/immediate value operations not involving memory access for a large reduction in the average  number of CPU clock cycles per operation.

I believe that it is `faithful to base` in that, unlike some "word" techniques it does not combine the culling/marking of composite bits within the same word with a single operation using a multi value mask but has a marking operation for each and every bit; it also assumes no prior knowledge of the base prime values other than as allowed that the only even prime is two, and covers the cases of culling by all odd step values such as nine and fifteen, which will never by used as they are not prime.

The code is long because Chapel does not have code generating macros (only something that can be used as a template) so the required dense culling patterns had to be externally code generated.  However, as Chapel is an Object Oriented Programming language, the code should be easy to read by most programmers and easily translated to other languages.

The code is issued as a program that authors of other languages can emulate the techniques used and thereby see how well optimized the code as generated by their language is; it is more interesting than the general "drag race" because authors would implement this very same technique and thus compare the compiler's ability.  Also, authors should try to write as efficiently and elegantly as possible in their chosen language, as the code will be reviewed at end culmination of this race.

Other languages, especially those that have code generating macros, will be able to greatly shorten the code and may be able to extend the threshold of dense base primes up to the value of above 31 for an extra small increase in speed.

## Contributing requirements
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
