### PR TITLE
TeX/solution_2: arm-compatible Dockerfile

### DIFF
--- a/PrimeTeX/solution_2/Dockerfile
+++ b/PrimeTeX/solution_2/Dockerfile
@@ -1,6 +1,10 @@
-FROM phipsgabler/texlive-minimal@sha256:f1e37453ef11783e582033adc07ba908839c00889634d17364a3a7869bc7f56d
+FROM ubuntu:20.04
 
 WORKDIR /opt/app
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y texlive-base
 
 COPY shared_batteries.tex *_sieve.tex *_benchmark.tex runpdftex.sh texmf.cnf ./
 

--- a/PrimeTeX/solution_2/README.md
+++ b/PrimeTeX/solution_2/README.md
@@ -47,8 +47,8 @@ range of `1,000,000`, as each pass consumes about `500,000` words of font
 memory which can not be released (the memory could be re-used, but for
 fairness of the benchmark each pass re-allocates new memory).
 
-As at my locale I achieve with `pdftex` about `77` passes for the
-`wheel48of210` implementation, a computer about `4` times faster than mine
+As at my locale I achieve with `pdftex` running in the Docker container about `80` passes for the
+`wheel48of210` implementation, a computer about `3.7` times faster than mine
 would exhaust the `pdftex` maximal font memory during the benchmark, even with
 `pdftex` configured to use the maximal possibly font memory setting, as is
 done via the `runpdftex.sh` script used by the Dockerfile.
@@ -99,19 +99,19 @@ DDR3 of memory (mid-2012 machine, native OS: mac osx high sierra).
 Docker run with `pdftex`:
 
 ```
-jfbu-tex;24;5.20622;1;algorithm=base,faithful=no,bits=32
-jfbu-tex-8of30;62;5.07578;1;algorithm=wheel,faithful=no,bits=32
-jfbu-tex-48of210;71;5.04659;1;algorithm=wheel,faithful=no,bits=32
-jfbu-tex-480of2310;40;5.11597;1;algorithm=wheel,faithful=no,bits=32
+jfbu-tex;28;5.14409;1;algorithm=base,faithful=no,bits=32
+jfbu-tex-8of30;73;5.0266;1;algorithm=wheel,faithful=no,bits=32
+jfbu-tex-48of210;81;5.00916;1;algorithm=wheel,faithful=no,bits=32
+jfbu-tex-480of2310;45;5.04994;1;algorithm=wheel,faithful=no,bits=32
 ```
 
-Docker run, when Dockerfile was using `luatex` (via `run.sh`):
+Docker run (with a Dockerfile modified to use `luatex` via `run.sh` in place of `runpdftex.sh`):
 
 ```
-jfbu-tex;22;5.02206;1;algorithm=base,faithful=no,bits=32
-jfbu-tex-8of30;55;5.0123;1;algorithm=wheel,faithful=no,bits=32
-jfbu-tex-48of210;60;5.03543;1;algorithm=wheel,faithful=no,bits=32
-jfbu-tex-480of2310;35;5.09851;1;algorithm=wheel,faithful=no,bits=32
+jfbu-tex;26;5.0469;1;algorithm=base,faithful=no,bits=32
+jfbu-tex-8of30;63;5.05162;1;algorithm=wheel,faithful=no,bits=32
+jfbu-tex-48of210;71;5.06566;1;algorithm=wheel,faithful=no,bits=32
+jfbu-tex-480of2310;41;5.12201;1;algorithm=wheel,faithful=no,bits=32
 ```
 
 The reason why the 480-of-2310 wheel is significantly slower than the two
@@ -146,21 +146,14 @@ TeXLive 2021.
 The native `pdftex` is compiled
 locally from sources with compiler flags for speed.
 
-The Dockerfile is based on a minimal TeXLive 2018 install.
+The Dockerfile is based on Ubuntu 20.04 and installs its
+[texlive-base](https://packages.ubuntu.com/focal/texlive-base) package
+(which uses TeXLive 2019).
 
 I don't know why the speed ratio wheel/base is higher with `pdftex`, or with
 the `luatex` in a Docker container, than with the native `luatex`.
 
 ## Information on some of the files
-
-`Dockerfile` is based on
-[`texlive-minimal`](https://hub.docker.com/r/phipsgabler/texlive-minimal) from
-phipsgabler and uses a TeXLive 2018 installation.  In case you wan't to re-use it and expand it with addition of more TeXLive 2018 contents, this can be useful:
-
-```
-RUN tlmgr update --repository http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2018/tlnet-final/ --self
-RUN tlmgr install --repository http://ftp.math.utah.edu/pub/tex/historic/systems/texlive/2018/tlnet-final/ <whatever>
-```
 
 `texmf.cnf` is a file which instructs `pdftex` to use more memory, once the
 `TEXMFCNF` environment variable is suitably set, as done by `runpdftex.sh`. It

--- a/PrimeTeX/solution_2/README.md
+++ b/PrimeTeX/solution_2/README.md
@@ -220,6 +220,13 @@ sieves up to `100,000,000` in about `7s` at my locale, but then needs
 an additional `18s` to produce the file with the `5,761,455` primes
 `<100,000,000`, one per line.
 
+The above syntax (without the `time`) works also on Windows with TeXLive. On Windows with MikTeX, try this:
+
+```
+pdftex.exe -font-mem-size=51000000 -extra-mem-top=13000000 "\def\Range{100000000}\input wheel48of210_primestofile"
+```
+
+
 Even with maximal font memory, `pdftex` will not allow sieving up to about `295,000,000` and beyond. With `luatex` we can go up to `999,999,999`:
 
 ```
@@ -233,7 +240,7 @@ array (about two minutes).
 See files `{erato,wheel8of30,wheel48of210,wheel}_primestofile_timings.txt` for
 some further typical timings as seen on my hardware. These files contain the
 console commands needed to execute the various runs in a syntax which I am
-told is Windows-compatible, apart from the usage of `time` utility.
+told is Windows-compatible (if using TeXLive), apart from the usage of `time` utility.
 
 
 ## More info on native runs with pdftex

--- a/PrimeTeX/solution_2/wheel_primestofile_timings.txt
+++ b/PrimeTeX/solution_2/wheel_primestofile_timings.txt
@@ -155,7 +155,7 @@ sys	0m0.428s
 N = 999,999,999
 ===============
 
-$ time luatex \\def\\Range{999999999}\\input wheel_primestofile
+$ time luatex "\def\Range{999999999}\input wheel_primestofile"
 This is LuaTeX, Version 1.13.0 (TeX Live 2021) 
  restricted system commands enabled.
 (./wheel_primestofile.tex (./wheel_sieve.tex (./shared_batteries.tex))


### PR DESCRIPTION
## Description
<!--
Add your description yere.
-->

I modify the Dockerfile to be based on Ubuntu:20.04 and its texlive-base as this is the simplest solution I have found for compatibility with both arm and amd. Inspired by the Dockerfile of TeX/solution_1.

As a bonus the Docker runs are a bit faster, don't know why (previous one was Alpine based texlive-minimal install).

Also some tidbits on usage with Windows/MikTeX or TeXLive

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
