### PR TITLE
Change Nim solution_3 to unrolled hybrid...

### DIFF
--- a/PrimeNim/solution_3/Dockerfile
+++ b/PrimeNim/solution_3/Dockerfile
@@ -1,17 +1,7 @@
-FROM fedora:34
+FROM primeimages/nim:1.4.8
 
-# install prerequisites and build Nim from source...
-RUN dnf --refresh -y upgrade && dnf install -y wget xz gcc \
-      && mkdir nim-lang && cd nim-lang \
-      && wget https://nim-lang.org/download/nim-1.4.8.tar.xz \
-      && tar -axf nim-1.4.8.tar.xz && cd nim-1.4.8 \
-      && sh build.sh && bin/nim c -d:release koch && ./koch boot -d:release \
-      && cd .. && rm -rdf nim-1.4.8.tar.xz && cd ..
-
-# compile program...
 WORKDIR /opt/app
 COPY primes.nim .
-RUN PATH=/nim-lang/nim-1.4.8/bin:$PATH nim c --gc:arc -d:danger -t:-march=native -d:lto primes.nim
+RUN nim c --gc:arc -d:danger -t:-march=native -d:lto primes.nim
 
-# program binary ready to run...
 ENTRYPOINT [ "/opt/app/primes" ]

--- a/PrimeNim/solution_3/Dockerfile
+++ b/PrimeNim/solution_3/Dockerfile
@@ -1,7 +1,17 @@
-FROM nimlang/nim:ubuntu
+FROM fedora:34
 
+# install prerequisites and build Nim from source...
+RUN dnf --refresh -y upgrade && dnf install -y wget xz gcc \
+      && mkdir nim-lang && cd nim-lang \
+      && wget https://nim-lang.org/download/nim-1.4.8.tar.xz \
+      && tar -axf nim-1.4.8.tar.xz && cd nim-1.4.8 \
+      && sh build.sh && bin/nim c -d:release koch && ./koch boot -d:release \
+      && cd .. && rm -rdf nim-1.4.8.tar.xz && cd ..
+
+# compile program...
 WORKDIR /opt/app
 COPY primes.nim .
-RUN nim c --gc:arc -d:danger -t:-march=native -d:lto primes.nim
+RUN PATH=/nim-lang/nim-1.4.8/bin:$PATH nim c --gc:arc -d:danger -t:-march=native -d:lto primes.nim
 
+# program binary ready to run...
 ENTRYPOINT [ "/opt/app/primes" ]

--- a/PrimeNim/solution_3/README.md
+++ b/PrimeNim/solution_3/README.md
@@ -34,7 +34,7 @@ This version runs about the same speed run either on the Docker image or locally
 
 The following is as run on an Intel SkyLake i5-6500 at 3.6 GHz (single-threaded):
 ```
-GordonBGood_unrolled_hybrid;41183;5.000098727;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_extreme_hybrid;41183;5.000098727;1;algorithm=base,faithful=yes,bits=1
 ```
 
 ## Benchmarks
@@ -54,7 +54,7 @@ Which matches the results when run with Docker on the same machine as follows:
 ┌───────┬────────────────┬──────────┬─────────────────────────────┬────────┬──────────┬─────────┬───────────┬──────────┬──────┬───────────────┐
 │ Index │ Implementation │ Solution │ Label                       │ Passes │ Duration │ Threads │ Algorithm │ Faithful │ Bits │ Passes/Second │
 ├───────┼────────────────┼──────────┼─────────────────────────────┼────────┼──────────┼─────────┼───────────┼──────────┼──────┼───────────────┤
-│   1   │ nim            │ 3        │ GordonBGood_unrolled_hybrid │ 41322  │ 5.00004  │    1    │   base    │   yes    │ 1    │  8264.33563   │
+│   1   │ nim            │ 3        │ GordonBGood_extreme_hybrid │ 41322  │ 5.00004  │    1    │   base    │   yes    │ 1    │  8264.33563   │
 └───────┴────────────────┴──────────┴─────────────────────────────┴────────┴──────────┴─────────┴───────────┴──────────┴──────┴───────────────┘
 
 

--- a/PrimeNim/solution_3/README.md
+++ b/PrimeNim/solution_3/README.md
@@ -1,4 +1,4 @@
-# Nim implementation #3
+# Nim implementation #3 by GordonBGood
 
 ![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
 ![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
@@ -24,15 +24,17 @@ docker build -t primes .
 docker run --rm primes
 ```
 
-Uses the official Ubuntu images.
+The Dockerfile builds a Nim compiler in a Fedora container from source on whatever architecture it is run.
 
 ## Benchmarks
 
 This version runs about the same speed run either on the Docker image or locally when run on the same machine.
 
 ## Output
+
+The following is as run on an Intel SkyLake i5-6500 at 3.6 GHz (single-threaded):
 ```
-GordonBGood_1of2;18223;5.000027703;1;algorithm=base,faithful=yes,bits=1
+GordonBGood_unrolled_hybrid;41183;5.000098727;1;algorithm=base,faithful=yes,bits=1
 ```
 
 ## Benchmarks
@@ -40,22 +42,21 @@ GordonBGood_1of2;18223;5.000027703;1;algorithm=base,faithful=yes,bits=1
 Running locally on my Intel SkyLake i5-6500 at 3.6 GHz when single threaded, I get some astounding numbers:
 
 ```
-Passes: 18206, Time: 5.000073695, Avg: 0.0002746387836427551, Limit: 1000000, Count1: 78498, Count2: 78498, Valid: true
-Passes: 18032, Time: 5.000169903, Avg: 0.0002772942492790594, Limit: 1000000, Count1: 78498, Count2: 78498, Valid: true
-Passes: 18188, Time: 5.000128758, Avg: 0.0002749136110622388, Limit: 1000000, Count1: 78498, Count2: 78498, Valid: true
-Passes: 18168, Time: 5.000089205, Avg: 0.0002752140689674152, Limit: 1000000, Count1: 78498, Count2: 78498, Valid: true
-Passes: 18223, Time: 5.000027703, Avg: 0.0002743800528453053, Limit: 1000000, Count1: 78498, Count2: 78498, Valid: true
+Passes: 41183, Time: 5.000098727, Avg: 0.0001214117166549304, Limit: 1000000, Count1: 78498, Count2: 78498, Valid: true
+Passes: 41197, Time: 5.000114014, Avg: 0.0001213708283127412, Limit: 1000000, Count1: 78498, Count2: 78498, Valid: true
+Passes: 41103, Time: 5.000067782, Avg: 0.0001216472710507749, Limit: 1000000, Count1: 78498, Count2: 78498, Valid: true
+Passes: 41681, Time: 5.000082284, Avg: 0.0001199607083323337, Limit: 1000000, Count1: 78498, Count2: 78498, Valid: true
+Passes: 41709, Time: 5.0000606, Avg: 0.0001198796566688245, Limit: 1000000, Count1: 78498, Count2: 78498, Valid: true
 ```
 Which matches the results when run with Docker on the same machine as follows:
 
-```
-                                                          Single-threaded                                                           
-┌───────┬────────────────┬──────────┬──────────────────┬────────┬──────────┬─────────┬───────────┬──────────┬──────┬───────────────┐
-│ Index │ Implementation │ Solution │ Label            │ Passes │ Duration │ Threads │ Algorithm │ Faithful │ Bits │ Passes/Second │
-├───────┼────────────────┼──────────┼──────────────────┼────────┼──────────┼─────────┼───────────┼──────────┼──────┼───────────────┤
-│   1   │ PrimeNim       │ 3        │ GordonBGood_1of2 │ 18023  │ 5.00008  │    1    │   base    │   yes    │ 1    │  3604.54114   │
-└───────┴────────────────┴──────────┴──────────────────┴────────┴──────────┴─────────┴───────────┴──────────┴──────┴───────────────┘
-```
+                                                                Single-threaded                                                                
+┌───────┬────────────────┬──────────┬─────────────────────────────┬────────┬──────────┬─────────┬───────────┬──────────┬──────┬───────────────┐
+│ Index │ Implementation │ Solution │ Label                       │ Passes │ Duration │ Threads │ Algorithm │ Faithful │ Bits │ Passes/Second │
+├───────┼────────────────┼──────────┼─────────────────────────────┼────────┼──────────┼─────────┼───────────┼──────────┼──────┼───────────────┤
+│   1   │ nim            │ 3        │ GordonBGood_unrolled_hybrid │ 41322  │ 5.00004  │    1    │   base    │   yes    │ 1    │  8264.33563   │
+└───────┴────────────────┴──────────┴─────────────────────────────┴────────┴──────────┴─────────┴───────────┴──────────┴──────┴───────────────┘
+
 
 ## Notes
 
@@ -69,11 +70,13 @@ This benchmark is written to be true to the "faithful to base algorithm" specifi
 6. The sieving buffer starts in zeroed state with composite number bit representatives marked as one when culled as is allowed.
 7. There are approximately 810,000 culling/marking of composite representations just as for the original odds-only algorithm.
 
-There are minor tweaks, but the major reason that this implementation is so much faster than others, is "Extreme Loop Unrolling" using a Nim macro to generate the thousands of lines of code based on modulo patterns that result from stepping within a (even bits) byte array.  This technique is similar to the "striping" technique used by the fastest "faithful to base algorithm" Rust implementation which culls by eight simpler-than-"bit-twiddling"-per-bit constant mask value loops per base prime, but this implementation instead combines those eight "striping" loops into a single loop with eight culling operations per loop, with the macro calculating the necessary variations as to the immediate bit mask to be used for each cull in each of the patterns.  Thus, it is similar to the techniques that have already been accepted, just refined to the utmost.
+There are minor tweaks, but one reason that this implementation is so much faster than others, is "Extreme Loop Unrolling" using a Nim macro to generate the thousands of lines of code based on modulo patterns that result from stepping within a (even bits) byte array.  This technique is similar to the "striping" technique used by the fastest "faithful to base algorithm" Rust implementation which culls by eight simpler-than-"bit-twiddling"-per-bit constant mask value loops per base prime, but this implementation instead combines those eight "striping" loops into a single loop with eight culling operations per loop, with the macro calculating the necessary variations as to the immediate bit mask to be used for each cull in each of the patterns.  Thus, it is similar to the techniques that have already been accepted, just refined to the utmost.
+
+The other even more important reason this implementation is so fast is that it uses the same dense culling for small base prime values as in the fastest Chapel version, where when there are multiple bits per 64-bit word to be culled, the entire word is read into a variable `v`, the individual bits to be culled are marked by a modulo pattern mask each, and when all bits to be culled in the given word have been marked, the value `v` is committed back to the original location in the deliverable sieve buffer; this sequence is then repeated for the number of words in the repeating modulo pattern.  This is so fast for two reasons:  first, it reduces the average operation time to as little a one third of a CPU clock cycle per operations, and second, it improves cache associativity by cache lines as it advances linearly across the entire sieving buffer, just as the above extreme loop unrolling does, but now the extreme loop unrolling also advances by at least eight bytes at a time.  This dense marking technique is likely even more important than the extreme loop unrolling technique as many more of the operations ar dense than not.  The dense threshold has been set at base primes below 64, which seems to be about optimum, and again helps speed as compared to the Chapel version for which the dense base prime threshold is 19.  One can see the generated code at compile time for the base prime/step value of three by uncommenting line 178.
 
 In order to make it obvious that this implementation is "faithful to base", the `bitSeq  bit array has been implemented as a custom type with all memory access operations done through custom functions/methods/operators; in particular the `setRange` function implements a marking starting at an index, to an index, stepping by an index which is a built-in ability in many languages.
 
-This technique allows culling/marking operations to take an average of about 1.25 CPU clock cycles per read/modify/write `or` machine instruction used to mark the composites with a modern high-efficiency CPU.
+This technique allows culling/marking operations to take an average of about 0.5 CPU clock cycles per marking operation with a modern high-efficiency CPU.
 
 As common to all efficient SoE implementations, almost all of the expended time is spent in the composite number culling/marking.
 

--- a/PrimeNim/solution_3/primes.nim
+++ b/PrimeNim/solution_3/primes.nim
@@ -1,3 +1,7 @@
+# Extreme-Loop-Unrolled Odds-Only Bit-Packed Sieve of Eratosthenes Benchmark...
+# This was created for the "Software Drag Racing" GitHub repo as per:
+# https://github.com/PlummersSoftwareLLC/Primes...
+ 
 import std/[ monotimes, tables, strformat ] # timing, verifying, displaying
 import std/macros
 from std/math import sqrt
@@ -19,6 +23,8 @@ const DICT = {
     10000000000.Prime : 455052511,
 }.toTable()
 const RESULT = DICT[LIMIT]
+
+const DENSETHRESHOLD = 63
 
 const BITMASK = [ 1'u8, 2, 4, 8, 16, 32, 64, 128 ] # faster than shifting!
 
@@ -75,18 +81,98 @@ macro unrollLoops(bitbufa, bytelen, ndx0, step: untyped) = # ndx0 must be var
       newLit(n),
       ofbrstmnts
     )
-  for n in 0x80'u8 .. 255'u8: # fill in defaults for remaining possibilities
-    csstmnt.add nnkOfBranch.newTree(
-      newLit(n),
-      nnkStmtList.newTree(
-        nnkDiscardStmt.newTree(
-          newEmptyNode()
-        )
-      )
+  csstmnt.add nnkElse.newTree(
+    nnkDiscardStmt.newTree(
+      newEmptyNode()
     )
+  )
   result.add quote do:
     let `endalmtid` = `bufalmtid` - `strt7id`
     var `setaid` = `bitbufa` + `strt0id`
+    `csstmnt`
+#  echo csstmnt[10].astGenRepr # see AST for a given case (plus one - 1 .. 32)
+#  echo csstmnt[50].toStrLit # see code for a given case (plus one - 1 .. 32)
+#  echo result.toStrLit # see entire produced code at compile time
+
+# This macro adds special treatment for base prime values which
+# are less than some threshold like 31 and still have multiple culls within
+# a given 64-bit word...
+macro denseSetBits(bitbufa, bytelen, ndx0, step: untyped) = # ndx0 must be var
+  let endalmtid = "endalmt".newIdentNode
+  let strt0id = "strt0".newIdentNode
+  let mod0id = "mod0".newIdentNode
+  let advid = "adv".newIdentNode
+  let setaid = "seta".newIdentNode
+  let ndxlmtid = "ndxlmt".newIdentNode
+  let cptrid = "cptr".newIdentNode
+  result = quote do:
+    let `ndxlmtid` = `ndx0` or 63
+    while `ndx0` <= ndxlmt:
+      let `cptrid` = cast[ptr byte](`bitbufa` +  (`ndx0` shr 3))
+      `cptrid`[] = `cptrid`[] or BITMASK[`ndx0` and 7]
+      `ndx0` += `step`
+    let `strt0id` = `ndx0` shr 3
+    let `mod0id` = `ndx0` and 63
+    let `advid` = `step` shl 3 # eight byte per step
+    let `endalmtid` = `bitbufa` + `bytelen` - (`advid` - 8) - 1
+    var `setaid` = `bitbufa` + (`strt0id` and (-8))
+  let csstmnt = quote do:
+    case `step`.uint8
+    of 0'u8: discard
+  csstmnt.del 1 # delete last dummy "of"
+  for stpv in countup(3, DENSETHRESHOLD, 2):
+    let swi = (stpv * stpv - 3) shr 1
+    let r = ((((swi + 64) shr 3) and (-8)) * 8 - swi) mod stpv
+    var bi = (if r == 0: 0 else: stpv - r); var wi = 0
+    let vid = "v".newIdentNode
+    let msk0id = newLit((1 shl (bi and 63)).uint64)
+    let loopstmnts = nnkStmtList.newTree()
+    if (bi + stpv) shr 6 > 0:
+      loopstmnts.add quote do:
+        let `cptrid` = cast[ptr UncheckedArray[uint64]](`setaid`)
+        var `vid`: uint64
+        `cptrid`[0] = `cptrid`[0] or `msk0id`
+    else:
+      loopstmnts.add quote do:
+        let `cptrid` = cast[ptr UncheckedArray[uint64]](`setaid`)
+        var `vid` = `cptrid`[0] or `msk0id`
+    bi += stpv
+    while wi < stpv:
+      let mskid = newLit((1 shl (bi and 63)).uint64)
+      if bi shr 6 > wi:
+        wi += 1
+        let wrdid = newLit(wi.int)
+        if (bi + stpv) shr 6 > wi:
+          loopstmnts.add quote do:
+            `cptrid`[`wrdid`] = `cptrid`[`wrdid`] or `mskid`
+          bi += stpv; continue
+        else:
+          loopstmnts.add quote do:
+            `vid` = `cptrid`[`wrdid`] or `mskid`
+      bi += stpv
+      if bi shr 6 > wi:
+        let wrdid = newLit(wi.int)
+        loopstmnts.add quote do:
+          `cptrid`[`wrdid`] = `vid` or `mskid`
+      else:
+        loopstmnts.add quote do:
+          `vid` = `vid` or `mskid`
+    loopstmnts.add quote do:
+      `setaid` += `advid`
+    let ofbrstmnts = quote do:
+      while `setaid` <= `endalmtid`:
+        `loopstmnts`
+      `ndx0` = ((`setaid` - `bitbufa`) shl 3) or `mod0id`.int
+    csstmnt.add nnkOfBranch.newTree(
+      newLit(stpv.uint8),
+      ofbrstmnts
+    )
+  csstmnt.add nnkElse.newTree(
+    nnkDiscardStmt.newTree(
+      newEmptyNode()
+    )
+  )
+  result.add quote do:
     `csstmnt`
 #  echo csstmnt[10].astGenRepr # see AST for a given case (plus one - 1 .. 32)
 #  echo csstmnt[50].toStrLit # see code for a given case (plus one - 1 .. 32)
@@ -97,8 +183,8 @@ type # encloses all bit sequence operations used...
     size: Natural
     buffer: seq[byte]
 
-func newBitSeq(size: int): BitSeq =
-  BitSeq(size: size, buffer: newSeq[byte](((size - 1) shr 3) + 1))
+func newBitSeq(size: int): BitSeq = # round up to even 64-bit size
+  BitSeq(size: size, buffer: newSeq[byte](((size - 1 + 64) shr 3) and (-8)))
 
 func `[]`(bitseq: BitSeq; i: int): bool {.inline.} =
   (bitseq.buffer[i shr 3] and BITMASK[i and 7]) != 0'u8
@@ -119,10 +205,11 @@ func setRange(bitseq: BitSeq; start, stop: int; step: int = 1) =
   var ndx = start
   let sz = min(bitseq.buffer.len, (stop + 8) shr 3) # round up
   if start <= sz * 8 - 16 * step: # enough loops to be worth the setup
-    unrollLoops(bitbufa, sz, ndx, step)
+    if step <= DENSETHRESHOLD: denseSetBits(bitbufa, sz, ndx, step)
+    else: unrollLoops(bitbufa, sz, ndx, step)
   while ndx <= stop:
     let cp = cast[ptr byte](bitbufa + (ndx shr 3))
-    cp[] = cp[] or (1'u8 shl (ndx and 7)) # BITMASK[result and 7]
+    cp[] = cp[] or BITMASK[ndx and 7] # BITMASK[result and 7]
     ndx += step
 
 func countTrues(bitseq: BitSeq): int =
@@ -192,4 +279,5 @@ let primeCount = rslt.countPrimes
 isValid = isValid and primeCount == RESULT # a thrid check
 
 stderr.writeLine(&"Passes: {passes}, Time: {elapsed}, Avg: {(elapsed / passes.float64)}, Limit: {LIMIT}, Count1: {count}, Count2: {primeCount}, Valid: {isValid}")
-echo &"GordonBGood_1of2;{passes};{elapsed};1;algorithm=base,faithful=yes,bits=1"
+echo &"GordonBGood_unrolled_hybrid;{passes};{elapsed};1;algorithm=base,faithful=yes,bits=1"
+

--- a/PrimeNim/solution_3/primes.nim
+++ b/PrimeNim/solution_3/primes.nim
@@ -174,8 +174,8 @@ macro denseSetBits(bitbufa, bytelen, ndx0, step: untyped) = # ndx0 must be var
   )
   result.add quote do:
     `csstmnt`
-#  echo csstmnt[10].astGenRepr # see AST for a given case (plus one - 1 .. 32)
-#  echo csstmnt[50].toStrLit # see code for a given case (plus one - 1 .. 32)
+#  echo csstmnt[1].astGenRepr # see AST for a given case (this is for step 3)
+#  echo csstmnt[1].toStrLit # see code for a given case (this is for step 3)
 #  echo result.toStrLit # see entire produced code at compile time
 
 type # encloses all bit sequence operations used...
@@ -279,5 +279,5 @@ let primeCount = rslt.countPrimes
 isValid = isValid and primeCount == RESULT # a thrid check
 
 stderr.writeLine(&"Passes: {passes}, Time: {elapsed}, Avg: {(elapsed / passes.float64)}, Limit: {LIMIT}, Count1: {count}, Count2: {primeCount}, Valid: {isValid}")
-echo &"GordonBGood_unrolled_hybrid;{passes};{elapsed};1;algorithm=base,faithful=yes,bits=1"
+echo &"GordonBGood_extreme_hybrid;{passes};{elapsed};1;algorithm=base,faithful=yes,bits=1"
 


### PR DESCRIPTION
## Description

**Note:**  The included Dockerfile actually builds the Nim compiler from source so that it will work across all platforms; however, if this is considered to be too slow, the race administrators may elect to build a set of custom Docker images including the pre-compiled Nim compiler using the commands from this file and I would change this Dockerfile to `FROM` those images on Docker Hub.

This changes this contribution to use both the old technique of "Extreme Loop Unrolling" for the sparse prime factors and the new technique of "Dense Marking" for base prime factor values below a set threshold; currently the threshold is set to odd primes below 64 for this Nim version.

This is similar to the latest Chapel hybrid version except that it uses Nim's AST macros to extend the capability to larger factors without having to use external code generation.  However, it is fast for the same reasons: it copies the sieve buffer into a register value `v`, then sets the composite multiple bits one by one with static register operations until all bits have been marked in the word for this factor, then commits the 64-bit word to the deliverable sieve buffer, repeating 64-bit words until all words in the modulo pattern are complete, then looping for all patterns across the full sieve buffer.  As the majority of the marking operations are immediate/register operation not requiring memory access, its maximum speed approaches the maximum Instructions per Clock Cycle for the CPU used minus some losses for "cache thrashing".  It is faster than the Chapel version because it has a higher "dense factor" threshold and also likely due to better compiler optimizations.

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
