### PR TITLE
Java add unroll and strided block implementation

### DIFF
--- a/PrimeJava/solution_4/README.md
+++ b/PrimeJava/solution_4/README.md
@@ -17,7 +17,8 @@ This is a collection of prime sieve algorithms implemented in Java. All solution
 * I64: Using 64 bit integers to store primes, 1 bit per prime
 * I64C: Using 64 bit integers to store primes, 1 bit per prime, precache masks
 * I64PatternCalc: Using 64 bit integers to store primes, 1 bit per prime, using masks to mark multiple values per array write, making it an "other" algorithm
-* W appended means a warmup was done
+* I32CUnroll: Using 32 bit integers to store primes, 1 bit per prime, unrolling the loop by 4.
+* Strided32Blocks: Using 32 bit integers to store primes, 1 bit per prime, unrolled, and using the repeating pattern of bitmasks (for `factor`, the mask will be repeat every `factor` bits in the dataSet) to go over the dataSet 32 times with 32 different bit patterns. This avoids calculating the mask per bit cleared. To alleviate the cache trashing that comes with this, the clearing is done in blocks of data that fit in most L1 caches. The mask always has a single bit set. We get better performance then I64PatternCalc, while now also being faithful base.
 
 ## Building and running
 
@@ -37,40 +38,24 @@ Results:
 
 i7-8750H
 ```
-chrvanorleI32W;6160;5.007000;1;algorithm=base,faithful=yes,bits=1
-chrvanorleI32CW;7380;5.006000;1;algorithm=base,faithful=yes,bits=1
-chrvanorleI64W;6041;5.005000;1;algorithm=base,faithful=yes,bits=1
-chrvanorleI64CW;7171;5.013000;1;algorithm=base,faithful=yes,bits=1
-chrvanorleI64PatternCalcW;9286;5.012000;1;algorithm=other,faithful=yes,bits=1
-chrvanorleI8W;5367;5.012000;1;algorithm=base,faithful=yes,bits=1
-```
-
-e5-2670 (v1)
-```
-chrvanorleI32W;3735;5.000000;1;algorithm=base,faithful=yes,bits=1
-chrvanorleI32CW;4358;5.000000;1;algorithm=base,faithful=yes,bits=1
-chrvanorleI64W;3665;5.000000;1;algorithm=base,faithful=yes,bits=1
-chrvanorleI64CW;4157;5.000000;1;algorithm=base,faithful=yes,bits=1
-chrvanorleI64PatternCalcW;4999;5.005000;1;algorithm=other,faithful=yes,bits=1
-chrvanorleI8W;3444;5.000000;1;algorithm=base,faithful=yes,bits=1
-```
-
-i5-3570k
-```
-chrvanorleI32W;5005;5.000000;1;algorithm=base,faithful=yes,bits=1
-chrvanorleI32CW;5013;5.000000;1;algorithm=base,faithful=yes,bits=1
-chrvanorleI64W;4855;5.000000;1;algorithm=base,faithful=yes,bits=1
-chrvanorleI64CW;4771;5.000000;1;algorithm=base,faithful=yes,bits=1
-chrvanorleI64PatternCalcW;7408;5.000000;1;algorithm=other,faithful=yes,bits=1
-chrvanorleI8W;4123;5.000000;1;algorithm=base,faithful=yes,bits=1
+chrvanorleI32;6088;5.000000;1;algorithm=base,faithful=yes,bits=1
+chrvanorleI32C;7252;5.000000;1;algorithm=base,faithful=yes,bits=1
+chrvanorleI32CUnroll;8295;5.000000;1;algorithm=base,faithful=yes,bits=1
+chrvanorleI64;5958;5.000000;1;algorithm=base,faithful=yes,bits=1
+chrvanorleI64C;7077;5.000000;1;algorithm=base,faithful=yes,bits=1
+chrvanorleI64PatternCalc;9227;5.000000;1;algorithm=other,faithful=yes,bits=1
+chrvanorleI8;4926;5.000000;1;algorithm=base,faithful=yes,bits=1
+chrvanorleStrided32Blocks16k;11505;5.000000;1;algorithm=base,faithful=yes,bits=1
 ```
 
 r7-3700x (debian)
 ```
-chrvanorleI32W;8428;5.000000;1;algorithm=base,faithful=yes,bits=1
-chrvanorleI32CW;9269;5.000000;1;algorithm=base,faithful=yes,bits=1
-chrvanorleI64W;8040;5.000000;1;algorithm=base,faithful=yes,bits=1
-chrvanorleI64CW;7869;5.000000;1;algorithm=base,faithful=yes,bits=1
-chrvanorleI64PatternCalcW;11819;5.000000;1;algorithm=other,faithful=yes,bits=1
-chrvanorleI8W;3985;5.000000;1;algorithm=base,faithful=yes,bits=1
+chrvanorleI32;4361;5.000000;1;algorithm=base,faithful=yes,bits=1
+chrvanorleI32C;4468;5.000000;1;algorithm=base,faithful=yes,bits=1
+chrvanorleI32CUnroll;10224;5.000000;1;algorithm=base,faithful=yes,bits=1
+chrvanorleI64;4398;5.000000;1;algorithm=base,faithful=yes,bits=1
+chrvanorleI64C;4379;5.000000;1;algorithm=base,faithful=yes,bits=1
+chrvanorleI64PatternCalc;6571;5.000000;1;algorithm=other,faithful=yes,bits=1
+chrvanorleI8;4420;5.000000;1;algorithm=base,faithful=yes,bits=1
+chrvanorleStrided32Blocks16k;16466;5.000000;1;algorithm=base,faithful=yes,bits=1
 ```

--- a/PrimeJava/solution_4/runSolution.sh
+++ b/PrimeJava/solution_4/runSolution.sh
@@ -10,3 +10,7 @@ java -cp src PrimeSieveI64PatternCalc -warmup
 java -cp src PrimeSieveI64PatternCalc -parallel -warmup
 java -cp src PrimeSieveI8 -warmup
 java -cp src PrimeSieveI8 -parallel -warmup
+java -cp src PrimeSieveI32CUnroll -warmup
+java -cp src PrimeSieveI32CUnroll -parallel -warmup
+java -cp src PrimeSieveStrided32Blocks -warmup
+java -cp src PrimeSieveStrided32Blocks -parallel -warmup

--- a/PrimeJava/solution_4/src/PrimeSieveBase.java
+++ b/PrimeJava/solution_4/src/PrimeSieveBase.java
@@ -24,7 +24,7 @@ public abstract class PrimeSieveBase {
 	
 	protected int bits = 1;
 	protected String type = "base";
-	protected int sieveSize = 0;
+	protected final int sieveSize;
 
 	public PrimeSieveBase(int size) {
 		sieveSize = size;
@@ -48,33 +48,28 @@ public abstract class PrimeSieveBase {
 	}
 	
 	public abstract boolean getBit(int index);
-	public abstract void clearBit(int index);
+	public abstract void clearBits(int factor);
 	
 	public void runSieve() {
 		int q = (int) Math.sqrt(sieveSize);
 		for (int factor = 3; factor <= q; factor += 2) {
-			for (int num = factor; num <= sieveSize; num += 2) {
-				if (getBit(num)) {
-					factor = num;
-					break;
-				}
-			}
-			for (int num = factor * factor; num <= sieveSize; num += factor * 2) {
-				clearBit(num);
+			if (getBit(factor)) {
+				clearBits(factor);
 			}
 		}
 	}
-
+	
 	public void printResults(double duration, int passes, SieveArgs args) {
 		if(!args.isWarmup) {
 			validateResults();
-			System.out.printf("chrvanorle%s%s%s;%d;%f;%d;algorithm=%s,faithful=yes,bits=%d\n", toString(), args.warmup ? "W" : "", args.postfix,passes, duration, args.getThreads(), type, bits);
+			System.out.printf("chrvanorle%s%s;%d;%f;%d;algorithm=%s,faithful=yes,bits=%d\n", toString(), args.postfix,passes, duration, args.getThreads(), type, bits);
 		}
 	}
 	
 	public String toString() {
 		return getClass().getSimpleName().replace("PrimeSieve", "");
 	}
+	
 	static class SieveArgs{
 		public String postfix = "";
 		public boolean parallel = false;

--- a/PrimeJava/solution_4/src/PrimeSieveBaseBit.java
+++ b/PrimeJava/solution_4/src/PrimeSieveBaseBit.java
@@ -1,0 +1,14 @@
+
+public abstract class PrimeSieveBaseBit extends PrimeSieveBase{
+	public PrimeSieveBaseBit(int size) {
+		super(size);
+	}
+
+	public abstract void clearBit(int factor);
+	
+	public void clearBits(int factor) {
+		for (int num = factor * factor; num <= sieveSize; num += factor * 2) {
+			clearBit(num);
+		}
+	}
+}

--- a/PrimeJava/solution_4/src/PrimeSieveI32.java
+++ b/PrimeJava/solution_4/src/PrimeSieveI32.java
@@ -1,4 +1,4 @@
-public class PrimeSieveI32 extends PrimeSieveBase{
+public class PrimeSieveI32 extends PrimeSieveBaseBit{
 	private static final int SHIFT_SIZE = 5;
 	private static final int SHIFT_SIZE_ADD = SHIFT_SIZE + 1;// one more because we don't store even numbers
 	private static final int SIZE = 1 << SHIFT_SIZE;

--- a/PrimeJava/solution_4/src/PrimeSieveI32C.java
+++ b/PrimeJava/solution_4/src/PrimeSieveI32C.java
@@ -1,4 +1,4 @@
-public class PrimeSieveI32C extends PrimeSieveBase{
+public class PrimeSieveI32C extends PrimeSieveBaseBit{
 	private static final int SHIFT_SIZE = 5;
 	private static final int SHIFT_SIZE_ADD = SHIFT_SIZE + 1;// one more because we don't store even numbers
 	private static final int SIZE = 1 << SHIFT_SIZE;

--- a/PrimeJava/solution_4/src/PrimeSieveI32CUnroll.java
+++ b/PrimeJava/solution_4/src/PrimeSieveI32CUnroll.java
@@ -1,0 +1,65 @@
+public class PrimeSieveI32CUnroll extends PrimeSieveBase{
+	private static final int SHIFT_SIZE = 5;
+	private static final int SHIFT_SIZE_ADD = SHIFT_SIZE + 1;// one more because we don't store even numbers
+	private static final int SIZE = 1 << SHIFT_SIZE;
+	private static final int MOD = (SIZE << 1) - 1;
+	// bitset of odd numbers, zero means its a prime
+	private final int[] dataSet;
+	
+	private static final int[] masks;
+	
+	static {
+		// double size so that we don't need to halve index in clearBit
+		masks = new int[SIZE << 1];
+		for(int index = 0; index < masks.length;index++) {
+			// index >> 1 because of not storing even numbers
+			masks[index] = 1 << (index >> 1);
+		}
+	}
+	
+	public PrimeSieveI32CUnroll(int sieveSize) {
+		super(sieveSize);
+		dataSet = new int[((sieveSize + 1) >> 1) / SIZE + 1];
+	}
+
+	public boolean getBit(int index) {		
+		return (dataSet[index >> SHIFT_SIZE_ADD] & (1 << (index >> 1))) == 0;
+	}
+
+	public void clearBits(int factor) {
+		int i0 = factor * factor;
+		int factor2 = factor << 1;
+		int factor4 = factor << 2;
+		int factor8 = factor << 3;
+		int i1 = i0 + factor2;
+		int i2 = i1 + factor2;
+		int i3 = i2 + factor2;
+
+
+		while(i3 < sieveSize) {
+			dataSet[i0 >> SHIFT_SIZE_ADD] |= (masks[i0 & MOD]);
+			i0 += factor8;
+			dataSet[i1 >> SHIFT_SIZE_ADD] |= (masks[i1 & MOD]);
+			i1 += factor8;
+			dataSet[i2 >> SHIFT_SIZE_ADD] |= (masks[i2 & MOD]);
+			i2 += factor8;
+			dataSet[i3 >> SHIFT_SIZE_ADD] |= (masks[i3 & MOD]);
+			i3 += factor8;
+		}
+		while(i1 < sieveSize) {
+			dataSet[i0 >> SHIFT_SIZE_ADD] |= (masks[i0 & MOD]);
+			i0 += factor4;
+			dataSet[i1 >> SHIFT_SIZE_ADD] |= (masks[i1 & MOD]);
+			i1 += factor4;
+		}
+		while(i0 < sieveSize) {
+			dataSet[i0 >> SHIFT_SIZE_ADD] |= (masks[i0 & MOD]);
+			i0 += factor2;
+		}
+
+	}
+	
+	public static void main(String[] args) throws InterruptedException {
+		PrimeSieveBase.run(() -> new PrimeSieveI32CUnroll(1000000), args);
+	}
+}

--- a/PrimeJava/solution_4/src/PrimeSieveI64.java
+++ b/PrimeJava/solution_4/src/PrimeSieveI64.java
@@ -1,4 +1,4 @@
-public class PrimeSieveI64 extends PrimeSieveBase{
+public class PrimeSieveI64 extends PrimeSieveBaseBit{
 	private static final int SHIFT_SIZE = 6;
 	private static final int SHIFT_SIZE_ADD = SHIFT_SIZE + 1;// one more because we don't store even numbers
 	private static final int SIZE = 1 << SHIFT_SIZE;

--- a/PrimeJava/solution_4/src/PrimeSieveI64C.java
+++ b/PrimeJava/solution_4/src/PrimeSieveI64C.java
@@ -1,4 +1,4 @@
-public class PrimeSieveI64C extends PrimeSieveBase{
+public class PrimeSieveI64C extends PrimeSieveBaseBit{
 	private static final int SHIFT_SIZE = 6;
 	private static final int SHIFT_SIZE_ADD = SHIFT_SIZE + 1;// one more because we don't store even numbers
 	private static final int SIZE = 1 << SHIFT_SIZE;

--- a/PrimeJava/solution_4/src/PrimeSieveI64PatternCalc.java
+++ b/PrimeJava/solution_4/src/PrimeSieveI64PatternCalc.java
@@ -20,25 +20,6 @@ public class PrimeSieveI64PatternCalc extends PrimeSieveBase{
 	public boolean getBit(int index) {
 		return (dataSet[index >> SHIFT_SIZE_ADD] & (1l << (index >> 1))) == 0;
 	}
-
-	public void clearBit(int index) {
-		throw new AssertionError();
-	}
-	
-	public void runSieve() {
-		int factor = 3;
-		int q = (int) Math.sqrt(sieveSize);
-		while (factor <= q) {
-			for (int num = factor; num <= sieveSize; num += 2) {
-				if (getBit(num)) {
-					factor = num;
-					break;
-				}
-			}
-			clearBits(factor);
-			factor += 2;
-		}
-	}
 	
 	public void clearBits(int factor) {
 		if(factor < PATTERN_SIZE) {

--- a/PrimeJava/solution_4/src/PrimeSieveI8.java
+++ b/PrimeJava/solution_4/src/PrimeSieveI8.java
@@ -1,4 +1,4 @@
-public class PrimeSieveI8 extends PrimeSieveBase{
+public class PrimeSieveI8 extends PrimeSieveBaseBit{
 	private static final int SHIFT_SIZE = 3;
 	private static final int SHIFT_SIZE_ADD = SHIFT_SIZE + 1;
 	private static final int SIZE = 1 << SHIFT_SIZE;

--- a/PrimeJava/solution_4/src/PrimeSieveStrided32Blocks.java
+++ b/PrimeJava/solution_4/src/PrimeSieveStrided32Blocks.java
@@ -1,0 +1,76 @@
+public class PrimeSieveStrided32Blocks extends PrimeSieveBase{
+	private static final int SHIFT_SIZE = 5;
+	private static final int SHIFT_SIZE_ADD = SHIFT_SIZE + 1;// one more because we don't store even numbers
+	private static final int SIZE = 1 << SHIFT_SIZE;
+	private static final int BLOCK_SIZE_BITS = 1024 * 128;
+	private static final int BLOCK_SIZE = BLOCK_SIZE_BITS / SIZE;
+	
+	
+	private final int[][] dataBlocks;
+	private final int blocks;
+	
+	public PrimeSieveStrided32Blocks(int sieveSize) {
+		super(sieveSize);
+		int size = ((sieveSize + 1) >> 1) / SIZE + 1;
+		blocks = size / BLOCK_SIZE + 1;
+		dataBlocks = new int[blocks][BLOCK_SIZE];
+	}
+
+	public boolean getBit(int index) {
+		int idx = index >> SHIFT_SIZE_ADD;
+		int block = idx / BLOCK_SIZE;
+		idx = idx - block * BLOCK_SIZE;// index into selected block
+		return (dataBlocks[block][idx] & (1 << (index >> 1))) == 0;
+	}
+
+	public void clearBits(int factor) {
+		int ff = factor * factor;
+		int factor2 = factor << 1;
+		int factor4 = factor2 << 1;
+		int[] strideStarts = new int[SIZE];
+		for(int stride = 0; stride < SIZE;stride++) {
+			strideStarts[stride] = (ff + stride * factor2) >> SHIFT_SIZE_ADD;
+		}
+		for(int block = 0; block < blocks;block++) {
+			int[] dataSet = dataBlocks[block];
+			for(int stride = 0; stride < SIZE;stride++) {
+				int mask = 1 << ((ff + stride * factor2) >> 1);
+				int start0 = strideStarts[stride] - block * BLOCK_SIZE;
+				int start1 = start0 + factor;
+				int start2 = start1 + factor;
+				int start3 = start2 + factor;
+				
+				while(start3 < dataSet.length) {
+					dataSet[start0] |= mask;
+					start0 += factor4;
+					dataSet[start1] |= mask;
+					start1 += factor4;
+					dataSet[start2] |= mask;
+					start2 += factor4;
+					dataSet[start3] |= mask;
+					start3 += factor4;
+				}
+				while(start1 < dataSet.length) {
+					dataSet[start0] |= mask;
+					start0 += factor2;
+					dataSet[start1] |= mask;
+					start1 += factor2;
+				}
+				while(start0 < dataSet.length) {
+					dataSet[start0] |= mask;
+					start0 += factor;
+				}
+				// remember where we were with this stride for the next block
+				strideStarts[stride] = start0 + block * BLOCK_SIZE;
+			}
+		}
+	}
+	
+	public String toString() {
+		return super.toString()+(BLOCK_SIZE_BITS / 8192)+"k";
+	}
+	
+	public static void main(String[] args) throws InterruptedException {
+		PrimeSieveBase.run(() -> new PrimeSieveStrided32Blocks(1000000), args);
+	}
+}


### PR DESCRIPTION
## Description
Added an unrolled and an unrolled strided block version. The strided variant uses the idea of the repeating patterns used in I64PatternCalc, while not using the multibit masks that made that an `other` algorithm. Using blocks prevents the cache trashing that would otherwise occur.

From the striped/strided names i've seen, i think strided makes the most sense for this one (final name being chrvanorleStrided32Blocks16k). I removed the W(armup) from the name as it doesn't really add anything since all runs use it.

There is a significant drop in performance on (ry)zen due to the changes in PrimeSieveBase::runSieve. This is due to an issue i don't fully understand (#679), but only seems to affect the implementations using the simple loops, and not the unrolled variants. As this only affects the slow implementations for a single architecture, i decided to just go forwards with this PR.

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
