### PR TITLE
Rust solution_1: small fix

### DIFF
--- a/PrimeRust/solution_1/prime-sieve-rust/src/unrolled.rs
+++ b/PrimeRust/solution_1/prime-sieve-rust/src/unrolled.rs
@@ -181,76 +181,19 @@ impl FlagStorage for FlagStorageUnrolledHybrid {
     }
 }
 
+/// Very simple reset implementation for larger skip factors, where
+/// it's not worth the cost of calculating all of the relative indices
+/// as we do in [`ResetterSparseU8`]
 impl FlagStorageUnrolledHybrid {
     fn reset_simple(&mut self, start: usize, skip: usize) {
         const U64_BITS: usize = u64::BITS as usize;
-
-        let mut idx = start;
-        while idx < self.length_bits {
+        let mut i = start;
+        while i < self.length_bits {
             unsafe {
                 // Safety: idx / U64_BITS is always less than self.length bits
-                *self.words.get_unchecked_mut(idx / U64_BITS) |= 1 << (idx % U64_BITS);
-            }
-            idx += skip;
-        }
-    }
-
-    fn reset_simple_rolling1(&mut self, start: usize, skip: usize) {
-        const U64_BITS: usize = u64::BITS as usize;
-        let roll_bits = skip as u32;
-
-        let mut i = start;
-        let mut rolling_mask = 1 << (start % U64_BITS);
-        while i < self.words.len() * U64_BITS {
-            let word_idx = i / U64_BITS;
-            // Safety: We have ensured that word_index < self.words.len().
-            // Unsafe required to ensure that we elide the bounds check reliably.
-            unsafe {
-                *self.words.get_unchecked_mut(word_idx) |= rolling_mask;
+                *self.words.get_unchecked_mut(i / U64_BITS) |= 1 << (i % U64_BITS);
             }
             i += skip;
-            rolling_mask = rolling_mask.rotate_left(roll_bits);
-        }
-    }
-
-    fn reset_simple_rolling2(&mut self, start: usize, skip: usize) {
-        const U64_BITS: usize = u64::BITS as usize;
-
-        let mut i = start;
-        let roll_bits = skip as u32;
-        let mut rolling_mask1 = 1 << (start % U64_BITS);
-        let mut rolling_mask2 = 1 << ((start + skip) % U64_BITS);
-
-        // if the skip is larger than the word size, we're clearing bits in different
-        // words each time: we can unroll the loop
-        if skip > U64_BITS {
-            let roll_bits_double = roll_bits * 2;
-            let unrolled_end = (self.words.len() * U64_BITS).saturating_sub(skip);
-            while i < unrolled_end {
-                let word_idx1 = i / U64_BITS;
-                let word_idx2 = (i + skip) / U64_BITS;
-                // Safety: We have ensured that (i+skip) < self.words.len() * U32_BITS.
-                // The compiler will not elide these bounds checks,
-                // so there is a performance benefit to using get_unchecked_mut here.
-                unsafe {
-                    *self.words.get_unchecked_mut(word_idx1) |= rolling_mask1;
-                    *self.words.get_unchecked_mut(word_idx2) |= rolling_mask2;
-                }
-                rolling_mask1 = rolling_mask1.rotate_left(roll_bits_double);
-                rolling_mask2 = rolling_mask2.rotate_left(roll_bits_double);
-                i += skip * 2;
-            }
-        }
-
-        while i < self.words.len() * U64_BITS {
-            let word_idx = i / U64_BITS;
-            // Safety: We have ensured that word_index < self.words.len().
-            // Unsafe required to ensure that we elide the bounds check reliably.
-            unsafe {
-                *self.words.get_unchecked_mut(word_idx) |= rolling_mask1;
-            }
-            i += skip;
-            rolling_mask1 = rolling_mask1.rotate_left(roll_bits);
         }
     }
 }

--- a/PrimeRust/solution_1/prime-sieve-rust/src/unrolled.rs
+++ b/PrimeRust/solution_1/prime-sieve-rust/src/unrolled.rs
@@ -190,7 +190,8 @@ impl FlagStorageUnrolledHybrid {
         let mut i = start;
         while i < self.length_bits {
             unsafe {
-                // Safety: idx / U64_BITS is always less than self.length bits
+                // Safety: idx / U64_BITS is always less the extend of the array, as this 
+                // is determined by self.length_bits in the first place.
                 *self.words.get_unchecked_mut(i / U64_BITS) |= 1 << (i % U64_BITS);
             }
             i += skip;


### PR DESCRIPTION
## Description
This is a small fix/optimisation to the unrolled implementation submitted last week. I missed an important optimisation: essentially, it's quite expensive setting up the sparse resetters because we need to calculate the relative indices of the words we're going to be resetting. This only makes sense when we have lots of iterations to do. When we've only got a few to do (with large prime factors), it's a lot faster to just smash the bits in the simple way (like the basic implementations in this solution do). 

@GordonBGood had this implemented in his solutions, and it makes a pretty big difference on the humble Pi.  Apologies for missing this in the previous submission @rbergen. At least this is a small PR this time :)

## Contributing requirements
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
