### PR TITLE
Rust solution_1 - start location fix

### DIFF
--- a/PrimeRust/solution_1/prime-sieve-rust/src/unrolled.rs
+++ b/PrimeRust/solution_1/prime-sieve-rust/src/unrolled.rs
@@ -169,7 +169,6 @@ impl FlagStorage for FlagStorageUnrolledHybrid {
     }
 }
 
-
 /// Specific implementation for the dense resetter where we have words that
 /// are close together. Since the `SKIP` is a constant (generic) parameter,
 /// the compiler produces a specific separate type for each `SKIP` factor,
@@ -236,18 +235,21 @@ impl<const EQUIVALENT_SKIP: usize> ResetterSparseU8<EQUIVALENT_SKIP> {
     #[inline(never)]
     fn reset_sparse(words: &mut [u64], skip: usize, length_bits: usize) {
         let square_start = square_start(skip);
-        debug_assert!(square_start < length_bits, "square_start should be less than length_bits");
+        debug_assert!(
+            square_start < length_bits,
+            "square_start should be less than length_bits"
+        );
 
         // calculate relative indices for the words we need to reset
         let relative_indices = index_pattern::<8>(skip);
-        
+
         // cast our wide word vector to bytes
         let bytes: &mut [u8] = reinterpret_slice_mut_u64_u8(words);
 
-        // determine the offset of the first skip-size chunk we need 
-        // to touch, and proceed from there. 
+        // determine the offset of the first skip-size chunk we need
+        // to touch, and proceed from there.
         let start_chunk_offset = square_start / 8 / skip * skip;
-        let slice = &mut bytes[start_chunk_offset ..];
+        let slice = &mut bytes[start_chunk_offset..];
 
         slice.chunks_exact_mut(skip).for_each(|chunk| {
             #[allow(clippy::needless_range_loop)]

--- a/PrimeRust/solution_1/prime-sieve-rust/src/unrolled.rs
+++ b/PrimeRust/solution_1/prime-sieve-rust/src/unrolled.rs
@@ -148,7 +148,7 @@ impl FlagStorage for FlagStorageUnrolledHybrid {
                     3,
                     2,
                     17,
-                    ResetterSparseU8::<N>::reset_sparse(&mut self.words, skip, self.length_bits),
+                    ResetterSparseU8::<N>::reset_sparse(&mut self.words, skip),
                     debug_assert!(
                         false,
                         "this case should not occur skip {} equivalent {}",
@@ -233,13 +233,7 @@ impl<const EQUIVALENT_SKIP: usize> ResetterSparseU8<EQUIVALENT_SKIP> {
     const SINGLE_BIT_MASK_SET: [u8; 8] = mask_pattern_set_u8(EQUIVALENT_SKIP);
 
     #[inline(never)]
-    fn reset_sparse(words: &mut [u64], skip: usize, length_bits: usize) {
-        let square_start = square_start(skip);
-        debug_assert!(
-            square_start < length_bits,
-            "square_start should be less than length_bits"
-        );
-
+    fn reset_sparse(words: &mut [u64], skip: usize) {
         // calculate relative indices for the words we need to reset
         let relative_indices = index_pattern::<8>(skip);
 
@@ -248,6 +242,11 @@ impl<const EQUIVALENT_SKIP: usize> ResetterSparseU8<EQUIVALENT_SKIP> {
 
         // determine the offset of the first skip-size chunk we need
         // to touch, and proceed from there.
+        let square_start = square_start(skip);
+        debug_assert!(
+            square_start < bytes.len() * 8,
+            "square_start should be within the bounds of our array; check caller"
+        );
         let start_chunk_offset = square_start / 8 / skip * skip;
         let slice = &mut bytes[start_chunk_offset..];
 

--- a/PrimeRust/solution_1/prime-sieve-rust/src/unrolled.rs
+++ b/PrimeRust/solution_1/prime-sieve-rust/src/unrolled.rs
@@ -181,76 +181,19 @@ impl FlagStorage for FlagStorageUnrolledHybrid {
     }
 }
 
+/// Very simple reset implementation for larger skip factors, where
+/// it's not worth the cost of calculating all of the relative indices
+/// as we do in [`ResetterSparseU8`]
 impl FlagStorageUnrolledHybrid {
     fn reset_simple(&mut self, start: usize, skip: usize) {
         const U64_BITS: usize = u64::BITS as usize;
-
-        let mut idx = start;
-        while idx < self.length_bits {
+        let mut i = start;
+        while i < self.length_bits {
             unsafe {
                 // Safety: idx / U64_BITS is always less than self.length bits
-                *self.words.get_unchecked_mut(idx / U64_BITS) |= 1 << (idx % U64_BITS);
-            }
-            idx += skip;
-        }
-    }
-
-    fn reset_simple_rolling1(&mut self, start: usize, skip: usize) {
-        const U64_BITS: usize = u64::BITS as usize;
-        let roll_bits = skip as u32;
-
-        let mut i = start;
-        let mut rolling_mask = 1 << (start % U64_BITS);
-        while i < self.words.len() * U64_BITS {
-            let word_idx = i / U64_BITS;
-            // Safety: We have ensured that word_index < self.words.len().
-            // Unsafe required to ensure that we elide the bounds check reliably.
-            unsafe {
-                *self.words.get_unchecked_mut(word_idx) |= rolling_mask;
+                *self.words.get_unchecked_mut(i / U64_BITS) |= 1 << (i % U64_BITS);
             }
             i += skip;
-            rolling_mask = rolling_mask.rotate_left(roll_bits);
-        }
-    }
-
-    fn reset_simple_rolling2(&mut self, start: usize, skip: usize) {
-        const U64_BITS: usize = u64::BITS as usize;
-
-        let mut i = start;
-        let roll_bits = skip as u32;
-        let mut rolling_mask1 = 1 << (start % U64_BITS);
-        let mut rolling_mask2 = 1 << ((start + skip) % U64_BITS);
-
-        // if the skip is larger than the word size, we're clearing bits in different
-        // words each time: we can unroll the loop
-        if skip > U64_BITS {
-            let roll_bits_double = roll_bits * 2;
-            let unrolled_end = (self.words.len() * U64_BITS).saturating_sub(skip);
-            while i < unrolled_end {
-                let word_idx1 = i / U64_BITS;
-                let word_idx2 = (i + skip) / U64_BITS;
-                // Safety: We have ensured that (i+skip) < self.words.len() * U32_BITS.
-                // The compiler will not elide these bounds checks,
-                // so there is a performance benefit to using get_unchecked_mut here.
-                unsafe {
-                    *self.words.get_unchecked_mut(word_idx1) |= rolling_mask1;
-                    *self.words.get_unchecked_mut(word_idx2) |= rolling_mask2;
-                }
-                rolling_mask1 = rolling_mask1.rotate_left(roll_bits_double);
-                rolling_mask2 = rolling_mask2.rotate_left(roll_bits_double);
-                i += skip * 2;
-            }
-        }
-
-        while i < self.words.len() * U64_BITS {
-            let word_idx = i / U64_BITS;
-            // Safety: We have ensured that word_index < self.words.len().
-            // Unsafe required to ensure that we elide the bounds check reliably.
-            unsafe {
-                *self.words.get_unchecked_mut(word_idx) |= rolling_mask1;
-            }
-            i += skip;
-            rolling_mask1 = rolling_mask1.rotate_left(roll_bits);
         }
     }
 }

--- a/PrimeRust/solution_1/prime-sieve-rust/src/unrolled.rs
+++ b/PrimeRust/solution_1/prime-sieve-rust/src/unrolled.rs
@@ -190,7 +190,8 @@ impl FlagStorageUnrolledHybrid {
         let mut i = start;
         while i < self.length_bits {
             unsafe {
-                // Safety: idx / U64_BITS is always less than self.length bits
+                // Safety: idx / U64_BITS is always less the extend of the array, as this 
+                // is determined by self.length_bits in the first place.
                 *self.words.get_unchecked_mut(i / U64_BITS) |= 1 << (i % U64_BITS);
             }
             i += skip;


### PR DESCRIPTION
## Description
This is a small fix to the unrolled implementation submitted last week. I opened a PR yesterday evening, but it turns out I was treating the symptom rather than the cause. Thanks @GordonBGood for taking a look. 

There was indeed something wrong with the sparse resetter: it was starting from the beginning of the array in all cases, even for large skip factors. While this is functionally still correct, it is a bit of a performance killer from both a cycles and L1 cache point of view.

This PR is a simple fix: start resetting bits only at the square of the factor, rather than the start of the array. 

@rbergen, my apologies for all the noise, as well as missing this the first time. Luckily this PR is really straightforward in comparison to previous ones. 

## Contributing requirements
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
