### PR TITLE
Nim - adjust dense base primes threshold...

### DIFF
--- a/PrimeNim/solution_3/primes.nim
+++ b/PrimeNim/solution_3/primes.nim
@@ -20,7 +20,7 @@ const DICT = {
 }.toTable()
 const RESULT = DICT[LIMIT]
 
-const DENSETHRESHOLD = 129
+const DENSETHRESHOLD = 63
 
 const BITMASK = [ 1'u8, 2, 4, 8, 16, 32, 64, 128 ] # faster than shifting!
 


### PR DESCRIPTION
## Description

Using a dense prime value threshold of 129 makes the code five percent faster on my local machine but twenty percent slower on the fastest of the "leader board" machines, so am adjusting it back to a limit of 63 (formerly 31, which is definitely slower on all machines).

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
