### PR TITLE
Rust solution_1: Small tweaks

### DIFF
--- a/PrimeRust/solution_1/Dockerfile
+++ b/PrimeRust/solution_1/Dockerfile
@@ -5,13 +5,17 @@
 
 # Note: Debian based, not Alpine; for some reason, the 
 # Alpine malloc call is slower than it should be.
-#
+# 
+# Also, immediately run `cargo search` to force
+# cargo to load the package index from crates.io.
+# This allows it to be cached as part of the build
+# layer, saving a lot of time on repeated builds.
 FROM rust:1.54 AS build
+RUN cargo search num_cpus -q --limit 1
 
 WORKDIR /app
 COPY . .
-RUN cargo test
-RUN cargo build --release
+RUN cargo test && cargo build --release
 
 # 2. runtime stage
 #   - start from clean container

--- a/PrimeRust/solution_1/prime-sieve-rust/src/main.rs
+++ b/PrimeRust/solution_1/prime-sieve-rust/src/main.rs
@@ -80,13 +80,13 @@ pub mod primes {
     }
 
     /// Recommended start for resetting bits -- at the square of the factor
-    pub fn square_start(skip_factor: usize) -> usize {
+    pub const fn square_start(skip_factor: usize) -> usize {
         skip_factor * skip_factor / 2
     }
 
     /// Minimum start for resetting bits -- this is the earliest reset
     /// we can apply without clobbering the factor itself
-    pub fn minimum_start(skip_factor: usize) -> usize {
+    pub const fn minimum_start(skip_factor: usize) -> usize {
         skip_factor / 2 + skip_factor
     }
 


### PR DESCRIPTION
## Description

These are a few small tweaks to improve performance _very_ slightly; just correcting a few small inefficiencies. 
- remove unnecessary restore in the sparse resets
- starting dense resets slightly later when possible
- check and apply sparse resets first -- the nested case statement was causing issues with inlining

I've also corrected the Dockerfile, so it should get rid of one lint complaint too. More importantly, I've also added an explicit `cargo search` command to the build layer to force cargo to download the index from crates.io. If we do the same in the other Rust solutions, this might improve build performance a bit as Docker will locally cache this layer with the already-retrieved index. Doing this before copying stuff into the image makes this stage independent of the specific code that goes into each solution. I think the other Dockerfiles are all based on this one anyway, at least initially.

## Contributing requirements
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
