### PR TITLE
CONTRIBUTING.md: make link with C++ sample point to a simpler version of PrimeCPP.cpp

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ The base algorithm is defined as follows:
 
 * Starting the clearing loop at factor * factor (instead of 3 * factor, as done in the original implementation) is permissible.
 
-If needed, the [original implementation in C++](https://github.com/PlummersSoftwareLLC/Primes/blob/drag-race/PrimeCPP/solution_1/PrimeCPP.cpp) can be used as a reference.
+If needed, the [original implementation in C++](https://github.com/PlummersSoftwareLLC/Primes/blob/38c826678a52a37b8a864465410562d330002091/PrimeCPP/solution_1/PrimeCPP.cpp) can be used as a reference.
 
 #### Tag
 


### PR DESCRIPTION
## Description
<!--
Add your description yere.
-->
CONTRIBUTING.md contains a link to a C++ solution that can be used as a reference. After some optimizations to PrimeCPP.cpp is faster but less readable than it originally was. This PR make the link point to an older version that IMO works better as an easily readable reference implementation.

Please decide for yourself if you want to merge this PR as is, or reject this PR leaving things as is, or do something else such as using an even better reference (maybe into the original branch?), I'm ok either way.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
