### PR TITLE
Pin Haskell to 8.10.4 to fix build failure

### DIFF
--- a/PrimeHaskell/solution_1/Dockerfile
+++ b/PrimeHaskell/solution_1/Dockerfile
@@ -1,4 +1,4 @@
-FROM haskell:8.10
+FROM haskell:8.10.4
 
 WORKDIR /opt/sieve
 


### PR DESCRIPTION
This pins the Haskell Docker base image to 8.10.4 instead of 8.10. The Haskell image with tag 8.10 got bumped to version 8.10.5, which breaks the build.

The issues reported by hadolint will be fixed with the merge of #711.