### PR TITLE
Dockerlint Part 2 (final?)

### DIFF
--- a/PrimeClipper/solution_1/Dockerfile
+++ b/PrimeClipper/solution_1/Dockerfile
@@ -12,10 +12,10 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* && \
     rm "${HARBOUR_PKG}" 
 
-COPY . /opt/
+COPY . .
 
-RUN hbmk2 -gtstd -optim -cflag=-O3 ./sieve.prg
-RUN hbmk2 -gtstd -optim -cflag=-O3 ./sievedb.prg
-RUN hbmk2 -gtstd -optim -cflag=-O3 ./sieve_xharbour.prg
+RUN hbmk2 -gtstd -optim -cflag=-O3 ./sieve.prg \
+    && hbmk2 -gtstd -optim -cflag=-O3 ./sievedb.prg \
+    && hbmk2 -gtstd -optim -cflag=-O3 ./sieve_xharbour.prg
 
 CMD [ "bash", "./run.sh" ]

--- a/PrimeCrystal/solution_2/Dockerfile
+++ b/PrimeCrystal/solution_2/Dockerfile
@@ -4,7 +4,10 @@ ENV CRYSTAL_VER="1.1"
 
 WORKDIR /opt
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y curl && \
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN apt-get update && apt-get install -y curl && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
     curl -fsSL https://crystal-lang.org/install.sh | bash -s -- --version="${CRYSTAL_VER}"
 # compiler build has been finished here, image ready for use...
 

--- a/PrimeMixed/solution_3/Dockerfile
+++ b/PrimeMixed/solution_3/Dockerfile
@@ -17,7 +17,7 @@ COPY --chown=michaelgrn setup.py .
 COPY --chown=michaelgrn src/ ./src/
 
 # The following is ignored, due to way venv is used. If you're a Python developer with knowledge of Docker. venv and user installs consider giving your insight here: https://github.com/PlummersSoftwareLLC/Primes/pull/744
-# hadolint ignore=SC1091
+# hadolint ignore=DL3059,SC1091
 RUN . venv/bin/activate
 # hadolint ignore=DL3059
 RUN python -m pip install -e . --user --no-cache-dir

--- a/PrimeMixed/solution_3/Dockerfile
+++ b/PrimeMixed/solution_3/Dockerfile
@@ -17,8 +17,9 @@ COPY --chown=michaelgrn setup.py .
 COPY --chown=michaelgrn src/ ./src/
 
 # The following is ignored, due to way venv is used. If you're a Python developer with knowledge of Docker. venv and user installs consider giving your insight here: https://github.com/PlummersSoftwareLLC/Primes/pull/744
-# hadolint ignore=DL3059,SC1091
+# hadolint ignore=SC1091
 RUN . venv/bin/activate
+# hadolint ignore=DL3059
 RUN python -m pip install -e . --user --no-cache-dir
 
 CMD ["python", "-m", "pysieve"]

--- a/PrimeMixed/solution_3/Dockerfile
+++ b/PrimeMixed/solution_3/Dockerfile
@@ -9,8 +9,8 @@ RUN python -m venv venv \
 
 USER michaelgrn
 
-ENV HOME=/home/michaelgrn
-ENV PATH=$HOME/.local/bin:$PATH
+ENV HOME=/home/michaelgrn \
+    PATH=$HOME/.local/bin:$PATH
 
 COPY --chown=michaelgrn setup.py .
 COPY --chown=michaelgrn src/ ./src/

--- a/PrimeMixed/solution_3/Dockerfile
+++ b/PrimeMixed/solution_3/Dockerfile
@@ -16,7 +16,7 @@ ENV PATH=$HOME/.local/bin:$PATH
 COPY --chown=michaelgrn setup.py .
 COPY --chown=michaelgrn src/ ./src/
 
-# The following is ignored, due to way venv is used. If you're a Python developer with knowledge of Docker and venv and user installs consider giving your insight here: https://github.com/PlummersSoftwareLLC/Primes/pull/744
+# The following is ignored, due to way venv is used. If you're a Python developer with knowledge of Docker. venv and user installs consider giving your insight here: https://github.com/PlummersSoftwareLLC/Primes/pull/744
 #hadolint ignore=SC1091,DL3059
 RUN . venv/bin/activate
 RUN python -m pip install -e . --user --no-cache-dir

--- a/PrimeMixed/solution_3/Dockerfile
+++ b/PrimeMixed/solution_3/Dockerfile
@@ -10,8 +10,8 @@ RUN python -m venv venv \
 
 USER michaelgrn
 
-ENV HOME=/home/michaelgrn \
-    PATH=$HOME/.local/bin:$PATH
+ENV HOME=/home/michaelgrn
+ENV PATH=$HOME/.local/bin:$PATH
 
 COPY --chown=michaelgrn setup.py .
 COPY --chown=michaelgrn src/ ./src/

--- a/PrimeMixed/solution_3/Dockerfile
+++ b/PrimeMixed/solution_3/Dockerfile
@@ -17,7 +17,7 @@ COPY --chown=michaelgrn setup.py .
 COPY --chown=michaelgrn src/ ./src/
 
 # The following is ignored, due to way venv is used. If you're a Python developer with knowledge of Docker. venv and user installs consider giving your insight here: https://github.com/PlummersSoftwareLLC/Primes/pull/744
-# hadolint ignore=SC1091,DL3059
+# hadolint ignore=DL3059,SC1091
 RUN . venv/bin/activate
 RUN python -m pip install -e . --user --no-cache-dir
 

--- a/PrimeMixed/solution_3/Dockerfile
+++ b/PrimeMixed/solution_3/Dockerfile
@@ -16,8 +16,8 @@ ENV PATH=$HOME/.local/bin:$PATH
 COPY --chown=michaelgrn setup.py .
 COPY --chown=michaelgrn src/ ./src/
 
-#hadolint ignore=SC1091
-RUN . venv/bin/activate \
-    && python -m pip install -e . --user --no-cache-dir
+#hadolint ignore=SC1091,DL3059
+RUN . venv/bin/activate
+RUN python -m pip install -e . --user --no-cache-dir
 
 CMD ["python", "-m", "pysieve"]

--- a/PrimeMixed/solution_3/Dockerfile
+++ b/PrimeMixed/solution_3/Dockerfile
@@ -17,7 +17,7 @@ COPY --chown=michaelgrn setup.py .
 COPY --chown=michaelgrn src/ ./src/
 
 #hadolint ignore=SC1091
-RUN . venv/bin/activate
-RUN python -m pip install -e . --user --no-cache-dir
+RUN . venv/bin/activate \
+    && python -m pip install -e . --user --no-cache-dir
 
 CMD ["python", "-m", "pysieve"]

--- a/PrimeMixed/solution_3/Dockerfile
+++ b/PrimeMixed/solution_3/Dockerfile
@@ -16,6 +16,7 @@ ENV PATH=$HOME/.local/bin:$PATH
 COPY --chown=michaelgrn setup.py .
 COPY --chown=michaelgrn src/ ./src/
 
+# The following is ignored, due to way venv is used. If you're a Python developer with knowledge of Docker and venv and user installs consider giving your insight here: https://github.com/PlummersSoftwareLLC/Primes/pull/744
 #hadolint ignore=SC1091,DL3059
 RUN . venv/bin/activate
 RUN python -m pip install -e . --user --no-cache-dir

--- a/PrimeMixed/solution_3/Dockerfile
+++ b/PrimeMixed/solution_3/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:3-alpine
 
-RUN apk add build-base --no-cache \
-    && /usr/sbin/adduser -u 1001 -D michaelgrn
+RUN apk add build-base --no-cache
 
+RUN /usr/sbin/adduser -u 1001 -D michaelgrn
 WORKDIR /home/michaelgrn
 
 RUN python -m venv venv \
@@ -10,13 +10,12 @@ RUN python -m venv venv \
 
 USER michaelgrn
 
-ENV HOME=/home/michaelgrn \
-    PATH=$HOME/.local/bin:$PATH
+ENV HOME=/home/michaelgrn
+ENV PATH=$HOME/.local/bin:$PATH
 
 COPY --chown=michaelgrn setup.py .
 COPY --chown=michaelgrn src/ ./src/
 
-#hadolint ignore=SC1091
 RUN . venv/bin/activate
 RUN python -m pip install -e . --user --no-cache-dir
 

--- a/PrimeMixed/solution_3/Dockerfile
+++ b/PrimeMixed/solution_3/Dockerfile
@@ -2,19 +2,19 @@ FROM python:3-alpine
 
 RUN apk add build-base --no-cache && \
     /usr/sbin/adduser -u 1001 -D michaelgrn
-WORKDIR /home/michaelgrn
 
-RUN python -m venv venv \
-    && chown -R michaelgrn .
-
-USER michaelgrn
-
-ENV HOME=/home/michaelgrn \
-    PATH=$HOME/.local/bin:$PATH
+ENV VIRTUAL_ENV=/opt/venv
+RUN python3 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 COPY --chown=michaelgrn setup.py .
 COPY --chown=michaelgrn src/ ./src/
 
-RUN python -m pip install -e . --user --no-cache-dir
+RUN python -m pip install --upgrade pip && \
+    pip install -e . --no-cache-dir
+
+USER michaelgrn
+
+WORKDIR /home/michaelgrn
 
 CMD ["python", "-m", "pysieve"]

--- a/PrimeMixed/solution_3/Dockerfile
+++ b/PrimeMixed/solution_3/Dockerfile
@@ -1,20 +1,23 @@
 FROM python:3-alpine
 
-RUN apk add build-base --no-cache && \
-    /usr/sbin/adduser -u 1001 -D michaelgrn
+RUN apk add build-base --no-cache \
+    && /usr/sbin/adduser -u 1001 -D michaelgrn
 
-ENV VIRTUAL_ENV=/opt/venv
-RUN python3 -m venv $VIRTUAL_ENV
-ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+WORKDIR /home/michaelgrn
+
+RUN python -m venv venv \
+    && chown -R michaelgrn /home/michaelgrn
+
+USER michaelgrn
+
+ENV HOME=/home/michaelgrn \
+    PATH=$HOME/.local/bin:$PATH
 
 COPY --chown=michaelgrn setup.py .
 COPY --chown=michaelgrn src/ ./src/
 
-RUN python -m pip install --upgrade pip && \
-    pip install -e . --no-cache-dir
-
-USER michaelgrn
-
-WORKDIR /home/michaelgrn
+#hadolint ignore=SC1091
+RUN . venv/bin/activate
+RUN python -m pip install -e . --user --no-cache-dir
 
 CMD ["python", "-m", "pysieve"]

--- a/PrimeMixed/solution_3/Dockerfile
+++ b/PrimeMixed/solution_3/Dockerfile
@@ -1,12 +1,11 @@
 FROM python:3-alpine
 
-RUN apk add build-base --no-cache
-
-RUN /usr/sbin/adduser -u 1001 -D michaelgrn
+RUN apk add build-base --no-cache && \
+    /usr/sbin/adduser -u 1001 -D michaelgrn
 WORKDIR /home/michaelgrn
 
 RUN python -m venv venv \
-    && chown -R michaelgrn /home/michaelgrn
+    && chown -R michaelgrn .
 
 USER michaelgrn
 
@@ -16,7 +15,6 @@ ENV PATH=$HOME/.local/bin:$PATH
 COPY --chown=michaelgrn setup.py .
 COPY --chown=michaelgrn src/ ./src/
 
-RUN . venv/bin/activate
 RUN python -m pip install -e . --user --no-cache-dir
 
 CMD ["python", "-m", "pysieve"]

--- a/PrimeMixed/solution_3/Dockerfile
+++ b/PrimeMixed/solution_3/Dockerfile
@@ -17,7 +17,7 @@ COPY --chown=michaelgrn setup.py .
 COPY --chown=michaelgrn src/ ./src/
 
 # The following is ignored, due to way venv is used. If you're a Python developer with knowledge of Docker. venv and user installs consider giving your insight here: https://github.com/PlummersSoftwareLLC/Primes/pull/744
-#hadolint ignore=SC1091,DL3059
+# hadolint ignore=SC1091,DL3059
 RUN . venv/bin/activate
 RUN python -m pip install -e . --user --no-cache-dir
 


### PR DESCRIPTION
During #711 a few languages popped up and this pr looks at these and fixes also those docker lint issues.

All builds are verified and do build and work.

My only concern would be: PrimeMixed/solution_3/Dockerfile as i believe venv is meant to use pip to install what's in the setup.py with it's src dir. I did a bit of googeling but the use of . venv/bin/activate is still unknown to me.

Even having the same solution and removing that part still works.