### PR TITLE
Fix zig/solution_1 Dockerfile

### DIFF
--- a/PrimeZig/solution_1/Dockerfile
+++ b/PrimeZig/solution_1/Dockerfile
@@ -1,6 +1,16 @@
-FROM archlinux:base
+FROM debian:buster-slim as builder
 
-RUN pacman --noconfirm -Sy zig
+RUN apt-get update && \
+    apt-get install -y curl xz-utils
+
+WORKDIR /deps
+RUN curl https://ziglang.org/download/0.8.0/zig-linux-"$(uname -m)"-0.8.0.tar.xz  -O && \
+    tar xf zig-linux-"$(uname -m)"-0.8.0.tar.xz && \
+    mv zig-linux-"$(uname -m)"-0.8.0 local/
+
+FROM debian:buster-slim
+COPY --from=builder /deps/local/ /deps/local/
+RUN ln -s /deps/local/zig /usr/bin/zig
 
 WORKDIR /opt/app
 COPY . .


### PR DESCRIPTION
This replaces the Zig/solution_1 Dockefile with that of Zig/solution_3. The reason for this is that the Zig/solution_1 Dockerfile started failing due to a dependency clash regarding libffi; glib2 requires libffi.so-7, whereas Zig started requiring libffi.so-8. 
I picked the Dockerfile for Zig/solution_3 as the replacement because Zig/solution_3 has been most recently maintained. 