### PR TITLE
Enable manual CI runs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,8 @@ on:
     branches: ["**"]
   pull_request:
     branches: ["**"]
+  workflow_dispatch:
+    branches: ["**"]
 
 jobs:
   collect-solutions:

--- a/PrimeV/solution_1/Dockerfile
+++ b/PrimeV/solution_1/Dockerfile
@@ -1,8 +1,8 @@
 FROM alpine:3.13 AS build
 
-ENV V_VER="weekly.2021.39.1"
+ENV V_VER="weekly.2021.45"
 
-RUN apk add --no-cache build-base=0.5-r2 bash=5.1.0-r0 git=2.30.2-r0
+RUN apk update && apk add --no-cache build-base=0.5-r2 bash=5.1.0-r0 git=2.30.2-r0
 
 WORKDIR /opt/vlang
 RUN git clone https://github.com/vlang/v /opt/vlang && git checkout "${V_VER}" && make

--- a/PrimeV/solution_2/Dockerfile
+++ b/PrimeV/solution_2/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.13 AS build
 
-ENV V_VER="weekly.2021.39.1"
+ENV V_VER="weekly.2021.45"
 
 RUN apk update && apk add --no-cache build-base bash=5.1.0-r0 git
 


### PR DESCRIPTION
This adds the workflow_dispatch event to the list of triggering events in CI.yml. 
This will allow maintainers to manually trigger CI in GitHub Actions. I would like to be able to do that to periodically check if builds still work, now that the influx of PRs has decreased and this doesn't regularly happen organically anymore.