### PR TITLE
Load BASIC program to start ML

### DIFF
--- a/Prime6502Assembly/solution_1/README.md
+++ b/Prime6502Assembly/solution_1/README.md
@@ -97,5 +97,5 @@ Note that the program writes a file to the disk in device 8, which thus has to b
 ## Results
 On my system, on Windows 10, the following is shown when the parse command is executed:
 ```
-rbergen;1;182.533333333333;1;algorithm=base,faithful=no,bits=1
+rbergen;1;172.466666666667;1;algorithm=base,faithful=no,bits=1
 ```

--- a/Prime6502Assembly/solution_1/README.md
+++ b/Prime6502Assembly/solution_1/README.md
@@ -1,4 +1,4 @@
-# 6502 assembly solution by rbergen
+# 6502 assembly solution by rbergen for Commodore 128
 
 ![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
 ![Faithfulness](https://img.shields.io/badge/Faithful-no-yellowgreen)
@@ -97,5 +97,5 @@ Note that the program writes a file to the disk in device 8, which thus has to b
 ## Results
 On my system, on Windows 10, the following is shown when the parse command is executed:
 ```
-rbergen;1;172.45;1;algorithm=base,faithful=no,bits=1
+rbergen-c128;1;172.45;1;algorithm=base,faithful=no,bits=1
 ```

--- a/Prime6502Assembly/solution_1/README.md
+++ b/Prime6502Assembly/solution_1/README.md
@@ -89,7 +89,7 @@ After assembly, the program can be loaded in any C128 emulator (or an actual C12
 Assuming the program is itself the only program stored on a disk in device 8, it can be loaded and started using the following commands:
 ```
 LOAD"*",8,1
-SYS 4864
+RUN
 ```
 
 Note that the program writes a file to the disk in device 8, which thus has to be present. The contents of this file are described under [Output](#output).

--- a/Prime6502Assembly/solution_1/README.md
+++ b/Prime6502Assembly/solution_1/README.md
@@ -47,7 +47,7 @@ Instructions for installing these applications aren't provided here; the applica
   ```
   Note that `build.ps1` does not need to be executed in subsequent runs; executing `run.ps1` will then suffice.
 - When the execution of the prime sieve completes, BASIC will show a READY prompt. The VICE window will look like this:
-  ![VICE window](https://i.ibb.co/7G9fk2N/c128primes.png)
+  ![VICE window](https://i.ibb.co/f9F5bJv/c128primes.png)
 
   VICE can now be closed.
 - Execute the following command to parse and display the result:
@@ -97,5 +97,5 @@ Note that the program writes a file to the disk in device 8, which thus has to b
 ## Results
 On my system, on Windows 10, the following is shown when the parse command is executed:
 ```
-rbergen;1;172.466666666667;1;algorithm=base,faithful=no,bits=1
+rbergen;1;172.45;1;algorithm=base,faithful=no,bits=1
 ```

--- a/Prime6502Assembly/solution_1/README.md
+++ b/Prime6502Assembly/solution_1/README.md
@@ -97,5 +97,5 @@ Note that the program writes a file to the disk in device 8, which thus has to b
 ## Results
 On my system, on Windows 10, the following is shown when the parse command is executed:
 ```
-rbergen;1;182.55;1;algorithm=base,faithful=no,bits=1
+rbergen;1;182.533333333333;1;algorithm=base,faithful=no,bits=1
 ```

--- a/Prime6502Assembly/solution_1/parse.ps1
+++ b/Prime6502Assembly/solution_1/parse.ps1
@@ -9,4 +9,4 @@ Get-Content output.txt | ForEach-Object {
         "rbergen;1;$([Convert]::ToInt64($fields[1], 16)/60);1;algorithm=base,faithful=no,bits=1"
     }
 }
-rm output.txt
+Remove-Item output.txt

--- a/Prime6502Assembly/solution_1/primes.s
+++ b/Prime6502Assembly/solution_1/primes.s
@@ -15,7 +15,7 @@ CNT_HIGH=$01
 BUF_BITS=SIEVE_SIZE/2
 BUF_BYTES=BUF_BITS/8
 HALF_BUF_SIZE=BUF_BYTES/2
-HALF_BUF_END=HALF_BUF_SIZE-1
+HALF_BUF_LAST=HALF_BUF_SIZE-1
 SQRT_BYTES=SIEVE_SQRT/8
 
 CURPTR=$fa
@@ -42,7 +42,7 @@ SYS=$9e
 BASIC_START=$1c01
 PROGRAM_START=$1300     ; 4864
 BUF_START=$2000
-BUF_END=BUF_START+HALF_BUF_END
+BUF_END=BUF_START+HALF_BUF_LAST
 
     ; load BASIC program to start
     .org BASIC_START
@@ -348,9 +348,9 @@ init_halfbuf:
     lda #>BUF_START
     sta CURPTR+1
 
-    lda #<HALF_BUF_END
+    lda #<HALF_BUF_LAST
     sta counter
-    lda #>HALF_BUF_END
+    lda #>HALF_BUF_LAST
     sta counter+1
 
     ; setup registers

--- a/Prime6502Assembly/solution_1/primes.s
+++ b/Prime6502Assembly/solution_1/primes.s
@@ -65,7 +65,6 @@ fname: .byte "OUTPUT,S,W"
 fname_end: 
 time_label: .byte "TIME 0X",0
 valid_label: .byte "VALID ",0
-done_label: .byte EOL,"DONE",EOL,0
 ram_config: .word 0
 hex_chars: .byte "0123456789ABCDEF"
 

--- a/Prime6502Assembly/solution_1/primes.s
+++ b/Prime6502Assembly/solution_1/primes.s
@@ -411,8 +411,7 @@ inc_fctr:
 
     lda fctr_bitcnt
     cmp #8
-    bmi ld_fctrroot
-    sec
+    bcc ld_fctrroot
     sbc #8
     sta fctr_bitcnt
 
@@ -450,11 +449,11 @@ fctr_chkend:
     ; see if we've reached the end of our buffer
     lda CURPTR+1
     cmp #>BUF_END
-    bmi unset_curbit
+    bcc unset_curbit
     bne unset_halfbuf_end
     lda CURPTR
     cmp #<BUF_END
-    bmi unset_curbit
+    bcc unset_curbit
     bne unset_halfbuf_end
 
 ; clear bit under pointer

--- a/Prime6502Assembly/solution_1/primes.s
+++ b/Prime6502Assembly/solution_1/primes.s
@@ -132,11 +132,9 @@ cnd_loop:
     jsr inc_fctr            ; this also loads the factor byte number into X
 
     ; we can stop if we've reached the square root of the sieve size
-    cpx SQRT_BYTES
-    beq validate            ; we can't let this label get too far away from us
-
-    ; keep looking
-    jmp cnd_loop
+    cpx #SQRT_BYTES
+    bmi cnd_loop
+    jmp validate            ; we can't let this label get too far away from us
 
 ; we found a factor, let's clear multiples!
 unset_fctrs:
@@ -194,7 +192,10 @@ sub_savelow:
 
     ; we can stop if we've reached the square root of the sieve size
     cpx #SQRT_BYTES  
-    beq validate
+    bmi next_fctr
+    jmp validate
+
+next_fctr:    
 
     ; restore pointer and find next factor
     lda cndptr

--- a/Prime6502Assembly/solution_1/primes.s
+++ b/Prime6502Assembly/solution_1/primes.s
@@ -193,7 +193,7 @@ sub_savelow:
     jsr inc_fctr            ; this also loads the factor byte number into X
 
     ; we can stop if we've reached the square root of the sieve size
-    cpx SQRT_BYTES  
+    cpx #SQRT_BYTES  
     beq validate
 
     ; restore pointer and find next factor

--- a/Prime6502Assembly/solution_1/primes.s
+++ b/Prime6502Assembly/solution_1/primes.s
@@ -133,7 +133,7 @@ cnd_loop:
 
     ; we can stop if we've reached the square root of the sieve size
     cpx #SQRT_BYTES
-    bmi cnd_loop
+    bcc cnd_loop
     jmp validate            ; we can't let this label get too far away from us
 
 ; we found a factor, let's clear multiples!
@@ -192,7 +192,7 @@ sub_savelow:
 
     ; we can stop if we've reached the square root of the sieve size
     cpx #SQRT_BYTES  
-    bmi next_fctr
+    bcc next_fctr
     jmp validate
 
 next_fctr:    

--- a/Prime6502Assembly/solution_1/primes.s
+++ b/Prime6502Assembly/solution_1/primes.s
@@ -37,15 +37,19 @@ SETTIM=$ffdb
 RDTIM=$ffde
 
 EOL=13
+SYS=$9e
 
-BASIC_START=$0801
+BASIC_START=$1c01
 PROGRAM_START=$1300     ; 4864
 BUF_START=$2000
 BUF_END=BUF_START+HALF_BUF_END
 
-;    ; load BASIC program to start: 10 SYS 4864
-;    .org BASIC_START
-;    .byte $0c,$08,$0a,$00,$9e,$20,"4864",$00,$00,$00
+    ; load BASIC program to start
+    .org BASIC_START
+    .word basic_end             ; address of next BASIC line
+    .byte 10,0,SYS," 4864",0    ; 10 SYS 4864
+basic_end:
+    .word $00                   ; end of program
 
     .org PROGRAM_START
     jmp start

--- a/Prime6502Assembly/solution_1/run.ps1
+++ b/Prime6502Assembly/solution_1/run.ps1
@@ -1,2 +1,2 @@
 c1541 -format primes,c1 d64 .\primes.d64 -write .\primes.prg
-x128 -autoload .\primes.d64 -keybuf "sys 4864`n"
+x128 -autostart .\primes.d64

--- a/Prime6502Assembly/solution_1/run.sh
+++ b/Prime6502Assembly/solution_1/run.sh
@@ -1,4 +1,4 @@
 #/bin/bash
 c1541 -format primes,c1 d64 ./primes.d64 -write ./primes.prg
-x128 -autoload ./primes.d64 -keybuf "sys 4864
+x128 -autostart ./primes.d64
 "


### PR DESCRIPTION
## Description
This extends 6502Assembly/solution_1 with a small BASIC program that calls the actual machine language implementation.

This allows the starting of the solution to be simplified to a `LOAD`/`RUN` combination. That in turn makes it possible to use the VICE `-autostart` option.

The reason this didn't work before (and the relevant part of `primes.s` was commented out) was that I was loading the BASIC program into where the BASIC RAM is located _in the C64_. A case of RTFM, in other words.

## Contributing requirements
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [ ] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
