### PR TITLE
Fix OCaml Dockerfiles

### DIFF
--- a/PrimeOCaml/solution_1/Dockerfile
+++ b/PrimeOCaml/solution_1/Dockerfile
@@ -1,5 +1,7 @@
 FROM primeimages/ocaml:4.12-r1 AS build
 
+RUN mkdir /home/opam/primeocaml
+
 WORKDIR /home/opam/primeocaml
 
 COPY *.ml ./

--- a/PrimeOCaml/solution_2/Dockerfile
+++ b/PrimeOCaml/solution_2/Dockerfile
@@ -1,5 +1,7 @@
 FROM primeimages/ocaml:4.12-r1 AS build
 
+RUN mkdir /home/opam/primeocaml
+
 WORKDIR /home/opam/primeocaml
 
 COPY *.ml ./


### PR DESCRIPTION
This makes the OCaml Dockerfiles explicitly create the /home/opam/primeocaml directory before WORKDIR-ing into it. This makes that the directory is created by the opam user, instead of root.

In  fresh `docker build`s of the OCaml solutions on one of my machines, the builds failed due to `corebuild` (running as user opam) trying to create a `_build` directory under a root-owned /home/opam/primeocaml.