### PR TITLE
Update PrimeSieveOctave.m

### DIFF
--- a/PrimeOctave/solution_1/PrimeSieveOctave.m
+++ b/PrimeOctave/solution_1/PrimeSieveOctave.m
@@ -37,7 +37,7 @@ endwhile
 final_time = time()-start_time;
 
 % Average runtime per pass
-avg = final_time/count;
+avg = final_time/passes;
 
 % Validate if a known limit was used
 % rbergen: ended line with semicolon to suppress output line 


### PR DESCRIPTION


## Description
<!--
In the current version, avg is miscalculated as the average time-per-prime in the final pass.

Updated version calculates avg as average time-per-pass
-->

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [ ] I placed my solution in the correct solution folder.
* [ ] I added a README.md with the right badge(s).
* [ ] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [ ] All code herein is licensed compatible with BSD-3.
