### PR TITLE
Fix output of extra tags in FSharp Solution 4

### DIFF
--- a/PrimeFSharp/solution_4/Program.fs
+++ b/PrimeFSharp/solution_4/Program.fs
@@ -72,7 +72,7 @@ let printResults showResults duration passes sieveSize numPrimes =
           passes duration (duration / (float passes)) sieveSize numPrimes isValid
 
   if isValid then
-    printfn "GordonBGood_unpeeled;%d;%f;1;algorithm=base;faithful=yes;bits=1" passes duration
+    printfn "GordonBGood_unpeeled;%d;%f;1;algorithm=base,faithful=yes,bits=1" passes duration
   else
     printfn "ERROR: invalid results"
 


### PR DESCRIPTION
Fixed output of extra tags so that it uses commas instead of semicolons for separators.

## Description
<!--
Fixed output of extra tags so that it uses commas instead of semicolons for separators.
-->

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
