### PR TITLE
Fixing extra tags output for PrimeBefunge/solution_1 by replacing the semicolons with commas for the tag separators.

### DIFF
--- a/PrimeBefunge/solution_1/primes.b98
+++ b/PrimeBefunge/solution_1/primes.b98
@@ -18,7 +18,7 @@ g      ^ < SPACE ' ' IS 32                         #                  >'0+>:#,_$
 1                                       >0";89fb-lojt">:#,_$\  > 0\>:aw>:a%'0v '
 +      v                                           <               ^ ;>^;/a\+< .
 :                               >,v                            ^      %*:**aaa,<
-2                               |:<     $#";1;algorithm=base;faithful=no;bits=1"a0<
+2                               |:<     $#";1;algorithm=base,faithful=no,bits=1"a0<
 1                               @   > :v  :<  "valid"a0   <   VALIDATE PRIME COUNT BELOW
 p                                   ^ ,_^  ^"invalid"a0  _^#-  <      <          <         <   **<
 p                                   ^ "unclear"a0 <    <      <      <        <        <<        :

--- a/PrimeFSharp/solution_4/Program.fs
+++ b/PrimeFSharp/solution_4/Program.fs
@@ -72,7 +72,7 @@ let printResults showResults duration passes sieveSize numPrimes =
           passes duration (duration / (float passes)) sieveSize numPrimes isValid
 
   if isValid then
-    printfn "GordonBGood_unpeeled;%d;%f;1;algorithm=base;faithful=yes;bits=1" passes duration
+    printfn "GordonBGood_unpeeled;%d;%f;1;algorithm=base,faithful=yes,bits=1" passes duration
   else
     printfn "ERROR: invalid results"
 


### PR DESCRIPTION

## Description
Fixing extra tags output for PrimeBefunge/solution_1 by replacing the semicolons with commas for the tag separators.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
