### PR TITLE
Optimize 6502 assembly solutions

### DIFF
--- a/Prime6502Assembly/solution_1/README.md
+++ b/Prime6502Assembly/solution_1/README.md
@@ -59,7 +59,9 @@ docker run -ti --rm 6502assembly1
   .\build.ps1
   .\run.ps1
   ```
-  Note that `build.ps1` does not need to be executed in subsequent runs; executing `run.ps1` will then suffice.
+  Note that:
+  - `build.ps1` does not need to be executed in subsequent runs; executing `run.ps1` will then suffice.
+  - any arguments passed to `run.ps1` will be passed on to the emulator.
 - When the execution of the prime sieve completes, BASIC will show a READY prompt. The VICE window will look like this:
   ![VICE window](https://i.ibb.co/f9F5bJv/c128primes.png)
 
@@ -88,7 +90,9 @@ docker run -ti --rm 6502assembly1
   ./build.sh
   ./run.sh
   ```
-  Note that `build.sh` does not need to be executed in subsequent runs; executing `run.sh` will then suffice.
+  Note that:
+  - `build.sh` does not need to be executed in subsequent runs; executing `run.sh` will then suffice.
+  - any arguments passed to `run.sh` will be passed on to the emulator.
 - When the execution of the prime sieve completes, BASIC will show a READY prompt. The VICE window will look like shown above. <br/>
   VICE can now be closed.
 - Execute the following command to parse and display the result:

--- a/Prime6502Assembly/solution_1/dockerrun.sh
+++ b/Prime6502Assembly/solution_1/dockerrun.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 c1541 -format primes,c1 d64 ./primes.d64 -write ./primes.prg > /dev/null
-x128 -console -autostart ./primes.d64 +sound > /dev/null &
+x128 -console -autostart ./primes.d64 +sound -warp > /dev/null &
 
 while : ; do
     sleep 10 

--- a/Prime6502Assembly/solution_1/primes.s
+++ b/Prime6502Assembly/solution_1/primes.s
@@ -67,7 +67,7 @@ time_label: .byte "TIME ",0
 valid_label: .byte "VALID ",0
 clock_string: .byte 0
     .storage 8
-remainder: .storage 3
+remainder: .storage 1
 ram_config: .word 0
 
 start:
@@ -553,10 +553,6 @@ write_str_end:
 ; that can be found at https://www.youtube.com/watch?v=v3-a-zqKfgA. While you're there, watch the whole series and check  
 ; out his project page: https://eater.net/6502.
 ;
-
-div_tmp: .word 0
-
-;
 ; routine: convert 24-bit value at *clock to decimal string at *clock_string using binary long division
 ; Note that the value at *clock to *clock+2 will be destroyed (set to 0) in the process
 ;
@@ -564,8 +560,6 @@ clock_to_string:
     ; set remainder to 0
     lda #0
     sta remainder
-    sta remainder+1
-    sta remainder+2
     clc
 
     ldx #24
@@ -576,28 +570,16 @@ div_loop:
     rol clock+1
     rol clock+2
     rol remainder
-    rol remainder+1
-    rol remainder+2
 
     ; try to substract divisor
     sec
     lda remainder
     sbc #10
-    sta div_tmp
-    lda remainder+1
-    sbc #0
-    sta div_tmp+1
-    lda remainder+2
-    sbc #0
     
     ; dividend < divisor
     bcc ignore_result
 
-    ; store current state of remainder
-    sta remainder+2
-    lda div_tmp+1 
-    sta remainder+1
-    lda div_tmp 
+    ; store current remainder
     sta remainder
 
 ignore_result:
@@ -611,7 +593,6 @@ ignore_result:
     rol clock+2
 
     ; current remainder is clock digit value
-    lda remainder
     clc
     adc #'0'
 

--- a/Prime6502Assembly/solution_1/primes.s
+++ b/Prime6502Assembly/solution_1/primes.s
@@ -593,6 +593,7 @@ ignore_result:
     rol clock+2
 
     ; current remainder is clock digit value
+    lda remainder
     clc
     adc #'0'
 

--- a/Prime6502Assembly/solution_1/run.ps1
+++ b/Prime6502Assembly/solution_1/run.ps1
@@ -1,2 +1,2 @@
 c1541 -format primes,c1 d64 .\primes.d64 -write .\primes.prg
-x128 -autostart .\primes.d64
+x128 -autostart .\primes.d64 $args

--- a/Prime6502Assembly/solution_1/run.sh
+++ b/Prime6502Assembly/solution_1/run.sh
@@ -1,3 +1,3 @@
 #/bin/bash
 c1541 -format primes,c1 d64 ./primes.d64 -write ./primes.prg
-x128 -autostart ./primes.d64
+x128 -autostart ./primes.d64 "$@"

--- a/Prime6502Assembly/solution_2/README.md
+++ b/Prime6502Assembly/solution_2/README.md
@@ -59,7 +59,9 @@ docker run -ti --rm 6502assembly2
   .\build.ps1
   .\run.ps1
   ```
-  Note that `build.ps1` does not need to be executed in subsequent runs; executing `run.ps1` will then suffice.
+  Note that:
+  - `build.ps1` does not need to be executed in subsequent runs; executing `run.ps1` will then suffice.
+  - any arguments passed to `run.ps1` will be passed on to the emulator.
 - When the execution of the prime sieve completes, BASIC will show a READY prompt. The VICE window will look like this:
   ![VICE window](https://i.ibb.co/S09QLfP/petprimes.png)
 
@@ -88,7 +90,9 @@ docker run -ti --rm 6502assembly2
   ./build.sh
   ./run.sh
   ```
-  Note that `build.sh` does not need to be executed in subsequent runs; executing `run.sh` will then suffice.
+  Note that:
+  - `build.sh` does not need to be executed in subsequent runs; executing `run.sh` will then suffice.
+  - any arguments passed to `run.sh` will be passed on to the emulator.
 - When the execution of the prime sieve completes, BASIC will show a READY prompt. The VICE window will look like shown above. <br/>
   VICE can now be closed.
 - Execute the following command to parse and display the result:

--- a/Prime6502Assembly/solution_2/dockerrun.sh
+++ b/Prime6502Assembly/solution_2/dockerrun.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 c1541 -format primes,c1 d64 ./primes.d64 -write ./primes.prg > /dev/null
-xpet -console -autostart ./primes.d64 +sound > /dev/null &
+xpet -console -autostart ./primes.d64 +sound -warp > /dev/null &
 
 while : ; do
     sleep 10 

--- a/Prime6502Assembly/solution_2/parse.sh
+++ b/Prime6502Assembly/solution_2/parse.sh
@@ -13,7 +13,7 @@ if ! grep -Fq 'VALID Y' output.txt ; then
 fi
 
 mac2unix output.txt > /dev/null 2>&1
-cat output.txt
+
 awk '/TIME/ {RUNTIME=$2} END {printf("rbergen-pet;1;%.3f;1;algorithm=base,faithful=no,bits=1\n", RUNTIME/60.0)}' output.txt
 
 rm output.txt

--- a/Prime6502Assembly/solution_2/parse.sh
+++ b/Prime6502Assembly/solution_2/parse.sh
@@ -13,7 +13,7 @@ if ! grep -Fq 'VALID Y' output.txt ; then
 fi
 
 mac2unix output.txt > /dev/null 2>&1
-
+cat output.txt
 awk '/TIME/ {RUNTIME=$2} END {printf("rbergen-pet;1;%.3f;1;algorithm=base,faithful=no,bits=1\n", RUNTIME/60.0)}' output.txt
 
 rm output.txt

--- a/Prime6502Assembly/solution_2/primes.s
+++ b/Prime6502Assembly/solution_2/primes.s
@@ -506,6 +506,7 @@ ignore_result:
     rol clock+2
 
     ; current remainder is clock digit value
+    lda remainder
     clc
     adc #'0'
 

--- a/Prime6502Assembly/solution_2/primes.s
+++ b/Prime6502Assembly/solution_2/primes.s
@@ -67,7 +67,7 @@ time_label: .byte "TIME ",0
 valid_label: .byte "VALID ",0
 clock_string: .byte 0
     .storage 8
-remainder: .storage 3
+remainder: .storage 1
 
 start:
     ; save temp pointer
@@ -466,10 +466,6 @@ write_str_end:
 ; that can be found at https://www.youtube.com/watch?v=v3-a-zqKfgA. While you're there, watch the whole series and check  
 ; out his project page: https://eater.net/6502.
 ;
-
-div_tmp: .word 0
-
-;
 ; routine: convert 24-bit value at *clock to decimal string at *clock_string using binary long division
 ; Note that the value at *clock to *clock+2 will be destroyed (set to 0) in the process
 ;
@@ -477,8 +473,6 @@ clock_to_string:
     ; set remainder to 0
     lda #0
     sta remainder
-    sta remainder+1
-    sta remainder+2
     clc
 
     ldx #24
@@ -489,28 +483,16 @@ div_loop:
     rol clock+1
     rol clock+2
     rol remainder
-    rol remainder+1
-    rol remainder+2
 
     ; try to substract divisor
     sec
     lda remainder
     sbc #10
-    sta div_tmp
-    lda remainder+1
-    sbc #0
-    sta div_tmp+1
-    lda remainder+2
-    sbc #0
     
     ; dividend < divisor
     bcc ignore_result
 
-    ; store current state of remainder
-    sta remainder+2
-    lda div_tmp+1 
-    sta remainder+1
-    lda div_tmp 
+    ; store current remainder
     sta remainder
 
 ignore_result:
@@ -524,7 +506,6 @@ ignore_result:
     rol clock+2
 
     ; current remainder is clock digit value
-    lda remainder
     clc
     adc #'0'
 

--- a/Prime6502Assembly/solution_2/run.ps1
+++ b/Prime6502Assembly/solution_2/run.ps1
@@ -1,2 +1,2 @@
 c1541 -format primes,c2 d64 .\primes.d64 -write .\primes.prg
-xpet -autostart .\primes.d64
+xpet -autostart .\primes.d64 $args

--- a/Prime6502Assembly/solution_2/run.sh
+++ b/Prime6502Assembly/solution_2/run.sh
@@ -1,3 +1,3 @@
 #/bin/bash
 c1541 -format primes,c2 d64 ./primes.d64 -write ./primes.prg
-xpet -autostart ./primes.d64
+xpet -autostart ./primes.d64 "$@"


### PR DESCRIPTION
This optimizes the 6502 assembly solutions for the C128 and PET in the following ways:
- The division algorithm in `clock_to_string` now uses only one byte to hold the remainder, which simplifies the routine significantly. It occurred to me that with a divisor of 10, the highest value `remainder` can hold is 19, which comfortably fits in a single byte. In fact, one byte is enough for any divisor up to and including 128.
- In Docker, the emulators are executed with the -warp option set. This significantly decreases the actual Docker run time, without impacting the reported sieve run durations. The reason for that is that the latter is measured within the emulated machines. 
- Any arguments passed to the run scripts (`run.ps1`, `run.sh`) are passed on to the applicable emulator (either `x128` or `xpet`).