### PR TITLE
Fixed awk solution 1's output to output 1 for number of threads

### DIFF
--- a/PrimeAWK/solution_1/primes.awk
+++ b/PrimeAWK/solution_1/primes.awk
@@ -95,7 +95,7 @@ function print_results(show_results, passes, duration)
 
     print "Passes: " passes ", Time: " duration ", Average: " duration / passes ", Count: " count ", Valid: " validate_results();
 
-    print "DaviNakamuraCardoso;" passes ";" duration ";algorithm=base,faithful=no";
+    print "DaviNakamuraCardoso;" passes ";" duration ";1;algorithm=base,faithful=no";
     return;
 }
 


### PR DESCRIPTION
## Description
<!--
Add your description here.
-->
Fixed awk solution 1's output to output 1 for number of threads
## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
