### PR TITLE
Add a third Clojure solution

### DIFF
--- a/PrimeClojure/solution_3/.gitignore
+++ b/PrimeClojure/solution_3/.gitignore
@@ -1,0 +1,2 @@
+.cpcache/
+.nrepl-port

--- a/PrimeClojure/solution_3/Dockerfile
+++ b/PrimeClojure/solution_3/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure
+FROM clojure:openjdk-18-tools-deps-1.10.3.1040
 WORKDIR /primes
 COPY deps.edn sieve.clj run.sh ./
 ENTRYPOINT ["./run.sh"]

--- a/PrimeClojure/solution_3/Dockerfile
+++ b/PrimeClojure/solution_3/Dockerfile
@@ -1,0 +1,4 @@
+FROM clojure
+WORKDIR /primes
+COPY deps.edn sieve.clj run.sh ./
+ENTRYPOINT ["./run.sh"]

--- a/PrimeClojure/solution_3/README.md
+++ b/PrimeClojure/solution_3/README.md
@@ -1,0 +1,82 @@
+# Clojure solution 3 by Peter Strömberg (@PEZ)
+
+![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
+![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
+![Parallelism](https://img.shields.io/badge/Parallel-yes-green)
+![Bit count](https://img.shields.io/badge/Bits-8-yellowgreen)
+
+A faithful [Clojure](https://clojure.org/) implementation of
+the [Sieve of Eratosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes)
+algorithm.
+
+The solution uses Clojure [transients](https://clojure.org/reference/transients) to make it run faster than it would do with the regular immutable datastructure, gaining about 2X in speed this way.
+
+It also uses [futures](https://clojure.org/about/concurrent_programming) to try gain some extra speed, (hence the **Parallelism = yes** tag). This actually does not gain us all that much, but it's notable enough so I have kept it. Also, I think that when you start to sieve much more than the first one million primes, you will start to see gains from the parallelism. (But I'm not an expert, so don't take my word for it.)
+
+## Run instructions
+
+The runner infrastructure is copied from Alex Vaer's [Clojure Solution 2](https://github.com/PlummersSoftwareLLC/Primes/tree/drag-race/PrimeClojure/solution_2).
+
+
+1. Install a JDK.
+2. Install the [Clojure CLI tools](https://clojure.org/guides/getting_started#_clojure_installer_and_cli_tools).
+3. Run with `clojure -X sieve/run :warm-up? true`
+
+The warm-up makes the runner start with a silent run, before running one that is reported, giving slightly more consistent results. (But, really, you should use Criterium for benchmarking while developing, see below.)
+
+You can also run this via Docker:
+
+```sh
+$ docker pull clojure
+$ docker build -t primes-clojure .
+$ docker run --rm -it primes-clojure
+```
+
+## Output
+
+```
+Passes: 2546, Time: 5.000879000, Avg: 0.00196421, Limit: 1000000, Count: 78498, Valid: True
+pez-clj;2546;5.000879000;1;algorithm=base,faithful=yes,bits=8
+```
+
+(On an Apple M1 Max with 8 performance cores and 32GB of RAM.)
+
+## Development
+
+If you have experience with Clojure: It's just a regular tools/deps project. Start it and connect your Clojure editor of choice to it.
+
+If not, I suggest using [Calva](https://calva.io):
+
+1. Open the project root in in VS Code.
+1. Open `sieve.clj`
+1. Issue the command **Calva: Starta Clojure REPL in your Project and Connect (aka Jack-in)**
+1. When the REPL has started, issue **Calva: Load current file and its dependencies**
+
+Then find this Rich Comment block in the file:
+
+```clojure
+(comment
+  (sieve 1)
+  ;; => ()
+
+  (sieve 10)
+  ;; => [2 3 5 7]
+
+  (sieve 100)
+  ;; You try it!
+  
+  ;; `doall` is not strictly necessary for this sieve, because it is not lazy,
+  ;; but for good measure =)
+  (with-progress-reporting (quick-bench (doall (sieve 1000000))))
+  (quick-bench (doall (sieve 1000000)))
+
+  ;; This one takes a lot of time, you have been warned
+  (with-progress-reporting (bench (doall (sieve 1000000))))
+  )
+```
+
+Place the cursor in one of the forms (say `(sieve 1)`) and issue the command **Calva: Evaluate top level form** (default key binding `alt+enter`). Try `alt+enter` in some of the other forms too.
+
+The project is equipped with the excellent [Criterium](https://github.com/hugoduncan/criterium) library, which is very nice (and sort-of de-facto) for benchmarking Clojure code.
+
+Happy sieving! ♥️

--- a/PrimeClojure/solution_3/README.md
+++ b/PrimeClojure/solution_3/README.md
@@ -27,7 +27,7 @@ The warm-up makes the runner start with a silent run, before running one that is
 You can also run this via Docker:
 
 ```sh
-$ docker pull clojure
+$ docker pull clojure:openjdk-18-tools-deps-1.10.3.1040
 $ docker build -t primes-clojure .
 $ docker run --rm -it primes-clojure
 ```

--- a/PrimeClojure/solution_3/deps.edn
+++ b/PrimeClojure/solution_3/deps.edn
@@ -1,0 +1,3 @@
+{:paths ["."]
+ :deps {org.clojure/clojure {:mvn/version "1.10.3"}
+        criterium/criterium {:mvn/version "0.4.6"}}}

--- a/PrimeClojure/solution_3/run.sh
+++ b/PrimeClojure/solution_3/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+clojure -X sieve/run :warm-up? true

--- a/PrimeClojure/solution_3/sieve.clj
+++ b/PrimeClojure/solution_3/sieve.clj
@@ -123,7 +123,7 @@
          "Count: " (count primes) ", "
          "Valid: " (if valid? "True" "False")
          "\n"
-         "pez-clj;" passes ";" timef ";1;algorithm=base,faithful=yes,bits=8")))
+         "pez-clj;" passes ";" timef ";8;algorithm=base,faithful=yes,bits=8")))
 
 
 (defn run [{:keys [warm-up?]

--- a/PrimeClojure/solution_3/sieve.clj
+++ b/PrimeClojure/solution_3/sieve.clj
@@ -1,0 +1,134 @@
+(ns sieve
+  "Clojure implementation of Sieve of Eratosthenes by Peter Strömberg (a.k.a. PEZ)
+
+  This implementation is faithful to Dave's original implementation,
+   see `README.md` for a bit more on this (or the code below, of course)"
+  (:require [criterium.core :refer [with-progress-reporting bench quick-bench]])
+  (:import [java.time Instant Duration]))
+
+
+;; Disable overflow checks on mathematical ops and warn when compiler is unable
+;; to optimise correctly.
+(set! *warn-on-reflection* true)
+(set! *unchecked-math* :warn-on-boxed)
+
+
+(defn sieve [^long n]
+  (let [primes (boolean-array (inc n) true)
+        sqrt-n (int (Math/ceil (Math/sqrt n)))]
+    (if (< n 2)
+      '()
+      (loop [p 3]
+        (if (< sqrt-n p)
+          (let [num-slices 8 ; I'm not sure what is a good default
+                num-slices (if (and (zero? ^long (mod n num-slices))
+                                    (> n 1000))
+                             num-slices
+                             1)
+                slice-size (quot n num-slices)
+                futures (mapv (fn [^long slice-num]
+                                (future
+                                  (let [start (inc (* slice-num slice-size))
+                                        end (dec (+ start slice-size))
+                                        start (if (= start 1) 3 start)]
+                                    (loop [res (transient [])
+                                           i start]
+                                      (if (<= i end)
+                                        (recur (if (aget primes i)
+                                                 (conj! res i)
+                                                 res)
+                                               (+ i 2))
+                                        (persistent! res))))))
+                              (range num-slices))]
+            (into [2]
+                  (mapcat deref)
+                  futures))
+          (do
+            (when (aget primes p)
+              (loop [i (* p p)]
+                (when (<= i n)
+                  (aset primes i false)
+                  (recur (+ i p p)))))
+            (recur  (+ p 2))))))))
+
+(comment
+  (sieve 1)
+  ;; => ()
+
+  (sieve 10)
+  ;; => [2 3 5 7]
+
+  (sieve 100)
+  ;; You try it!
+
+  ;; `doall` is not strictly necessary for this sieve, because it is not lazy,
+  ;; but for good measure =)
+  (with-progress-reporting (quick-bench (doall (sieve 1000000))))
+  (quick-bench (doall (sieve 1000000)))
+
+  ;; This one takes a lot of time, you have been warned
+  (with-progress-reporting (bench (doall (sieve 1000000))))
+  )
+
+(def prev-results
+  "Previous results to check against sieve results."
+  {1           0
+   10          4
+   100         25
+   1000        168
+   10000       1229
+   100000      9592
+   1000000     78498
+   10000000    664579
+   100000000   5761455
+   1000000000  50847534
+   10000000000 455052511})
+
+
+(defn benchmark
+  "Benchmark Sieve of Eratosthenes algorithm."
+  []
+  (let [limit       1000000
+        start-time  (Instant/now)
+        end-by      (+ (.toEpochMilli start-time) 5000)]
+    (loop [pass 1]
+      (let [primes   (sieve limit)
+            n        (count primes)
+            cur-time (System/currentTimeMillis)]
+        (if (<= cur-time end-by)
+          (recur (inc pass))
+          ;; Return benchmark report.
+          {:primes primes
+           :passes pass
+           :limit  limit
+           :time   (Duration/between start-time (Instant/now))
+           :valid? (= n
+                      (prev-results limit))})))))
+
+
+;; Reenable overflow checks on mathematical ops and turn off warnings.
+(set! *warn-on-reflection* false)
+(set! *unchecked-math* false)
+
+
+(defn format-results
+  "Format benchmark results into expected output."
+  [{:keys [primes passes limit time valid?]}]
+  (let [nanos (.toString (.toNanos time))
+        timef (str (subs nanos 0 1) "." (subs nanos 1))]
+    (str "Passes: " passes ", "
+         "Time: " timef ", "
+         "Avg: " (float (/ (/ (.toNanos time) 1000000000) passes)) ", "
+         "Limit: " limit ", "
+         "Count: " (count primes) ", "
+         "Valid: " (if valid? "True" "False")
+         "\n"
+         "pez-clj;" passes ";" timef ";1;algorithm=base,faithful=yes,bits=8")))
+
+
+(defn run [{:keys [warm-up?]
+            :or   {warm-up? false}}]
+  (when warm-up?
+    ;; Warm-up reduces the variability of results.
+    (format-results (benchmark)))
+  (println (format-results (benchmark))))


### PR DESCRIPTION
## Description

A faithful [Clojure](https://clojure.org/) implementation of the [Sieve of Eratosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes) algorithm.

The solution uses Clojure [transients](https://clojure.org/reference/transients) to make it run faster than it would do with the regular immutable datastructure, gaining about 2X in speed this way.

It also uses [futures](https://clojure.org/about/concurrent_programming) to try gain some extra speed, (hence the **Parallelism = yes** tag). This actually does not gain us all that much, but it's notable enough so I have kept it. Also, I think that when you start to sieve much more than the first one million primes, you will start to see gains from the parallelism. (But I'm not an expert, so don't take my word for it.)

### Why a third solution?

This solution is quite different from the others and I really didn't see a time-efficient way to I could ”merge” the ideas into the existing solutions. 

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
