### PR TITLE
Add two non-parallel Clojure Solution 3 variants

### DIFF
--- a/PrimeClojure/solution_3/README.md
+++ b/PrimeClojure/solution_3/README.md
@@ -79,7 +79,7 @@ Then find one of the Rich Comment blocks in the file, one looks like so:
   )
 ```
 
-Place the cursor in one of the forms (say `(sieve 1)`) and issue the command **Calva: Evaluate top level form** (default key binding `alt+enter`). Try `alt+enter` in some of the other forms too.
+Place the cursor in one of the forms (say `(sieve-ba-post-even-filter 1)`) and issue the command **Calva: Evaluate top level form** (default key binding `alt+enter`). Try `alt+enter` in some of the other forms too.
 
 The project is equipped with the excellent [Criterium](https://github.com/hugoduncan/criterium) library, which is very nice (and sort-of de-facto) for benchmarking Clojure code.
 

--- a/PrimeClojure/solution_3/README.md
+++ b/PrimeClojure/solution_3/README.md
@@ -5,7 +5,7 @@
 ![Parallelism](https://img.shields.io/badge/Parallel-yes-green)
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
 ![Bit count](https://img.shields.io/badge/Bits-8-yellowgreen)
-![Bit count](https://img.shields.io/badge/Bits-1-yellowgreen)
+![Bit count](https://img.shields.io/badge/Bits-1-green)
 
 Some faithful [Clojure](https://clojure.org/) implementations of
 the [Sieve of Eratosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes)

--- a/PrimeClojure/solution_3/run.sh
+++ b/PrimeClojure/solution_3/run.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
-clojure -X sieve/run :warm-up? true
+clojure -X sieve/run :variant :boolean-array :warm-up? true
+clojure -X sieve/run :variant :bitset :warm-up? false
+clojure -X sieve/run :variant :boolean-array-futures :warm-up? true

--- a/PrimeClojure/solution_3/sieve.clj
+++ b/PrimeClojure/solution_3/sieve.clj
@@ -128,7 +128,7 @@
          "Count: " (count primes) ", "
          "Valid: " (if valid? "True" "False")
          "\n"
-         "pez-clj;" passes ";" timef ";8;algorithm=base,faithful=yes,bits=8")))
+         "pez-clj;" passes ";" timef ";8;algorithm=base,faithful=yes,bits=1")))
 
 
 (defn run [{:keys [warm-up?]

--- a/PrimeClojure/solution_3/sieve.clj
+++ b/PrimeClojure/solution_3/sieve.clj
@@ -128,7 +128,7 @@
          "Count: " (count primes) ", "
          "Valid: " (if valid? "True" "False")
          "\n"
-         "pez-clj;" passes ";" timef ";8;algorithm=base,faithful=yes,bits=1")))
+         "pez-clj;" passes ";" timef ";8;algorithm=base,faithful=yes,bits=8")))
 
 
 (defn run [{:keys [warm-up?]


### PR DESCRIPTION
## Description

* Add a boolean-array solution that instead of post-processing the sieve to remove the even numbers, it does this step first, in a non-parallel fashion
* Add a BitSet solution which is just like that ^ boolean-array one, only storing in a BitSet
* Change the return value for the `limit < 2` case of the current variant, to return a vector (this doesn't much matter, but it's nice to get the same type out for all inputs.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
