### PR TITLE
Add a parallelized pre-even-filter

### DIFF
--- a/PrimeClojure/solution_3/README.md
+++ b/PrimeClojure/solution_3/README.md
@@ -63,7 +63,7 @@ If not, I suggest using [Calva](https://calva.io):
 
 1. Open the project root in in VS Code.
 1. Open `sieve.clj`
-1. Issue the command **Calva: Starta Clojure REPL in your Project and Connect (aka Jack-in)**
+1. Issue the command **Calva: Start a Clojure REPL in your Project and Connect (aka Jack-in)**
 1. When the REPL has started, issue **Calva: Load current file and its dependencies**
 
 Then find one of the Rich Comment blocks in the file, one looks like so:

--- a/PrimeClojure/solution_3/README.md
+++ b/PrimeClojure/solution_3/README.md
@@ -14,9 +14,12 @@ algorithm.
 * `pez-clj-bitset` – a BitSet is sieved, all bits visited in one pass
 * `pez-clj-bitset-pre` – a BitSet is first initialized so that all bits, but 0, 1 and a all even numbers > 2 are marked as primes, and then the sieve works on removing non-primes
 * `pez-clj-boolean-array` – a boolean array is sieved, all indexes visited in one pass
+* `pez-clj-boolean-skip-evens` – a boolean array representing all odd numbers is sieved
 * `pez-clj-boolean-array-pre` – a boolean array is first initialized so that all indexes, but 0, 1 and a all even numbers > 2 are marked as primes, and then the sieve works on removing non-primes
 * `pez-clj-boolean-array-futures-pre` – same as `boolean-array-pre`, except the evens are cleared in a parallelized manner using [futures](https://clojure.org/about/concurrent_programming)
 * `pez-clj-boolean-array-to-vector-futures` – a boolean array is first initialized so that all indexes, are marked as primes, then the sieve works on removing odd non-primes, then 0, 1 and all even numbers > 2 are removed. The last step uses [transients](https://clojure.org/reference/transients) and is also parallelized using `futures`.
+
+In summary: There are two storages represented, BitSet and boolean array. For both we either visit all indexes or every other. When visiting every other, all but one variant sieve away the even numbers in a separate step. In two solutions we try parallelizing that step. For boolean arrays we have one variant returning the primes, and one returning the primes array of half the size, where the indexes represent the odd numbers (except index 0, representing 2).
 
 ## Run instructions
 
@@ -39,18 +42,20 @@ $ docker run --rm -it pez-primes-clojure
 ## Sample output
 
 ```
-Passes: 496, Time: 5.002424000, Avg: 0.010085532, Limit: 1000000, Count: 78498, Valid: True
-pez-clj-bitset;496;5.002424000;1;algorithm=base,faithful=yes,bits=1
-Passes: 1472, Time: 5.000757000, Avg: 0.0033972533, Limit: 1000000, Count: 78498, Valid: True
-pez-clj-bitset-pre;1472;5.000757000;1;algorithm=base,faithful=yes,bits=1
-Passes: 1246, Time: 5.004753000, Avg: 0.0040166555, Limit: 1000000, Count: 78498, Valid: True
-pez-clj-boolean-array;1246;5.004753000;1;algorithm=base,faithful=yes,bits=8
-Passes: 2560, Time: 5.000806000, Avg: 0.0019534398, Limit: 1000000, Count: 78498, Valid: True
-pez-clj-boolean-array-pre;2560;5.000806000;1;algorithm=base,faithful=yes,bits=8
-Passes: 3419, Time: 5.001685000, Avg: 0.0014629087, Limit: 1000000, Count: 78498, Valid: True
-pez-clj-boolean-array-pre-futures;3419;5.001685000;8;algorithm=base,faithful=yes,bits=8
-Passes: 2529, Time: 5.000828000, Avg: 0.0019773934, Limit: 1000000, Count: 78498, Valid: True
-pez-clj-boolean-array-to-vector-futures;2529;5.000828000;8;algorithm=base,faithful=yes,bits=8
+Passes: 503, Time: 5.008766000, Avg: 0.009957786, Limit: 1000000, Count: 78498, Valid: True
+pez-clj-bitset;503;5.008766000;1;algorithm=base,faithful=yes,bits=1
+Passes: 1479, Time: 5.003185000, Avg: 0.003382816, Limit: 1000000, Count: 78498, Valid: True
+pez-clj-bitset-pre;1479;5.003185000;1;algorithm=base,faithful=yes,bits=1
+Passes: 1114, Time: 5.004537000, Avg: 0.004492403, Limit: 1000000, Count: 78498, Valid: True
+pez-clj-boolean-array;1114;5.004537000;1;algorithm=base,faithful=yes,bits=8
+Passes: 3801, Time: 5.002056000, Avg: 0.0013159842, Limit: 1000000, Count: 78498, Valid: True
+pez-clj-boolean-array-skip-evens;3801;5.002056000;1;algorithm=base,faithful=yes,bits=8
+Passes: 2562, Time: 5.001005000, Avg: 0.0019519926, Limit: 1000000, Count: 78498, Valid: True
+pez-clj-boolean-array-pre;2562;5.001005000;1;algorithm=base,faithful=yes,bits=8
+Passes: 3422, Time: 5.001372000, Avg: 0.0014615348, Limit: 1000000, Count: 78498, Valid: True
+pez-clj-boolean-array-pre-futures;3422;5.001372000;8;algorithm=base,faithful=yes,bits=8
+Passes: 2574, Time: 5.001419000, Avg: 0.0019430532, Limit: 1000000, Count: 78498, Valid: True
+pez-clj-boolean-array-to-vector-futures;2574;5.001419000;8;algorithm=base,faithful=yes,bits=8
 ```
 
 (On an Apple M1 Max with 8 performance cores and 32GB of RAM.)

--- a/PrimeClojure/solution_3/README.md
+++ b/PrimeClojure/solution_3/README.md
@@ -11,9 +11,12 @@ Some faithful [Clojure](https://clojure.org/) implementations of
 the [Sieve of Eratosthenes](https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes)
 algorithm.
 
-* `pez-clj-boolean-array` – a boolean array is first initialized so that all indexes, but 0, 1 and a all even numbers > 2 are marked as primes, and then the sieve works on removing non-primes
-* `pez-clj-boolean-array-futures` – a boolean array is first initialized so that all indexes, are marked as primes, then the sieve works on removing odd non-primes, then 0, 1 and all even numbers > 2 are removed. The last step uses [transients](https://clojure.org/reference/transients) and is also parallelized using [futures](https://clojure.org/about/concurrent_programming) for some (small) speed gain. This solution starts to be the fastest of the three at limits of about 10 million. (Depending on which machine is used)
-* `pez-clj-bitset` – a BitSet is first initialized so that all bits, but 0, 1 and a all even numbers > 2 are marked as primes, and then the sieve works on removing non-primes
+* `pez-clj-bitset` – a BitSet is sieved, all bits visited in one pass
+* `pez-clj-bitset-pre` – a BitSet is first initialized so that all bits, but 0, 1 and a all even numbers > 2 are marked as primes, and then the sieve works on removing non-primes
+* `pez-clj-boolean-array` – a boolean array is sieved, all indexes visited in one pass
+* `pez-clj-boolean-array-pre` – a boolean array is first initialized so that all indexes, but 0, 1 and a all even numbers > 2 are marked as primes, and then the sieve works on removing non-primes
+* `pez-clj-boolean-array-futures-pre` – same as `boolean-array-pre`, except the evens are cleared in a parallelized manner using [futures](https://clojure.org/about/concurrent_programming)
+* `pez-clj-boolean-array-to-vector-futures` – a boolean array is first initialized so that all indexes, are marked as primes, then the sieve works on removing odd non-primes, then 0, 1 and all even numbers > 2 are removed. The last step uses [transients](https://clojure.org/reference/transients) and is also parallelized using `futures`.
 
 ## Run instructions
 
@@ -36,12 +39,18 @@ $ docker run --rm -it pez-primes-clojure
 ## Sample output
 
 ```
-Passes: 2564, Time: 5.000985000, Avg: 0.0019504621, Limit: 1000000, Count: 78498, Valid: True
-pez-clj-boolean-array;2564;5.000985000;1;algorithm=base,faithful=yes,bits=8
-Passes: 908, Time: 5.001991000, Avg: 0.0055088005, Limit: 1000000, Count: 78498, Valid: True
-pez-clj-bitset;908;5.001991000;1;algorithm=base,faithful=yes,bits=1
-Passes: 2155, Time: 5.002808000, Avg: 0.0023214887, Limit: 1000000, Count: 78498, Valid: True
-pez-clj-boolean-array-futures;2155;5.002808000;8;algorithm=base,faithful=yes,bits=8
+Passes: 496, Time: 5.002424000, Avg: 0.010085532, Limit: 1000000, Count: 78498, Valid: True
+pez-clj-bitset;496;5.002424000;1;algorithm=base,faithful=yes,bits=1
+Passes: 1472, Time: 5.000757000, Avg: 0.0033972533, Limit: 1000000, Count: 78498, Valid: True
+pez-clj-bitset-pre;1472;5.000757000;1;algorithm=base,faithful=yes,bits=1
+Passes: 1246, Time: 5.004753000, Avg: 0.0040166555, Limit: 1000000, Count: 78498, Valid: True
+pez-clj-boolean-array;1246;5.004753000;1;algorithm=base,faithful=yes,bits=8
+Passes: 2560, Time: 5.000806000, Avg: 0.0019534398, Limit: 1000000, Count: 78498, Valid: True
+pez-clj-boolean-array-pre;2560;5.000806000;1;algorithm=base,faithful=yes,bits=8
+Passes: 3419, Time: 5.001685000, Avg: 0.0014629087, Limit: 1000000, Count: 78498, Valid: True
+pez-clj-boolean-array-pre-futures;3419;5.001685000;8;algorithm=base,faithful=yes,bits=8
+Passes: 2529, Time: 5.000828000, Avg: 0.0019773934, Limit: 1000000, Count: 78498, Valid: True
+pez-clj-boolean-array-to-vector-futures;2529;5.000828000;8;algorithm=base,faithful=yes,bits=8
 ```
 
 (On an Apple M1 Max with 8 performance cores and 32GB of RAM.)
@@ -61,25 +70,25 @@ Then find one of the Rich Comment blocks in the file, one looks like so:
 
 ```clojure
 (comment
-  (sieve-ba-post-even-filter 1)
+  (sieve-ba-to-vector-even-filter-futures 1)
   ;; => []
 
-  (sieve-ba-post-even-filter 10)
+  (sieve-ba-to-vector-even-filter-futures 10)
   ;; => [2 3 5 7]
 
-  (sieve-ba-post-even-filter 100)
+  (sieve-ba-to-vector-even-filter-futures 100)
   ;; You try it!
 
-  (with-progress-reporting (quick-bench (sieve-ba-post-even-filter 1000000)))
-  (quick-bench (sieve-ba-post-even-filter 1000000))
+  (with-progress-reporting (quick-bench (sieve-ba-to-vector-even-filter-futures 1000000)))
+  (quick-bench (sieve-ba-to-vector-even-filter-futures 1000000))
   ;; Execution time mean : 2.703046 ms
 
   ;; This one takes a lot of time, you have been warned
-  (with-progress-reporting (bench (sieve-ba-post-even-filter 1000000)))
+  (with-progress-reporting (bench (sieve-ba-to-vector-even-filter-futures 1000000)))
   )
 ```
 
-Place the cursor in one of the forms (say `(sieve-ba-post-even-filter 1)`) and issue the command **Calva: Evaluate top level form** (default key binding `alt+enter`). Try `alt+enter` in some of the other forms too.
+Place the cursor in one of the forms (say `(sieve-ba-to-vector-even-filter-futures 1)`) and issue the command **Calva: Evaluate top level form** (default key binding `alt+enter`). Try `alt+enter` in some of the other forms too.
 
 The project is equipped with the excellent [Criterium](https://github.com/hugoduncan/criterium) library, which is very nice (and sort-of de-facto) for benchmarking Clojure code.
 

--- a/PrimeClojure/solution_3/run.sh
+++ b/PrimeClojure/solution_3/run.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
-clojure -X sieve/run :variant :boolean-array :warm-up? true
 clojure -X sieve/run :variant :bitset :warm-up? false
-clojure -X sieve/run :variant :boolean-array-futures :warm-up? true
+clojure -X sieve/run :variant :bitset-pre :warm-up? false
+clojure -X sieve/run :variant :boolean-array :warm-up? false
+clojure -X sieve/run :variant :boolean-array-pre :warm-up? true
+clojure -X sieve/run :variant :boolean-array-pre-futures :warm-up? true
+clojure -X sieve/run :variant :boolean-array-to-vector-futures :warm-up? true

--- a/PrimeClojure/solution_3/run.sh
+++ b/PrimeClojure/solution_3/run.sh
@@ -3,6 +3,7 @@
 clojure -X sieve/run :variant :bitset :warm-up? false
 clojure -X sieve/run :variant :bitset-pre :warm-up? false
 clojure -X sieve/run :variant :boolean-array :warm-up? false
+clojure -X sieve/run :variant :boolean-array-skip-evens :warm-up? true
 clojure -X sieve/run :variant :boolean-array-pre :warm-up? true
 clojure -X sieve/run :variant :boolean-array-pre-futures :warm-up? true
 clojure -X sieve/run :variant :boolean-array-to-vector-futures :warm-up? true

--- a/PrimeClojure/solution_3/sieve.clj
+++ b/PrimeClojure/solution_3/sieve.clj
@@ -8,7 +8,7 @@
 (set! *warn-on-reflection* true)
 (set! *unchecked-math* :warn-on-boxed)
 
-(defn sieve-ba-post-even-filter
+(defn sieve-ba-to-vector-even-filter-futures
   "boolean-array-storage
    Returns the primes.
    We gain some time by skipping every other number while iterating.
@@ -55,22 +55,43 @@
             (recur  (+ p 2))))))))
 
 (comment
-  (sieve-ba-post-even-filter 1)
+  (sieve-ba-to-vector-even-filter-futures 1)
   ;; => []
 
-  (sieve-ba-post-even-filter 10)
+  (sieve-ba-to-vector-even-filter-futures 10)
   ;; => [2 3 5 7]
 
-  (sieve-ba-post-even-filter 100)
+  (sieve-ba-to-vector-even-filter-futures 100)
   ;; You try it!
 
-  (with-progress-reporting (quick-bench (sieve-ba-post-even-filter 1000000)))
-  (quick-bench (sieve-ba-post-even-filter 1000000))
+  (with-progress-reporting (quick-bench (sieve-ba-to-vector-even-filter-futures 1000000)))
+  (quick-bench (sieve-ba-to-vector-even-filter-futures 1000000))
   ;; Execution time mean : 2.703046 ms
 
   ;; This one takes a lot of time, you have been warned
-  (with-progress-reporting (bench (sieve-ba-post-even-filter 1000000)))
+  (with-progress-reporting (bench (sieve-ba-to-vector-even-filter-futures 1000000)))
   )
+
+(defn sieve-ba
+  "boolean-array storage
+   Returns the raw sieve.
+   No parallelisation."
+  [^long n]
+  (if (< n 2)
+    (boolean-array n)
+    (let [primes (boolean-array n true)
+          sqrt-n (long (Math/ceil (Math/sqrt n)))]
+      (aset primes 0 false)
+      (aset primes 1 false)
+      (loop [p 2]
+        (if-not (< p sqrt-n)
+          primes
+          (do
+            (loop [i (* p p)]
+              (when (< i n)
+                (aset primes i false)
+                (recur (+ i p))))
+            (recur (inc p))))))))
 
 (defn sieve-ba-pre-even-filter
   "boolean-array storage
@@ -98,44 +119,109 @@
                 (recur (+ i p p))))
             (recur (+ p 2))))))))
 
+(defn sieve-ba-pre-even-filter-futures
+  "boolean-array storage
+   Returns the raw sieve.
+   Remove even indexes before sieving.
+   Same as `sieve-ba-pre-even-filter`,
+     except we parallelize the first step with futures"
+  [^long n]
+  (if (< n 2)
+    (boolean-array n)
+    (let [primes (boolean-array n true)
+          sqrt-n (long (Math/ceil (Math/sqrt n)))]
+      (let
+       [num-slices 8 ; I'm not sure what is a good default
+        num-slices (if (and (zero? ^long (mod n num-slices))
+                            (> n 1000))
+                     num-slices
+                     1)
+        slice-size (quot n num-slices)
+        futures (mapv (fn [^long slice-num]
+                        (future
+                          (let [start (* slice-num slice-size)
+                                end (dec (+ start slice-size))]
+                            (loop [i start]
+                              (when (< i end)
+                                (aset primes i false)
+                                (recur (+ i 2)))))))
+                      (range num-slices))]
+        (doseq [f futures]
+          (deref f)))
+      (aset primes 1 false)
+      (aset primes 2 true)
+      (loop [p 3]
+        (if-not (< p sqrt-n)
+          primes
+          (do
+            (loop [i (* p p)]
+              (when (< i n)
+                (aset primes i false)
+                (recur (+ i p p))))
+            (recur (+ p 2))))))))
+
 (comment
+  ;; Evaluate the sieve you want to play with
+  (def sieve sieve-ba)
+  (def sieve sieve-ba-pre-even-filter)
+  (def sieve sieve-ba-pre-even-filter-futures)
+
   ;; We get the raw sieve back, a Java boolean array
-  (sieve-ba-pre-even-filter 1)
+  (sieve 1)
   ;; => #object ["[Z" 0x816eab0 "[Z@816eab0"]
 
   ;; Most often you can treat it as a Clojure sequence/collection
-  (first (sieve-ba-pre-even-filter 1))
+  (first (sieve 1))
   ;; => false
 
-  (nth (sieve-ba-pre-even-filter 3) 2)
+  (nth (sieve 3) 2)
   ;; => true
 
   ;; Evaluate this one to use for emptying/looting the raw sieve
   (defn loot [raw-sieve]
     (keep-indexed (fn [i v] (when v i)) raw-sieve))
 
-  (loot (sieve-ba-pre-even-filter 1))
+  (loot (sieve 1))
   ;; => ()
 
-  (loot (sieve-ba-pre-even-filter 10))
+  (loot (sieve 10))
   ;; => (2 3 5 7)
 
   (-> 1000000
-      sieve-ba-pre-even-filter
+      sieve
       loot 
       count)
   ;; => 78498
 
-  (loot (sieve-ba-pre-even-filter 100))
+  (loot (sieve 100))
   ;; You try it!
 
-  (with-progress-reporting (quick-bench (sieve-ba-pre-even-filter 1000000)))
-  (quick-bench (sieve-ba-pre-even-filter 1000000))
+  (with-progress-reporting (quick-bench (sieve 1000000)))
+  (quick-bench (sieve 1000000))
   ;; Execution time mean : 1.563407 ms
 
   ;; This one takes a lot of time, you have been warned
-  (with-progress-reporting (bench (sieve-ba-pre-even-filter 1000000)))
+  (with-progress-reporting (bench (sieve 1000000)))
   )
+
+(defn sieve-bs
+  "BitSet storage.
+   Returns the raw sieve.
+   No parallelisation."
+  [^long n]
+  (if (< n 2)
+    (java.util.BitSet. n)
+    (let [primes (doto (java.util.BitSet. n) (.set 2 n))
+          sqrt-n (long (Math/ceil (Math/sqrt n)))]
+      (loop [p 2]
+        (if-not (< p sqrt-n)
+          primes
+          (do
+            (loop [i (* p p)]
+              (when (< i n)
+                (.clear primes i)
+                (recur (+ i p))))
+            (recur (inc p))))))))
 
 (defn sieve-bs-pre-even-filter
   "BitSet storage.
@@ -145,10 +231,10 @@
   [^long n]
   (if (< n 2)
     (java.util.BitSet. n)
-    (let [primes (doto (java.util.BitSet. n) (.set 2 (inc n)))
+    (let [primes (doto (java.util.BitSet. n) (.set 2 n))
           sqrt-n (long (Math/ceil (Math/sqrt n)))]
       (loop [i 4]
-        (when (<= i n)
+        (when (< i n)
           (.clear primes i)
           (recur (+ i 2))))
       (loop [p 3]
@@ -156,31 +242,35 @@
           primes
           (do
             (loop [i (* p p)]
-              (when (<= i n)
+              (when (< i n)
                 (.clear primes i)
                 (recur (+ i p p))))
             (recur (+ p 2))))))))
 
 (comment
+  ;; Choose wisely
+  (def sieve sieve-bs)
+  (def sieve sieve-bs-pre-even-filter)
+
   ;; We get the raw sieve back, a Java BitSet
-  (sieve-bs-pre-even-filter 1)
+  (sieve-bs 1)
   ;; => #object [java.util.BitSet 0x222b4705 "{}"]
 
-  (sieve-bs-pre-even-filter 10)
+  (sieve-bs 10)
   ;; => #object [java.util.BitSet 0x5793c7ae "{2, 3, 5, 7}"]
 
-  (.cardinality (sieve-bs-pre-even-filter 1000000))
+  (.cardinality (sieve-bs 1000000))
   ;; => 78498
 
-  (sieve-bs-pre-even-filter 100)
+  (sieve-bs 100)
   ;; You try it!
 
-  (with-progress-reporting (quick-bench (sieve-bs-pre-even-filter 1000000)))
-  (quick-bench (sieve-bs-pre-even-filter 1000000))
+  (with-progress-reporting (quick-bench (sieve-bs 1000000)))
+  (quick-bench (sieve-bs 1000000))
   ;; Execution time mean : 5.173709 ms
 
   ;; This one takes a lot of time, you have been warned
-  (with-progress-reporting (bench (sieve-bs-pre-even-filter 1000000)))
+  (with-progress-reporting (bench (sieve-bs 1000000)))
   )
 
 (def prev-results
@@ -238,33 +328,48 @@
          "pez-clj-" (name variant) ";" passes ";" timef ";" threads ";algorithm=base,faithful=yes,bits=" bits)))
 
 (def confs
-  {:boolean-array-futures {:sieve sieve-ba-post-even-filter
-                           :count-f count
-                           :threads 8
-                           :bits 8}
-   :boolean-array {:sieve sieve-ba-pre-even-filter
+  {:bitset {:sieve sieve-bs
+            :count-f (fn [primes] (.cardinality primes))
+            :threads 1
+            :bits 1}
+   :bitset-pre {:sieve sieve-bs-pre-even-filter
+                :count-f (fn [primes] (.cardinality primes))
+                :threads 1
+                :bits 1}
+   :boolean-array {:sieve sieve-ba
                    :count-f (fn [primes] (count (filter true? primes)))
                    :threads 1
                    :bits 8}
-   :bitset {:sieve sieve-bs-pre-even-filter
-            :count-f (fn [primes] (.cardinality primes))
-            :threads 1
-            :bits 1}})
+   :boolean-array-pre {:sieve sieve-ba-pre-even-filter
+                       :count-f (fn [primes] (count (filter true? primes)))
+                       :threads 1
+                       :bits 8}
+   :boolean-array-pre-futures {:sieve sieve-ba-pre-even-filter-futures
+                               :count-f (fn [primes] (count (filter true? primes)))
+                               :threads 8
+                               :bits 8}
+   :boolean-array-to-vector-futures {:sieve sieve-ba-to-vector-even-filter-futures
+                                     :count-f count
+                                     :threads 8
+                                     :bits 8}})
 
 (defn run [{:keys [variant warm-up?]
-            :or   {variant :boolean-array
+            :or   {variant :boolean-array-pre-futures
                    warm-up? false}}]
   (let [conf (confs variant)
         sieve (:sieve conf)
         count-f (:count-f conf)]
     (when warm-up?
-    ;; Warm-up reduces the variability of results.
+      ;; Warm-up reduces the variability of results.
       (format-results (merge conf (benchmark sieve count-f) {:variant variant})))
     (println (format-results (merge conf (benchmark sieve count-f) {:variant variant})))))
 
 (comment
   (run {:warm-up? false})
-  (run {:variant :boolean-array-futures :warm-up? false})
+  (run {:variant :boolean-array-pre-futures :warm-up? false})
+  (run {:variant :boolean-array-pre :warm-up? false})
+  (run {:variant :boolean-array-to-vector-futures :warm-up? false})
+  (run {:variant :boolean-array :warm-up? false})
   (run {:variant :bitset :warm-up? false})
   (run {:warm-up? true})
   )


### PR DESCRIPTION
## Description

* Add a parallelized pre-even-filter for the boolean array sieve
* Also add two basecases , one for the BitSet variant and one for the boolean array, where the sieve visits all bits/indexes.

Rationale here is to demonstrate/uncover some possible tradeoffs for the curious Clojure programmer.

I'm also adding a variant where the primes array returned is half the size and the all indexes except 0 represent the odd numbers. Allowing me to skip the filtering away of even numbers that the other variants do in some different ways.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
