### PR TITLE
Improve performance of Clojure solution_2

### DIFF
--- a/PrimeClojure/solution_2/Dockerfile
+++ b/PrimeClojure/solution_2/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure:openjdk-17-tools-deps-alpine
+FROM clojure:openjdk-18-tools-deps-alpine
 WORKDIR /primes
 COPY deps.edn sieve_1_bit.clj sieve_8_bit.clj run.sh ./
 ENTRYPOINT ["./run.sh"]

--- a/PrimeClojure/solution_2/run.sh
+++ b/PrimeClojure/solution_2/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-clojure -X sieve-8-bit/run :warm-up? true
+clojure -X sieve-8-bit/run
 clojure -X sieve-1-bit/run

--- a/PrimeClojure/solution_2/sieve_1_bit.clj
+++ b/PrimeClojure/solution_2/sieve_1_bit.clj
@@ -2,8 +2,7 @@
   "Clojure implementation of Sieve of Eratosthenes by Alex Vear (axvr)
 
   This implementation is fast and faithful to Dave's original implementation,
-  is half the speed of the 8-bit version as it uses a 1-bit data structure
-  instead."
+  when run on Linux it is slower than my 8-bit version (for some reason)."
   (:import [java.time Instant Duration]
            java.util.BitSet))
 
@@ -14,40 +13,53 @@
 (set! *unchecked-math* :warn-on-boxed)
 
 
-;; This macro exists to improve readability of the `sieve` function.  It's
-;; a macro rather than a function to improve performance.
-(defmacro doubl
-  "Efficiently double a number."
-  [n]
-  `(bit-shift-left ~n 1))
+(defmacro << [n shift]
+   `(bit-shift-left ~n ~shift))
 
 
-;; This macro exists to improve readability of the `sieve` function.  It's
-;; a macro rather than a function to improve performance.
-(defmacro halve
-  "Efficiently halve a number."
-  [n]
-  `(bit-shift-right ~n 1))
+(defmacro >> [n shift]
+  `(unsigned-bit-shift-right ~n ~shift))
 
 
-(defn sieve [^long limit]
-  (let [q (inc (Math/sqrt limit))
-        sieve (BitSet.)]
-    ;; Highly optimised Sieve of Eratosthenes algorithm.
-    (loop [factor 3]
+;; NOTE: may not make a difference.
+(defmacro sqr [n]
+  `(unchecked-multiply-int ~n ~n))
+
+
+(defn sieve
+  "This returns a java.util.BitSet object where the index of each true bit is
+  the prime number (+ 1 (* 2 index)).  Despite this being unidiomatic, the
+  result of this function can be used by the benchmark without needing to
+  convert it into a proper list of primes. [1]
+
+  [1]: <https://github.com/PlummersSoftwareLLC/Primes/discussions/794>"
+  [^long limit]
+  (let [q (inc (int (Math/sqrt limit)))
+        sieve (BitSet. (>> limit 1))]
+    (loop [factor (int 3)]
       (when (< factor q)
-        (if-not (.get sieve (halve factor))
-          (let [factor*2 (doubl factor)]
-            (loop [num (* factor factor)]
-              (when (<= num limit)
-                (.set sieve (halve num) true)
-                (recur (+ num factor*2))))))
+        (when-not (.get sieve (>> factor 1))
+          (let [factor*2 (<< factor 1)]
+            (loop [num (sqr factor)]
+              (when (< num limit)
+                (.set sieve (>> num 1))
+                (recur (+ factor*2 num))))))
         (recur (+ 2 factor))))
-    ;; Return sequence of found prime numbers.
-    (cons 2 (->> (range 3 limit 2)
-                 (map (fn [^long n]
-                        (if-not (.get sieve (halve n)) n)))
-                 (filter some?)))))
+    (.flip sieve 0 (.length sieve))
+    sieve))
+
+
+(defn sieve->primes
+  "Function to convert the sieve output to a usable/printable list of primes."
+  [^BitSet sieve]
+  (let [out (transient [2])
+        size (.length sieve)]
+    (loop [idx (int 1)]
+      (when (pos? idx)
+        (when (.get sieve idx)
+          (conj! out (inc (<< idx 1))))
+        (recur (.nextSetBit sieve (inc idx)))))
+    (persistent! out)))
 
 
 (def prev-results
@@ -67,21 +79,22 @@
 (defn benchmark
   "Benchmark Sieve of Eratosthenes algorithm."
   []
-  (let [limit       1000000
-        start-time  (Instant/now)
-        end-by      (+ (.toEpochMilli start-time) 5000)]
+  (let [limit      1000000
+        start-time (Instant/now)
+        end-by     (+ (.toEpochMilli start-time) 5000)]
     (loop [pass 1]
-      (let [primes   (sieve limit)
-            cur-time (System/currentTimeMillis)]
+      (let [^BitSet sieve (sieve limit)
+            cur-time      (System/currentTimeMillis)]
         (if (<= cur-time end-by)
           (recur (inc pass))
           ;; Return benchmark report.
-          {:primes primes
-           :passes pass
-           :limit  limit
-           :time   (Duration/between start-time (Instant/now))
-           :valid? (= (count primes)
-                      (prev-results limit))})))))
+          (let [finished-at (Instant/now)]
+            {:primes (sieve->primes sieve)  ; Construct a printable version of sieve result.
+             :passes pass
+             :limit  limit
+             :time   (Duration/between start-time finished-at)
+             :count  (.cardinality sieve)
+             :valid? (= (.cardinality sieve) (prev-results limit))}))))))
 
 
 ;; Reenable overflow checks on mathematical ops and turn off warnings.
@@ -91,22 +104,19 @@
 
 (defn format-results
   "Format benchmark results into expected output."
-  [{:keys [primes passes limit time valid?]}]
-  (let [nanos (.toString (.toNanos time))
+  [{:keys [primes passes valid?] :as result}]
+  (let [nanos (.toString (.toNanos (:time result)))
         timef (str (subs nanos 0 1) "." (subs nanos 1))]
     (str "Passes: " passes ", "
          "Time: " timef ", "
-         "Avg: " (float (/ (/ (.toNanos time) 1000000000) passes)) ", "
-         "Limit: " limit ", "
-         "Count: " (count primes) ", "
+         "Avg: " (float (/ (/ (.toNanos (:time result)) 1000000000) passes)) ", "
+         "Limit: " (:limit result) ", "
+         "Count: " (:count result) ", "
          "Valid: " (if valid? "True" "False")
          "\n"
-         "axvr_clj-sln-2_1-bit;" passes ";" timef ";1;algorithm=base,faithful=yes,bits=1")))
+         "axvr_clj_1-bit;" passes ";" timef ";1;algorithm=base,faithful=yes,bits=1")))
 
 
-(defn run [{:keys [warm-up?]
-            :or   {warm-up? false}}]
-  (when warm-up?
-    ;; Warm-up reduces the variability of results.
-    (format-results (benchmark)))
-  (println (format-results (benchmark))))
+(defn run [& _]
+  (println (format-results (benchmark)))
+  (flush))

--- a/PrimeClojure/solution_3/README.md
+++ b/PrimeClojure/solution_3/README.md
@@ -23,7 +23,7 @@ In summary: There are two storages represented, BitSet and boolean array. For bo
 
 ## Run instructions
 
-The runner infrastructure is built from Alex Vaer's [Clojure Solution 2](https://github.com/PlummersSoftwareLLC/Primes/tree/drag-race/PrimeClojure/solution_2).
+The runner infrastructure is built from Alex Vear's [Clojure Solution 2](https://github.com/PlummersSoftwareLLC/Primes/tree/drag-race/PrimeClojure/solution_2).
 
 1. Install a JDK.
 2. Install the [Clojure CLI tools](https://clojure.org/guides/getting_started#_clojure_installer_and_cli_tools).


### PR DESCRIPTION
## Description

- Performance improvements to Clojure solution_2.
  - The 1-bit solution is now quite a bit faster in my testing, and the 8-bit solution is about the same as before.
- Warm-up is no longer needed.
- Changed the return value: rather than returning a lazy sequence, the sieve functions now return the internal sieve data structure as [allowed by the rules](https://github.com/PlummersSoftwareLLC/Primes/discussions/794).
   - As is noted in the code, this return value is non-idiomatic in Clojure, so I added a function to convert the sieve result into a vector of prime numbers (which is also faster than the lazy-sequence used in the previous implementation).
- Benchmark finish time is now recorded immediately upon finish, making the reported run time slightly closer to 5 seconds.
- Use OpenJDK 18.


## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
