### PR TITLE
Housekeeping: Rust solution_1 updates

### DIFF
--- a/PrimeRust/solution_1/Dockerfile
+++ b/PrimeRust/solution_1/Dockerfile
@@ -10,7 +10,7 @@
 # cargo to load the package index from crates.io.
 # This allows it to be cached as part of the build
 # layer, saving a lot of time on repeated builds.
-FROM rust:1.54 AS build
+FROM rust:1.57 AS build
 RUN cargo search num_cpus -q --limit 1
 
 WORKDIR /app

--- a/PrimeRust/solution_1/prime-sieve-rust/Cargo.toml
+++ b/PrimeRust/solution_1/prime-sieve-rust/Cargo.toml
@@ -2,7 +2,7 @@
 name = "prime-sieve-rust"
 version = "0.1.0"
 authors = ["Michael Barber <60610888+mike-barber@users.noreply.github.com>"]
-edition = "2018"
+edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/PrimeRust/solution_1/prime-sieve-rust/src/unrolled.rs
+++ b/PrimeRust/solution_1/prime-sieve-rust/src/unrolled.rs
@@ -92,7 +92,7 @@ fn reinterpret_slice_mut_u64_u8(words: &mut [u64]) -> &mut [u8] {
 /// approach combined with the elements of the dense-resetting approach in my `bit-storage-striped-hybrid`
 /// solution.
 pub struct FlagStorageUnrolledHybrid {
-    words: Vec<u64>,
+    words: Box<[u64]>,
     length_bits: usize,
 }
 
@@ -100,7 +100,7 @@ impl FlagStorage for FlagStorageUnrolledHybrid {
     fn create_true(size: usize) -> Self {
         let num_words = size / 64 + (size % 64).min(1);
         Self {
-            words: vec![0; num_words],
+            words: vec![0; num_words].into_boxed_slice(),
             length_bits: size,
         }
     }

--- a/PrimeRust/solution_1/prime-sieve-rust/src/unrolled.rs
+++ b/PrimeRust/solution_1/prime-sieve-rust/src/unrolled.rs
@@ -118,10 +118,10 @@ impl FlagStorage for FlagStorageUnrolledHybrid {
     /// ```ignore
     /// // dense reset
     /// match skip {
-    ///     3 => ResetterDenseU64::<3>::reset_dense(&mut self.words),
-    ///     5 => ResetterDenseU64::<5>::reset_dense(&mut self.words),
+    ///     3 => ResetterDenseU64::<3>::reset_dense(self.words.as_mut()),
+    ///     5 => ResetterDenseU64::<5>::reset_dense(self.words.as_mut()),
     ///     //... etc
-    ///     129 => ResetterDenseU64::<129>::reset_dense(&mut self.words),
+    ///     129 => ResetterDenseU64::<129>::reset_dense(self.words.as_mut()),
     ///     _ => debug_assert!(false, "this case should not occur"),
     ///  },
     /// ```
@@ -135,7 +135,7 @@ impl FlagStorage for FlagStorageUnrolledHybrid {
                 3,
                 2,
                 17,
-                ResetterSparseU8::<N>::reset_sparse(&mut self.words, skip),
+                ResetterSparseU8::<N>::reset_sparse(self.words.as_mut(), skip),
                 debug_assert!(
                     false,
                     "this case should not occur skip {} equivalent {}",
@@ -151,7 +151,7 @@ impl FlagStorage for FlagStorageUnrolledHybrid {
             3,
             2,
             129, // 64 unique sets
-            ResetterDenseU64::<N>::reset_dense(&mut self.words),
+            ResetterDenseU64::<N>::reset_dense(self.words.as_mut()),
             debug_assert!(
                 false,
                 "dense reset function should not be called for skip {}",

--- a/PrimeRust/solution_1/prime-sieve-rust/src/unrolled_extreme.rs
+++ b/PrimeRust/solution_1/prime-sieve-rust/src/unrolled_extreme.rs
@@ -13,7 +13,7 @@ use crate::{
 /// Performance, as a result, is very similar. This method has a slight edge over the const-generics, and is
 /// primarily included to demonstrate how this approach can be used in Rust.
 pub struct FlagStorageExtremeHybrid {
-    words: Vec<u64>,
+    words: Box<[u64]>,
     length_bits: usize,
 }
 
@@ -21,7 +21,7 @@ impl FlagStorage for FlagStorageExtremeHybrid {
     fn create_true(size: usize) -> Self {
         let num_words = size / 64 + (size % 64).min(1);
         Self {
-            words: vec![0; num_words],
+            words: vec![0; num_words].into_boxed_slice(),
             length_bits: size,
         }
     }

--- a/PrimeRust/solution_1/prime-sieve-rust/src/unrolled_extreme.rs
+++ b/PrimeRust/solution_1/prime-sieve-rust/src/unrolled_extreme.rs
@@ -40,7 +40,7 @@ impl FlagStorage for FlagStorageExtremeHybrid {
                 3,
                 2,
                 17,
-                ResetterSparseU8::<N>::reset_sparse(&mut self.words, skip),
+                ResetterSparseU8::<N>::reset_sparse(self.words.as_mut(), skip),
                 debug_assert!(
                     false,
                     "this case should not occur skip {} equivalent {}",
@@ -51,7 +51,7 @@ impl FlagStorage for FlagStorageExtremeHybrid {
         }
 
         // dense resets for all odd numbers in {3, 5, ... =129}
-        let words = &mut self.words[..];
+        let words = self.words.as_mut();
         extreme_reset!(skip);
     }
 


### PR DESCRIPTION
## Description

A little bit of housekeeping and updates. Rust Edition 2021 has been released now, and the compiler has been updated to use LLVM 13. Performance looks about the same, or perhaps a hair better. 

Changes in this PR:
- using latest Rust 1.57 for build in the Dockerfile (which includes LLVM 13)
- project uses `edition = "2021"` 
- slice/vector cleanup -- it's probably a tiny bit more efficient storing values in a boxed slice than a vector, and we don't need to change the size once it's created.

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
