### PR TITLE
Disable parallel implementations in Dart/solution_1

### DIFF
--- a/PrimeDart/solution_1/Dockerfile
+++ b/PrimeDart/solution_1/Dockerfile
@@ -15,4 +15,7 @@ WORKDIR /app
 COPY --from=build /runtime/ /
 COPY --from=build /app/Runner /app/PrimeDart* ./
 
-ENTRYPOINT [ "./Runner", "./PrimeDart", "./PrimeDartParallel", "./PrimeDartOneBit", "./PrimeDartParallelOneBit" ]
+# Parallel implementations were removed because they cause a hang on the 5950X runner that's in use on the project. 
+# They can be reinstated once that issue has been resolved. Original line was:
+# ENTRYPOINT [ "./Runner", "./PrimeDart", "./PrimeDartParallel", "./PrimeDartOneBit", "./PrimeDartParallelOneBit" ]
+ENTRYPOINT [ "./Runner", "./PrimeDart", "./PrimeDartOneBit" ]


### PR DESCRIPTION
This fixes #809. This change can be reverted once the hang in the parallelized implementation has been solved.