### PR TITLE
Clojure solution_3 - Use jdk-17

### DIFF
--- a/PrimeClojure/solution_3/.gitignore
+++ b/PrimeClojure/solution_3/.gitignore
@@ -1,2 +1,3 @@
 .cpcache/
 .nrepl-port
+.calva/output-window/

--- a/PrimeClojure/solution_3/Dockerfile
+++ b/PrimeClojure/solution_3/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure:openjdk-18-tools-deps-1.10.3.1040
+FROM clojure:openjdk-17-tools-deps
 WORKDIR /primes
 COPY deps.edn sieve.clj run.sh ./
 ENTRYPOINT ["./run.sh"]


### PR DESCRIPTION
## Description

There is some issue with how JDK18 treats this solution on the drag-racing machines. I'm not done with the investigation about what this could be about, but as an immediate measure I am switching out JDK18 for JDK17, which on my Ryzen-equipped test machine fixes the problem.

See https://twitter.com/pappapez/status/1487432005721763850?s=20&t=HnKdR7j2jtXgRbyx1eHWbg 

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
