### PR TITLE
Clojure solution 3 help the Clojure compiler better

### DIFF
--- a/PrimeClojure/solution_3/Dockerfile
+++ b/PrimeClojure/solution_3/Dockerfile
@@ -1,4 +1,4 @@
-FROM clojure:openjdk-17-tools-deps
+FROM clojure:openjdk-18-tools-deps
 WORKDIR /primes
 COPY deps.edn sieve.clj run.sh ./
 ENTRYPOINT ["./run.sh"]

--- a/PrimeClojure/solution_3/run.sh
+++ b/PrimeClojure/solution_3/run.sh
@@ -1,12 +1,18 @@
-#!/bin/sh
+#!/bin/bash
 
-clojure -X sieve/run :variant :vector :warm-up? false
-clojure -X sieve/run :variant :vector-transient :warm-up? false
-clojure -X sieve/run :variant :bitset :warm-up? true
-#clojure -X sieve/run :variant :bitset-all :warm-up? false
-#clojure -X sieve/run :variant :bitset-pre :warm-up? false
-clojure -X sieve/run :variant :boolean-array :warm-up? true
-#clojure -X sieve/run :variant :boolean-array-all :warm-up? false
-#clojure -X sieve/run :variant :boolean-array-pre :warm-up? false
-#clojure -X sieve/run :variant :boolean-array-pre-futures :warm-up? false
-#clojure -X sieve/run :variant :boolean-array-to-vector-futures :warm-up? false
+RUNS=$(if [ -z "$1" ]; then echo 1; else echo $1; fi)
+for ((i=0;i<${RUNS};i++))
+do
+  echo $i
+  #clojure -X sieve/run :variant :vector :warm-up? false
+  #clojure -X sieve/run :variant :vector-transient :warm-up? false
+  clojure -X sieve/run :variant :bitset :warm-up? true
+  #clojure -X sieve/run :variant :bitset-all :warm-up? false
+  #clojure -X sieve/run :variant :bitset-pre :warm-up? false
+  clojure -X sieve/run :variant :boolean-array :warm-up? true
+  sleep 20
+  #clojure -X sieve/run :variant :boolean-array-all :warm-up? false
+  #clojure -X sieve/run :variant :boolean-array-pre :warm-up? false
+  #clojure -X sieve/run :variant :boolean-array-pre-futures :warm-up? false
+  #clojure -X sieve/run :variant :boolean-array-to-vector-futures :warm-up? false
+done

--- a/PrimeClojure/solution_3/run.sh
+++ b/PrimeClojure/solution_3/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-RUNS=$(if [ -z "$1" ]; then echo 1; else echo $1; fi)
+RUNS=$(if [ -z "$1" ]; then echo 5; else echo $1; fi)
 for ((i=0;i<${RUNS};i++))
 do
   echo $i
@@ -10,7 +10,6 @@ do
   #clojure -X sieve/run :variant :bitset-all :warm-up? false
   #clojure -X sieve/run :variant :bitset-pre :warm-up? false
   clojure -X sieve/run :variant :boolean-array :warm-up? true
-  sleep 20
   #clojure -X sieve/run :variant :boolean-array-all :warm-up? false
   #clojure -X sieve/run :variant :boolean-array-pre :warm-up? false
   #clojure -X sieve/run :variant :boolean-array-pre-futures :warm-up? false

--- a/PrimeClojure/solution_3/run.sh
+++ b/PrimeClojure/solution_3/run.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 
-RUNS=$(if [ -z "$1" ]; then echo 5; else echo $1; fi)
+RUNS=$(if [ -z "$1" ]; then echo 1; else echo $1; fi)
 for ((i=0;i<${RUNS};i++))
 do
-  echo $i
-  #clojure -X sieve/run :variant :vector :warm-up? false
-  #clojure -X sieve/run :variant :vector-transient :warm-up? false
+  #echo $i
+  clojure -X sieve/run :variant :vector :warm-up? false
+  clojure -X sieve/run :variant :vector-transient :warm-up? false
   clojure -X sieve/run :variant :bitset :warm-up? true
   #clojure -X sieve/run :variant :bitset-all :warm-up? false
   #clojure -X sieve/run :variant :bitset-pre :warm-up? false

--- a/PrimeClojure/solution_3/sieve.clj
+++ b/PrimeClojure/solution_3/sieve.clj
@@ -61,29 +61,28 @@
   (time (count (loot (sieve 1000000))))
   (with-progress-reporting (quick-bench (sieve 1000000))))
 
-(defmacro sqr [n]
-  `(let [n# (unchecked-int ~n)] (unchecked-multiply-int n# n#)))
+(set! *unchecked-math* true)
 
 (defn sieve-ba
   "boolean-array storage
-   Returns the raw sieve with each index representing the odd numbers * 2
-   Skips even indexes.
-   No parallelisation."
+   Returns the raw sieve with only odd numbers present."
   [^long n]
   (if (< n 2)
-    (boolean-array n)
-    (let [half-n (int (bit-shift-right n 1))
+    (boolean-array 0)
+    (let [half-n (bit-shift-right n 1)
           primes (boolean-array half-n true)
-          sqrt-n (long (Math/ceil (Math/sqrt (double n))))]
-      (loop [p (int 3)]
+          sqrt-n (unchecked-long (Math/ceil (Math/sqrt (double n))))]
+      (loop [p 3]
         (when (< p sqrt-n)
-          (when (aget primes (bit-shift-right p 1))
-            (loop [i (bit-shift-right (sqr p) 1)]
+          (when (aget primes (bit-shift-right p (unchecked-int 1)))
+            (loop [i (bit-shift-right (unchecked-multiply p p) 1)]
               (when (< i half-n)
-                (aset primes i false)
-                (recur (unchecked-add-int i p)))))
-          (recur (unchecked-add-int p 2))))
+                (aset primes (unchecked-int i) false)
+                (recur (unchecked-add i p)))))
+          (recur (unchecked-add p 2))))
       primes)))
+
+(set! *unchecked-math* :warn-on-boxed)
 
 (comment
   (defn loot [raw-sieve]
@@ -109,18 +108,18 @@
    No parallelisation."
   [^long n]
   (if (< n 2)
-    (java.util.BitSet. (/ n 2))
+    (java.util.BitSet. 0)
     (let [half-n (int (bit-shift-right n 1))
           primes (doto (java.util.BitSet. n) (.set 0 half-n))
           sqrt-n (long (Math/ceil (Math/sqrt (double n))))]
-      (loop [p (int 3)]
+      (loop [p 3]
         (when (< p sqrt-n)
           (when (.get primes (bit-shift-right p 1))
-            (loop [i (bit-shift-right (sqr p) 1)]
+            (loop [i (bit-shift-right (unchecked-multiply p p) 1)]
               (when (< i half-n)
                 (.clear primes i)
-                (recur (unchecked-add-int i p)))))
-          (recur (unchecked-add-int p 2))))
+                (recur (unchecked-add i p)))))
+          (recur (unchecked-add p 2))))
       primes)))
 
 (comment

--- a/PrimeClojure/solution_3/sieve.clj
+++ b/PrimeClojure/solution_3/sieve.clj
@@ -103,9 +103,7 @@
 
 (defn sieve-bs
   "Java BitSet storage
-   Returns the raw sieve with each index representing the odd numbers * 2
-   Skips even indexes.
-   No parallelisation."
+   Returns the raw sieve with only odd numbers present."
   [^long n]
   (if (< n 2)
     (java.util.BitSet. 0)
@@ -114,12 +112,12 @@
           sqrt-n (long (Math/ceil (Math/sqrt (double n))))]
       (loop [p 3]
         (when (< p sqrt-n)
-          (when (.get primes (bit-shift-right p 1))
+          (when (.get primes (unchecked-int (bit-shift-right p (unchecked-int 1))))
             (loop [i (bit-shift-right (unchecked-multiply p p) 1)]
               (when (< i half-n)
-                (.clear primes i)
-                (recur (unchecked-add i p)))))
-          (recur (unchecked-add p 2))))
+                (.clear primes (unchecked-int i))
+                (recur (unchecked-add-int i p)))))
+          (recur (unchecked-add-int p 2))))
       primes)))
 
 (comment


### PR DESCRIPTION
## Description

Using clj-java-decompiler I have been able to find some more places where I can help the Clojure compiler produce code that avoids using the Clojure runtime where the sieve does not need it.

I've also somehow (unclear to me how) gotten the code to run as fast on JVM18 as it does on JVM17, so switching back to that again in the docker image.

## Contributing requirements
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
