### PR TITLE
Clojure solution 3 optimize 8-bit solution some

### DIFF
--- a/PrimeClojure/solution_3/.gitignore
+++ b/PrimeClojure/solution_3/.gitignore
@@ -1,3 +1,8 @@
 .cpcache/
 .nrepl-port
 .calva/output-window/
+*.class
+classes/
+.lsp/.cache/
+.clj-condo/.cache/
+decompiled*.java

--- a/PrimeClojure/solution_3/run.sh
+++ b/PrimeClojure/solution_3/run.sh
@@ -7,6 +7,7 @@ do
   clojure -X sieve/run :variant :vector :warm-up? false
   clojure -X sieve/run :variant :vector-transient :warm-up? false
   clojure -X sieve/run :variant :bitset :warm-up? true
+  #clojure -X sieve/run :variant :bitset-shroedinger :warm-up? true
   #clojure -X sieve/run :variant :bitset-all :warm-up? false
   #clojure -X sieve/run :variant :bitset-pre :warm-up? false
   clojure -X sieve/run :variant :boolean-array :warm-up? true

--- a/PrimeClojure/solution_3/sieve.clj
+++ b/PrimeClojure/solution_3/sieve.clj
@@ -64,7 +64,7 @@
 (set! *unchecked-math* true)
 
 (defn sieve-ba
-  "boolean-array storage
+  "Java boolean array storage
    Returns the raw sieve with only odd numbers present."
   [^long n]
   (if (< n 2)
@@ -74,12 +74,12 @@
           primes (boolean-array half-n)]
       (loop [p 3]
         (when (< p sqrt-n)
-          (when-not (aget primes (bit-shift-right p (unchecked-int 1)))
-            (loop [i (bit-shift-right (unchecked-multiply p p) 1)]
+          (when-not (aget primes (bit-shift-right p 1))
+            (loop [i (long (bit-shift-right (* p p) 1))]
               (when (< i half-n)
-                (aset primes (unchecked-int i) true)
-                (recur (unchecked-add i p)))))
-          (recur (unchecked-add p 2))))
+                (aset primes i true)
+                (recur (+ i p)))))
+          (recur (+ p 2))))
       primes)))
 
 (comment

--- a/PrimeClojure/solution_3/sieve.clj
+++ b/PrimeClojure/solution_3/sieve.clj
@@ -69,15 +69,15 @@
   [^long n]
   (if (< n 2)
     (boolean-array 0)
-    (let [half-n (bit-shift-right n 1)
-          primes (boolean-array half-n true)
+    (let [half-n (unchecked-int (bit-shift-right n 1))
+          primes (boolean-array half-n)
           sqrt-n (unchecked-long (Math/ceil (Math/sqrt (double n))))]
       (loop [p 3]
         (when (< p sqrt-n)
-          (when (aget primes (bit-shift-right p (unchecked-int 1)))
+          (when-not (aget primes (bit-shift-right p (unchecked-int 1)))
             (loop [i (bit-shift-right (unchecked-multiply p p) 1)]
               (when (< i half-n)
-                (aset primes (unchecked-int i) false)
+                (aset primes (unchecked-int i) true)
                 (recur (unchecked-add i p)))))
           (recur (unchecked-add p 2))))
       primes)))
@@ -87,9 +87,9 @@
 (comment
   (defn loot [raw-sieve]
     (keep-indexed (fn [i v]
-                    (when v (if (zero? i)
-                              2
-                              (inc (* i 2)))))
+                    (when-not v (if (zero? i)
+                                  2
+                                  (inc (* i 2)))))
                   raw-sieve))
   (loot (sieve-ba 1))
   (loot (sieve-ba 10))
@@ -485,7 +485,7 @@
                 :threads 1
                 :bits 1}
    :boolean-array {:sieve sieve-ba
-                   :count-f (fn [primes] (count (filter true? primes)))
+                   :count-f (fn [primes] (count (filter false? primes)))
                    :threads 1
                    :bits 8}
    :boolean-array-all {:sieve sieve-ba-all


### PR DESCRIPTION
## Description

* Flipping the true/false semantics of the boolean array variant to avoid filling it when it is created. This speeds it up some 10%.
* Also cleaned the boolean array variant up some to make for more readable Clojure code, without losing the help to the compiler. (clj-java-decompiler to the rescue).
* I've also added a version of the BitSet solution that runs faster on the machines I test it on. However, when run with Docker it runs at 0.5X it's max speed about 60% of the times. Super strange. **NB: This version of the function is not run in the drag-racing, just including it to be make it convenient for Clojure experts to clone and examine the mystery.


## Contributing requirements
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
