### PR TITLE
Bash/solution_1: improve integer square root

### DIFF
--- a/PrimeBash/solution_1/PrimeBash.sh
+++ b/PrimeBash/solution_1/PrimeBash.sh
@@ -23,12 +23,21 @@ declare -A bitArray=()
 readonly RUNTIME_SEC=5
 
 function sqrt {
-	local -n i=$1 # Output
-	i=1
-	while ((i**2<=$2)); do
-		((++i))
+	# integer square root using binary search (lilweege)
+	local -n ans=$1 # Output
+	ans=0
+	lo=1
+	hi=$2
+	mid=0
+	while ((lo<=hi)); do
+		((mid=(lo+hi)/2))
+		if [ $((mid*mid)) -le $2 ]; then
+			((lo=mid+1))
+			((ans=mid))
+		else
+			((hi=mid-1))
+		fi
 	done
-	((--i))
 }
 
 function initGlobals {

--- a/PrimeBash/solution_1/PrimeBash.sh
+++ b/PrimeBash/solution_1/PrimeBash.sh
@@ -31,7 +31,7 @@ function sqrt {
 	mid=0
 	while ((lo<=hi)); do
 		((mid=(lo+hi)/2))
-		if [ $((mid*mid)) -le $2 ]; then
+		if [[ $((mid*mid)) -le $2 ]]; then
 			((lo=mid+1))
 			((ans=mid))
 		else

--- a/PrimeBash/solution_1/PrimeBash.sh
+++ b/PrimeBash/solution_1/PrimeBash.sh
@@ -24,8 +24,7 @@ readonly RUNTIME_SEC=5
 
 function sqrt {
 	# integer square root using binary search (lilweege)
-	local -n ans=$1 # Output
-	ans=0
+	local -n lo=$1 # Output
 	lo=1
 	hi=$2
 	mid=0
@@ -33,11 +32,11 @@ function sqrt {
 		((mid=(lo+hi)/2))
 		if [[ $((mid*mid)) -le $2 ]]; then
 			((lo=mid+1))
-			((ans=mid))
 		else
 			((hi=mid-1))
 		fi
 	done
+	((--lo))
 }
 
 function initGlobals {

--- a/PrimeBash/solution_1/PrimeBashInline.sh
+++ b/PrimeBash/solution_1/PrimeBashInline.sh
@@ -23,12 +23,21 @@ declare -A bitArray=()
 readonly RUNTIME_SEC=5
 
 function sqrt {
-	local -n i=$1 # Output
-	i=1
-	while ((i**2<=$2)); do
-		((++i))
+	# integer square root using binary search (lilweege)
+	local -n ans=$1 # Output
+	ans=0
+	lo=1
+	hi=$2
+	mid=0
+	while ((lo<=hi)); do
+		((mid=(lo+hi)/2))
+		if [ $((mid*mid)) -le $2 ]; then
+			((lo=mid+1))
+			((ans=mid))
+		else
+			((hi=mid-1))
+		fi
 	done
-	((--i))
 }
 
 function initGlobals {

--- a/PrimeBash/solution_1/PrimeBashInline.sh
+++ b/PrimeBash/solution_1/PrimeBashInline.sh
@@ -31,7 +31,7 @@ function sqrt {
 	mid=0
 	while ((lo<=hi)); do
 		((mid=(lo+hi)/2))
-		if [ $((mid*mid)) -le $2 ]; then
+		if [[ $((mid*mid)) -le $2 ]]; then
 			((lo=mid+1))
 			((ans=mid))
 		else

--- a/PrimeBash/solution_1/PrimeBashInline.sh
+++ b/PrimeBash/solution_1/PrimeBashInline.sh
@@ -24,8 +24,7 @@ readonly RUNTIME_SEC=5
 
 function sqrt {
 	# integer square root using binary search (lilweege)
-	local -n ans=$1 # Output
-	ans=0
+	local -n lo=$1 # Output
 	lo=1
 	hi=$2
 	mid=0
@@ -33,11 +32,11 @@ function sqrt {
 		((mid=(lo+hi)/2))
 		if [[ $((mid*mid)) -le $2 ]]; then
 			((lo=mid+1))
-			((ans=mid))
 		else
 			((hi=mid-1))
 		fi
 	done
+	((--lo))
 }
 
 function initGlobals {

--- a/PrimeBash/solution_1/PrimeBashPacked.sh
+++ b/PrimeBash/solution_1/PrimeBashPacked.sh
@@ -23,12 +23,21 @@ declare -A bitArray=()
 readonly RUNTIME_SEC=5
 
 function sqrt {
-	local -n i=$1 # Output
-	i=1
-	while ((i**2<=$2)); do
-		((++i))
+	# integer square root using binary search (lilweege)
+	local -n ans=$1 # Output
+	ans=0
+	lo=1
+	hi=$2
+	mid=0
+	while ((lo<=hi)); do
+		((mid=(lo+hi)/2))
+		if [ $((mid*mid)) -le $2 ]; then
+			((lo=mid+1))
+			((ans=mid))
+		else
+			((hi=mid-1))
+		fi
 	done
-	((--i))
 }
 
 function initGlobals {

--- a/PrimeBash/solution_1/PrimeBashPacked.sh
+++ b/PrimeBash/solution_1/PrimeBashPacked.sh
@@ -31,7 +31,7 @@ function sqrt {
 	mid=0
 	while ((lo<=hi)); do
 		((mid=(lo+hi)/2))
-		if [ $((mid*mid)) -le $2 ]; then
+		if [[ $((mid*mid)) -le $2 ]]; then
 			((lo=mid+1))
 			((ans=mid))
 		else

--- a/PrimeBash/solution_1/PrimeBashPacked.sh
+++ b/PrimeBash/solution_1/PrimeBashPacked.sh
@@ -24,8 +24,7 @@ readonly RUNTIME_SEC=5
 
 function sqrt {
 	# integer square root using binary search (lilweege)
-	local -n ans=$1 # Output
-	ans=0
+	local -n lo=$1 # Output
 	lo=1
 	hi=$2
 	mid=0
@@ -33,11 +32,11 @@ function sqrt {
 		((mid=(lo+hi)/2))
 		if [[ $((mid*mid)) -le $2 ]]; then
 			((lo=mid+1))
-			((ans=mid))
 		else
 			((hi=mid-1))
 		fi
 	done
+	((--lo))
 }
 
 function initGlobals {


### PR DESCRIPTION
## Description
Replace brute force linear search square root function with binary search square root. Improves the complexity from n to lg(n). This is to make up for the fact that bash lacks a native math square root. In theory this is vastly superior to the brute force, in practice however there are other bottlenecks which only makes this improvement marginal (on my machine at least).


## Contributing requirements
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
