### PR TITLE
Ruby 3.1 implements a much faster yjit compiler we can take advantage of

### DIFF
--- a/PrimeRuby/solution_1/Dockerfile
+++ b/PrimeRuby/solution_1/Dockerfile
@@ -1,6 +1,6 @@
-FROM ruby:3.0-alpine3.13
+FROM ruby:3.1-alpine3.14
 
 WORKDIR /opt/app
 COPY *.rb .
 
-ENTRYPOINT [ "ruby", "prime.rb" ]
+ENTRYPOINT [ "ruby", "--jit", "prime.rb" ]


### PR DESCRIPTION
## Description
Switch to Ruby 3.1 so we can make use of the new YJIT compiler

## Contributing requirements
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.