### PR TITLE
Update Dockerfiles to use .NET 6.0

### DIFF
--- a/Prime6502Assembly/solution_1/Dockerfile
+++ b/Prime6502Assembly/solution_1/Dockerfile
@@ -8,7 +8,7 @@ RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-p
     apt-get update && \
     apt-get install -y apt-transport-https && \
     apt-get update && \
-    apt-get install -y aspnetcore-runtime-5.0 gawk grep unzip bash socat && \
+    apt-get install -y aspnetcore-runtime-6.0 gawk grep unzip bash socat && \
     rm -rf /var/lib/apt/lists/* && \
     wget https://enginedesigns.net/download/retroassembler.zip && \
     mkdir retroassembler && \

--- a/Prime6502Assembly/solution_2/Dockerfile
+++ b/Prime6502Assembly/solution_2/Dockerfile
@@ -8,7 +8,7 @@ RUN wget https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-p
     apt-get update && \
     apt-get install -y apt-transport-https && \
     apt-get update && \
-    apt-get install -y aspnetcore-runtime-5.0 gawk grep unzip bash socat && \
+    apt-get install -y aspnetcore-runtime-6.0 gawk grep unzip bash socat && \
     rm -rf /var/lib/apt/lists/* && \
     wget https://enginedesigns.net/download/retroassembler.zip && \
     mkdir retroassembler && \


### PR DESCRIPTION
This updates the Dockerfiles for the 6502Assembly solutions to install .NET 6.0 instead of .NET 5.0.
The reason for this is that an updated version of RetroAssembler was released that requires the 6.0 version to run.