### PR TITLE
fixed bun miliseconds bug

### DIFF
--- a/PrimeJavaScript/solution_1/Dockerfile
+++ b/PrimeJavaScript/solution_1/Dockerfile
@@ -1,6 +1,6 @@
 # use the image below as the preffered base image
 # see CONTRIBUTING.md
-FROM diefenbakerbell/ubuntu-bun:0.1.2
+FROM diefenbakerbell/ubuntu-bun:0.1.4
 
 WORKDIR /opt/app
 

--- a/PrimeJavaScript/solution_1/PrimeJavaScript.js
+++ b/PrimeJavaScript/solution_1/PrimeJavaScript.js
@@ -35,10 +35,7 @@ catch
 }
 
 
-// as of Bun 0.1.0, there's a bug that means performance.now() returns nanosecond instead of milliseconds
-const NOW_UNITS_PER_SECOND = runtime === "bun"
-	? 1000000000
-	: 1000;
+const NOW_UNITS_PER_SECOND = 1000;
 
 
 // Historical data for validating our results - the number of primes

--- a/PrimeJavaScript/solution_1/PrimeJavaScript_memcopy.js
+++ b/PrimeJavaScript/solution_1/PrimeJavaScript_memcopy.js
@@ -37,10 +37,7 @@ catch
 	verbose = process.argv.includes("verbose");
 }
 
-// as of Bun 0.1.0, there's a bug that means performance.now() returns nanosecond instead of milliseconds
-const NOW_UNITS_PER_SECOND = runtime === "bun"
-	? 1000000000
-	: 1000;
+const NOW_UNITS_PER_SECOND =  1000;
 
 // 32-bit bitArray for javascript, with only needed functions
 // int32, not uint and not 64bit because: javascript uses 32-bit int with bitwise operations

--- a/PrimeJavaScript/solution_1/PrimeJavaScript_worker_child.mjs
+++ b/PrimeJavaScript/solution_1/PrimeJavaScript_worker_child.mjs
@@ -26,12 +26,7 @@ catch
 	runtime = runtimeParts[runtimeParts.length - 1];
 }
 
-
-
-// as of Bun 0.1.0, there's a bug that means performance.now() returns nanosecond instead of milliseconds
-const NOW_UNITS_PER_SECOND = runtime === "bun"
-	? 1000000000
-	: 1000;
+const NOW_UNITS_PER_SECOND = 1000;
 
 // run the sieve for timeLimitSeconds
 const runSieveBatch = (sieveSize, timeLimitSeconds = 5) =>

--- a/PrimeJavaScript/solution_1/PrimeJavaScript_worker_main.mjs
+++ b/PrimeJavaScript/solution_1/PrimeJavaScript_worker_main.mjs
@@ -32,10 +32,7 @@ catch
     verbose = process.argv.includes("verbose");
 }
 
-// as of Bun 0.1.0, there's a bug that means performance.now() returns nanosecond instead of milliseconds
-const NOW_UNITS_PER_SECOND = runtime === "bun"
-    ? 1000000000
-    : 1000;
+const NOW_UNITS_PER_SECOND = 1000;
 
 // Historical data for validating our results - the number of primes
 // to be found under some limit, such as 168 primes under 1000


### PR DESCRIPTION
## Description
bun fixed the bug where `performance.now()` returned nanosecond instead of milliseconds, 
removing special bun case beacuse it made the benchmark run for 5,000 seconds 

- Tested on Bun 0.1.4  on Debian 11/WSL

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
