### PR TITLE
JavaScript/solution_1: Remove unnecessary pinned down versions

### DIFF
--- a/PrimeJavaScript/solution_1/Dockerfile
+++ b/PrimeJavaScript/solution_1/Dockerfile
@@ -7,15 +7,12 @@ WORKDIR /opt/app
 SHELL [ "/bin/bash", "-o", "pipefail", "-c" ]
 
 RUN apt-get update &&\
-    apt-get install --no-install-recommends -y \
+    apt-get install --no-install-recommends -y zip unzip \
         curl=7.81.0-1ubuntu1.3 \
-        zip=3.0-12build2 \
-        unzip=6.0-26ubuntu3 \
     &&\
     # NodeJS
     curl -fsSL https://deb.nodesource.com/setup_18.x | bash - &&\
-    apt-get install --no-install-recommends -y \
-        nodejs=18.4.0-deb-1nodesource1 \
+    apt-get install --no-install-recommends -y nodejs \
     &&\
     # Deno
     curl -fsSL https://deno.land/x/install/install.sh | sh -s v1.23.3 &&\

--- a/PrimeV/solution_1/Dockerfile
+++ b/PrimeV/solution_1/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.15 AS build
+FROM alpine:3.16 AS build
 
-ENV V_VER="weekly.2022.13"
+ENV V_VER="0.3"
 
 RUN apk update && apk add --no-cache build-base bash git
 
@@ -14,7 +14,7 @@ COPY *.v .
 
 RUN v -prod primes.v
 
-FROM alpine:3.15
+FROM alpine:3.16
 
 COPY --from=build /opt/app/primes /usr/local/bin/primes
 

--- a/PrimeV/solution_1/primes.v
+++ b/PrimeV/solution_1/primes.v
@@ -67,7 +67,7 @@ fn (sieve Sieve) print_results(show_results bool, duration time.Duration, passes
 
 	avg := f64(duration / passes)
 	count_primes := sieve.count_primes()
-	valid := (count_primes == dictionary[sieve.sieve_size.str()])
+	valid := (count_primes == u64(dictionary[sieve.sieve_size.str()]))
 	eprintln('Passes: $passes, Time: $duration, Avg: $avg, Limit: $sieve.sieve_size, Count1: $count, Count2: $count_primes, Valid: $valid')
 
 	println('marghidanu;$passes;$duration;1;algorithm=base,faithful=yes')

--- a/PrimeV/solution_2/Dockerfile
+++ b/PrimeV/solution_2/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine:3.15 AS build
+FROM alpine:3.16 AS build
 
-ENV V_VER="weekly.2022.13"
+ENV V_VER="0.3"
 
 RUN apk update && apk add --no-cache build-base bash git
 
@@ -14,7 +14,7 @@ COPY *.v .
 
 RUN v -prod primes.v
 
-FROM alpine:3.15
+FROM alpine:3.16
 
 COPY --from=build /opt/app/primes /usr/local/bin/primes
 


### PR DESCRIPTION
This removes the version specification for `zip`, `unzip` and `nodejs` from the JavaScript/solution_1 `Dockerfile`. The rationale is as follows:
- `zip` and `unzip` are stable generic tools, updates to which are unlikely to break their current usage
- `nodejs` is acquired from NodeSource, which regularly updates the versions it provides. The explicit pulling in of an 18.x version (which is already a type of version pinning) should be enough.

The pulling in of a specific version of `curl` is maintained; the version that is pulled in without a version specification complains about one of its options (`S`) not making sense in conjunction with the other ones.  

I've also:
- bumped the V solutions to V version 0.3, and Alpine 3.16 to fix another periodic build breakage. Let's hope version 0.3 will prove less brittle than the versions we've seen so far.  
- made a small change to V solution_1, to address an error the new V version started issuing when comparing int with u64.