### PR TITLE
Bump Ubuntu 21.04 to 22.04

### DIFF
--- a/PrimeBash/solution_1/Dockerfile
+++ b/PrimeBash/solution_1/Dockerfile
@@ -1,6 +1,6 @@
 # bash (with coreutils) in alpine seems to be less optimized than ubuntu
 # bash 5.1 seems to have much better performance than 5.0 shipped in 20.04
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 
 WORKDIR /opt/app
 COPY *.sh ./

--- a/PrimeCPP/solution_1/Dockerfile
+++ b/PrimeCPP/solution_1/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04 AS build
+FROM ubuntu:22.04 AS build
 
 RUN apt-get update -qq \
     && apt-get install -y clang
@@ -7,7 +7,7 @@ WORKDIR /opt/app
 COPY *.cpp .
 RUN clang++ -march=native -mtune=native -Ofast -std=c++17 PrimeCPP.cpp -o PrimeCPP
 
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 COPY --from=build /opt/app/PrimeCPP /usr/local/bin
 
 ENTRYPOINT [ "PrimeCPP" ]

--- a/PrimeCPP/solution_2/Dockerfile
+++ b/PrimeCPP/solution_2/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04 AS build
+FROM ubuntu:22.04 AS build
 
 RUN apt-get update -qq \
     && apt-get install -y clang
@@ -7,7 +7,7 @@ WORKDIR /opt/app
 COPY *.cpp .
 RUN clang++ -march=native -mtune=native -pthread -Ofast -std=c++17 PrimeCPP_PAR.cpp -oprimes_par
 
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 COPY --from=build /opt/app/primes_par /usr/local/bin
 
 ENTRYPOINT [ "primes_par", "-l", "1000000" ]

--- a/PrimeCPP/solution_3/Dockerfile
+++ b/PrimeCPP/solution_3/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04 AS build
+FROM ubuntu:22.04 AS build
 
 RUN apt-get update -qq \
     && apt-get install -y clang
@@ -6,7 +6,7 @@ COPY *.cpp *.h *.sh /opt/app/
 WORKDIR /opt/app
 RUN ./build.sh
 
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 COPY --from=build /opt/app/primes_constexpr /usr/local/bin
 
 ENTRYPOINT [ "primes_constexpr" ]

--- a/PrimeCPP/solution_4/Dockerfile
+++ b/PrimeCPP/solution_4/Dockerfile
@@ -1,6 +1,6 @@
 # Build
 
-FROM ubuntu:21.04 AS build
+FROM ubuntu:22.04 AS build
 
 RUN apt-get update -qq && apt-get install -y g++-11 clang-12 make
 
@@ -15,7 +15,7 @@ RUN make -j bench
 
 # Run
 
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 
 RUN apt-get update -qq && apt-get install -y make \
     && apt-get clean \

--- a/PrimeLean4/solution_1/Dockerfile
+++ b/PrimeLean4/solution_1/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 
 # Install elan, lean4 and runtime deps
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]

--- a/PrimeTeX/solution_1/Dockerfile
+++ b/PrimeTeX/solution_1/Dockerfile
@@ -2,7 +2,7 @@
 # code uses fairly recent LaTeX3 features)
 # There is a specific texlive image, but that includes the full distribution and
 # appropriately massive. This is smaller.
-FROM ubuntu:21.04
+FROM ubuntu:22.04
 
 WORKDIR /opt/app
 


### PR DESCRIPTION
This upgrades solutions that have their Dockerfile based on Ubuntu 21.04 to use Ubuntu 22.04 instead; this includes the C++ solutions. The 21.04 version of Ubuntu reached EOL in January 2022, which makes that new docker builds of 21.04 solutions now fail.