### PR TITLE
PrimeV: bump V version to weekly.2022.39

### DIFF
--- a/PrimeV/solution_1/Dockerfile
+++ b/PrimeV/solution_1/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.16 AS build
 
-ENV V_VER="0.3"
+ENV V_VER="weekly.2022.39"
 
 RUN apk update && apk add --no-cache build-base bash git
 

--- a/PrimeV/solution_2/Dockerfile
+++ b/PrimeV/solution_2/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3.16 AS build
 
-ENV V_VER="0.3"
+ENV V_VER="weekly.2022.39"
 
 RUN apk update && apk add --no-cache build-base bash git
 


### PR DESCRIPTION
V did its regular thing of breaking on an updated base image. This bumps its version to weekly.2022.39, which seems to work on Alpine 3.16, for now.