### PR TITLE
Optimized PrimeC/solution 5 - 50% speed increase and multiprocessor supported

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "files.associations": {
+        "stdio.h": "c",
+        "time.h": "c"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,0 @@
-{
-    "files.associations": {
-        "stdio.h": "c",
-        "time.h": "c"
-    }
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "files.associations": {
+        "bitset": "c",
+        "future": "c",
+        "random": "c"
+    }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-    "files.associations": {
-        "bitset": "c",
-        "future": "c",
-        "random": "c"
-    }
-}

--- a/PrimeC/solution_5/.gitignore
+++ b/PrimeC/solution_5/.gitignore
@@ -2,6 +2,7 @@
 .vs
 *.o
 *.asm
+*.s
 *.tmp
 testd.sh
 testm.sh

--- a/PrimeC/solution_5/.gitignore
+++ b/PrimeC/solution_5/.gitignore
@@ -1,0 +1,11 @@
+.DS_Store
+.vs
+*.o
+*.asm
+*.tmp
+testd.sh
+testm.sh
+sieve_extend
+sieve_extend_epar
+sieve_extend_par
+

--- a/PrimeC/solution_5/.gitignore
+++ b/PrimeC/solution_5/.gitignore
@@ -9,4 +9,6 @@ testm.sh
 sieve_extend
 sieve_extend_epar
 sieve_extend_par
+sieve_extend-u*
+sieve_extend_epar-u*
 

--- a/PrimeC/solution_5/Dockerfile
+++ b/PrimeC/solution_5/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM gcc:12.2
 
 RUN apt-get update && apt-get -y install build-essential \
     && apt-get clean \

--- a/PrimeC/solution_5/Dockerfile
+++ b/PrimeC/solution_5/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get -y install build-essential \
 
 WORKDIR /home/primes
 
-COPY compile.sh run.sh *.c ./
+COPY *.sh *.h *.c ./
 
 RUN ./compile.sh
 

--- a/PrimeC/solution_5/Dockerfile
+++ b/PrimeC/solution_5/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcc:12.2
+FROM ubuntu:22.04
 
 RUN apt-get update && apt-get -y install build-essential \
     && apt-get clean \

--- a/PrimeC/solution_5/Dockerfile
+++ b/PrimeC/solution_5/Dockerfile
@@ -6,7 +6,7 @@ RUN apt-get update && apt-get -y install build-essential \
 
 WORKDIR /home/primes
 
-COPY *.sh *.h *.c ./
+COPY *.sh *.c ./
 
 RUN ./compile.sh
 

--- a/PrimeC/solution_5/Dockerfile
+++ b/PrimeC/solution_5/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get -y install build-essential \
     && apt-get clean \

--- a/PrimeC/solution_5/README.md
+++ b/PrimeC/solution_5/README.md
@@ -43,9 +43,9 @@ Sources:
 - https://codeforces.com/blog/entry/96344?locale=ru
 
 ## Choice of Dockerfile
-This solution uses Ubuntu 20.04 as the base image.
-The gcc image at gcc:12-bullseye seems to be slower.
-ALso the alpine:3.13 base image has a slow `memcpy` function due to the `musl libc`. 
+This solution uses gcc:12-bullseye build, as described in https://github.com/PlummersSoftwareLLC/Primes/blob/drag-race/CONTRIBUTING.md#dockerfile
+The ubuntu 20.04 version seems to have roughly the same speed, but the newer gcc versions work better on the M1 processor. 
+Also the alpine:3.13 base image has a slow `memcpy` function due to the `musl libc`. 
 
 ## Run instructions
 

--- a/PrimeC/solution_5/README.md
+++ b/PrimeC/solution_5/README.md
@@ -91,8 +91,9 @@ docker run -it --entrypoint /bin/bash c:latest
 Below is an example of the output on my machine, running with Docker.
 
 ```bash
-rogiervandam_extend;59084;5.000057;1;algorithm=other,faithful=yes,bits=1
-rogiervandam_extend;358748;5.000128;12;algorithm=other,faithful=yes,bits=1
-rogiervandam_extend;273224;5.000128;6;algorithm=other,faithful=yes,bits=1
-rogiervandam_extend;158321;5.000052;3;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend;65863;5.000053;1;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar;352723;5.000135;12;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar;304570;5.000061;6;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar;179989;5.000081;3;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar;65742;5.000010;1;algorithm=other,faithful=yes,bits=1
 ```

--- a/PrimeC/solution_5/README.md
+++ b/PrimeC/solution_5/README.md
@@ -32,6 +32,7 @@ Inspired by:
 - Using vector can greatly speed thing up, because of the sse/avx extensions
 
 Sources:
+https://www.agner.org/optimize/
 https://stackoverflow.com/questions/21681300/diferences-between-pragmas-simd-and-ivdep-vector-always
 https://stackoverflow.com/questions/25248766/emulating-shifts-on-32-bytes-with-avx
 https://stackoverflow.com/questions/3005564/gcc-recommendations-and-options-for-fastest-code

--- a/PrimeC/solution_5/README.md
+++ b/PrimeC/solution_5/README.md
@@ -21,6 +21,21 @@ This defaults to a really small and short tuning. Using the command line, this c
 Inspired by: 
 - nodeJS/solution_1 - rogiervandam-memcopy. This is the implementation in C, to see how much speed can be gained by moving from nodeJS to C. 
 - PrimeC/solution_3 - fvbakel C-words. The segmented algorithm has similar concepts. But the extended algorithm implementations takes it further, by speed gains with a sub-byte (bit) level algorithms (race, pattern, small vs largestep optimizations).
+- PrimeRust/solution_1 - Michael Barber. Inspired the manual loop unroll optimization
+- PrimeC/solution_2 - danielspaangberg_1of2_epar. Inspired the multiprocessor versions. 
+
+## Lessons learned
+- Use #pragma ivdep to signal the compiler that it should not care about rereading memory in a loop.
+- Use manual unroll for small sizes
+- Small changes in code can have huge impact due to -Ofast of -O3 optimizations
+- Using vector can greatly speed thing up, because of the sse/avx extensions
+
+Sources:
+https://stackoverflow.com/questions/21681300/diferences-between-pragmas-simd-and-ivdep-vector-always
+https://stackoverflow.com/questions/25248766/emulating-shifts-on-32-bytes-with-avx
+https://stackoverflow.com/questions/3005564/gcc-recommendations-and-options-for-fastest-code
+https://github.com/simd-everywhere/simde
+https://www.cprogramming.com/tips/tip/common-optimization-tips
 
 ## Choice of Dockerfile
 This solution uses Ubuntu 20.04 as the base image.
@@ -29,8 +44,8 @@ ALso the alpine:3.13 base image has a slow `memcpy` function due to the `musl li
 
 ## Run instructions
 
-### Build and run native
 
+### Build and run native
 To run this solution you need the gcc compiler and dependencies.
 
 ```bash
@@ -38,7 +53,6 @@ cd path/to/sieve
 ./compile.sh
 ./run.sh
 ```
-
 or use the shortcut ./test.sh sieve_extend
 
 ### Run with Docker
@@ -58,10 +72,25 @@ To run with Docker take the following steps:
     docker run --rm -it  c:latest 
     ```
 
+Or do it all in one go:
+
+```bash
+docker build --pull --rm -f "Dockerfile" -t c:latest .; docker run c:latest 
+```
+
+Remember you can go in to the container like this:
+
+```bash
+docker run -it --entrypoint /bin/bash c:latest
+```
+
 ## Output
 
 Below is an example of the output on my machine, running with Docker.
 
 ```bash
-rogiervandam_extend;46042;5.000072;1;algorithm=other,faithful=yes,bits=1 
+rogiervandam_extend;59084;5.000057;1;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend;358748;5.000128;12;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend;273224;5.000128;6;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend;158321;5.000052;3;algorithm=other,faithful=yes,bits=1
 ```

--- a/PrimeC/solution_5/README.md
+++ b/PrimeC/solution_5/README.md
@@ -12,7 +12,7 @@ The algorithm is developed in NodeJS and C in parallel.
 ## The extend algorithm
 The extend algorithm marks all the multiples of a prime factor in the range of the product of the prime and all previous primes x2. E.g.: all multiples of 2,3 and 5 are marked until 2x (1x2x3x5) = 30. The range from 15-30 is a reoccuring pattern. So when we find 7, we can extend the pattern 15-30 until 7x15 = 105. Then we can mark all multiples of 7, and so on. So by gradually extending the seive by repeating the current pattern, we can have significant efficiency gains. 
 
-For larger primes, the range will be so large that it can't be effiently handles by the L1 cache. Therefore, the sieve is divided in blocks, so that the multiples are handler per group. The blocks can be entirely independent (start at prime x and then use the extend algortim again), but a hybrid approach is faster: keep extending till the range for the first product of primes extends the sieve. Then, stripe of per block. 
+For larger primes, the range will be so large that it can't be effiently handled by the L1 cache. Therefore, the sieve is divided in blocks, so that the multiples are handler per group. The blocks can be entirely independent (start at prime x and then use the extend algortim again), but a hybrid approach is faster: keep extending till the range for the first product of primes extends the sieve. Then, stripe of per block. 
 
 A number of techniques have been used to enable bit-level patterns to be extended fast. 
 Also all possible optimizations have been used to speed up the code in C.

--- a/PrimeC/solution_5/README.md
+++ b/PrimeC/solution_5/README.md
@@ -3,6 +3,7 @@
 ![Algorithm](https://img.shields.io/badge/Algorithm-other-yellowgreen)
 ![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
+![Parallelism](https://img.shields.io/badge/Parallel-yes-green)
 ![Bit count](https://img.shields.io/badge/Bits-1-green)
 
 This is an implementation in C.

--- a/PrimeC/solution_5/README.md
+++ b/PrimeC/solution_5/README.md
@@ -40,6 +40,7 @@ Sources:
 - https://stackoverflow.com/questions/3005564/gcc-recommendations-and-options-for-fastest-code
 - https://github.com/simd-everywhere/simde
 - https://www.cprogramming.com/tips/tip/common-optimization-tips
+- https://codeforces.com/blog/entry/96344?locale=ru
 
 ## Choice of Dockerfile
 This solution uses Ubuntu 20.04 as the base image.

--- a/PrimeC/solution_5/README.md
+++ b/PrimeC/solution_5/README.md
@@ -42,11 +42,6 @@ Sources:
 - https://www.cprogramming.com/tips/tip/common-optimization-tips
 - https://codeforces.com/blog/entry/96344?locale=ru
 
-## Choice of Dockerfile
-This solution uses gcc:12-bullseye build, as described in https://github.com/PlummersSoftwareLLC/Primes/blob/drag-race/CONTRIBUTING.md#dockerfile
-The ubuntu 20.04 version seems to have roughly the same speed, but the newer gcc versions work better on the M1 processor. 
-Also the alpine:3.13 base image has a slow `memcpy` function due to the `musl libc`. 
-
 ## Run instructions
 
 
@@ -90,6 +85,7 @@ docker run -it --entrypoint /bin/bash c:latest
 ```
 
 ### Command line options
+```bash
 Usage: ./sieve_extend [options] [maximum]
 Options:
   --block <kilobyte> Set the block size to a specific <size> in kilobytes
@@ -105,6 +101,7 @@ Options:
                      1 - show phase progress
                      2 - show general progress within the phase
                      3 - show actual work
+```
 
 ## Output
 Below is an example of the output on my machine, running with Docker.

--- a/PrimeC/solution_5/README.md
+++ b/PrimeC/solution_5/README.md
@@ -34,7 +34,7 @@ Inspired by:
 - doing while (index<range_stop) and then if (index==range_stop) is faster than while (index<=range_stop)
 
 Sources:
-- https://www.agner.org/optimize/
+- https://www.agner.org/optimize/ - excellent manuals on optimization
 - https://stackoverflow.com/questions/21681300/diferences-between-pragmas-simd-and-ivdep-vector-always
 - https://stackoverflow.com/questions/25248766/emulating-shifts-on-32-bytes-with-avx
 - https://stackoverflow.com/questions/3005564/gcc-recommendations-and-options-for-fastest-code
@@ -89,14 +89,30 @@ Remember you can go in to the container like this:
 docker run -it --entrypoint /bin/bash c:latest
 ```
 
-## Output
+### Command line options
+Usage: ./sieve_extend [options] [maximum]
+Options:
+  --block <kilobyte> Set the block size to a specific <size> in kilobytes
+  --check            Check the correctness of the algorithm
+  --help             This help function
+  --show  <maximum>  Show the primes found up to the maximum
+  --time  <seconds>  The maximum time (in seconds) to run passes of the sieve algorithm
+  --tune  <level>    find the best settings for the current os and hardware
+                     1 - fast tuning
+                     2 - refined tuning
+                     3 - maximum tuning (takes long)
+  --verbose <level>  Show more output to a certain level:
+                     1 - show phase progress
+                     2 - show general progress within the phase
+                     3 - show actual work
 
+## Output
 Below is an example of the output on my machine, running with Docker.
 
 ```bash
-rogiervandam_extend;65863;5.000053;1;algorithm=other,faithful=yes,bits=1
-rogiervandam_extend_epar;352723;5.000135;12;algorithm=other,faithful=yes,bits=1
-rogiervandam_extend_epar;304570;5.000061;6;algorithm=other,faithful=yes,bits=1
-rogiervandam_extend_epar;179989;5.000081;3;algorithm=other,faithful=yes,bits=1
-rogiervandam_extend_epar;65742;5.000010;1;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend;66705;5.000056;1;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar;350148;60.001882;12;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar;269084;30.000645;6;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar;161169;15.000181;3;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar;58202;5.000022;1;algorithm=other,faithful=yes,bits=1
 ```

--- a/PrimeC/solution_5/README.md
+++ b/PrimeC/solution_5/README.md
@@ -26,6 +26,7 @@ Inspired by:
 - PrimeC/solution_2 - danielspaangberg_1of2_epar. Inspired the multiprocessor versions. 
 
 ## Lessons learned
+- 32 bit vectors can be faster than 64 bit
 - Use #pragma ivdep to signal the compiler that it should not care about rereading memory in a loop.
 - Use manual unroll for small sizes
 - Small changes in code can have huge impact due to -Ofast of -O3 optimizations
@@ -104,12 +105,40 @@ Options:
 ```
 
 ## Output
-Below is an example of the output on my machine, running with Docker.
-
+The extension means the following:
 ```bash
-rogiervandam_extend;66705;5.000056;1;algorithm=other,faithful=yes,bits=1
-rogiervandam_extend_epar;350148;60.001882;12;algorithm=other,faithful=yes,bits=1
-rogiervandam_extend_epar;269084;30.000645;6;algorithm=other,faithful=yes,bits=1
-rogiervandam_extend_epar;161169;15.000181;3;algorithm=other,faithful=yes,bits=1
-rogiervandam_extend_epar;58202;5.000022;1;algorithm=other,faithful=yes,bits=1
+u32v8b31t3
+u32---------> unsigned 32 bit to store integers
+   v8-------> vectorized extending and striping using 8 x u 32 (or otherwise specified above)
+     b31----> block size of 31kB 
+        t3--> threads = 3 
+```
+
+Below is an example of the output on my machine, running with Docker.
+```bash
+rogiervandam_extend-u64v2b31;62520;5.000061;1;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend-u32v4b32;62281;5.000014;1;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend-u32v8b32;68550;5.000067;1;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend-u64v4b32;72737;5.000043;1;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend-u64v8b31;37117;5.000108;1;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u64v2b31t12;326098;5.000173;12;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u64v2b31t6;291160;5.000140;6;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u64v2b31t3;168067;5.000066;3;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u64v2b31;60189;5.000004;1;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u32v4b15t12;323704;5.000171;12;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u32v4b15t6;270277;5.000113;6;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u32v4b15t3;157055;5.000071;3;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u32v4b15;55885;5.000028;1;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u32v8b15t12;372283;5.000150;12;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u32v8b15t6;296594;5.000084;6;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u32v8b15t3;175971;5.000070;3;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u32v8b15;62281;5.000028;1;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u64v4b32t12;349984;5.000152;12;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u64v4b32t6;302958;5.000100;6;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u64v4b32t3;181114;5.000065;3;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u64v4b32;64122;5.000054;1;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u64v8b32t12;264962;5.000275;12;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u64v8b32t6;172144;5.000174;6;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u64v8b32t3;93330;5.000147;3;algorithm=other,faithful=yes,bits=1
+rogiervandam_extend_epar-u64v8b32;32110;5.000124;1;algorithm=other,faithful=yes,bits=1
 ```

--- a/PrimeC/solution_5/README.md
+++ b/PrimeC/solution_5/README.md
@@ -30,14 +30,16 @@ Inspired by:
 - Use manual unroll for small sizes
 - Small changes in code can have huge impact due to -Ofast of -O3 optimizations
 - Using vector can greatly speed thing up, because of the sse/avx extensions
+- __attribute__((always_inline)) can force inlining a function
+- doing while (index<range_stop) and then if (index==range_stop) is faster than while (index<=range_stop)
 
 Sources:
-https://www.agner.org/optimize/
-https://stackoverflow.com/questions/21681300/diferences-between-pragmas-simd-and-ivdep-vector-always
-https://stackoverflow.com/questions/25248766/emulating-shifts-on-32-bytes-with-avx
-https://stackoverflow.com/questions/3005564/gcc-recommendations-and-options-for-fastest-code
-https://github.com/simd-everywhere/simde
-https://www.cprogramming.com/tips/tip/common-optimization-tips
+- https://www.agner.org/optimize/
+- https://stackoverflow.com/questions/21681300/diferences-between-pragmas-simd-and-ivdep-vector-always
+- https://stackoverflow.com/questions/25248766/emulating-shifts-on-32-bytes-with-avx
+- https://stackoverflow.com/questions/3005564/gcc-recommendations-and-options-for-fastest-code
+- https://github.com/simd-everywhere/simde
+- https://www.cprogramming.com/tips/tip/common-optimization-tips
 
 ## Choice of Dockerfile
 This solution uses Ubuntu 20.04 as the base image.

--- a/PrimeC/solution_5/compile.sh
+++ b/PrimeC/solution_5/compile.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-CC="gcc -Ofast -march=native -mtune=native -funroll-all-loops -fno-asynchronous-unwind-tables -malign-data=cacheline -fno-exceptions -fomit-frame-pointer"  
+CC="gcc -Ofast -march=native -mtune=native -funroll-all-loops -fno-asynchronous-unwind-tables -fno-exceptions -fomit-frame-pointer"  
 PAR="-fopenmp"
 PAREXT="_epar"
 for x in sieve_extend; do

--- a/PrimeC/solution_5/compile.sh
+++ b/PrimeC/solution_5/compile.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
-CC="gcc -Ofast -march=native -mtune=native -funroll-all-loops" 
+CC="gcc -Ofast -march=native -mtune=native -funroll-all-loops -fno-asynchronous-unwind-tables -malign-data=cacheline" 
+PAR="-fopenmp"
+PAREXT="_epar"
 for x in sieve_extend; do
     $CC -o $x $x.c -lm
+    $CC $PAR -o $x$PAREXT $x.c -lm
 done

--- a/PrimeC/solution_5/compile.sh
+++ b/PrimeC/solution_5/compile.sh
@@ -3,7 +3,7 @@ CC="gcc -Ofast -march=native -mtune=native -funroll-all-loops -fno-asynchronous-
 PAR="-fopenmp"
 PAREXT="_epar"
 for x in sieve_extend; do
-    for y in u64_v2 u32_v4 u32_v8 u64_v4 u64_v8; do
+    for y in u32_v8 u64_v4 u64_v8; do
         $CC -o $x-$y $x.c -D$y -s
         $CC $PAR -o $x$PAREXT-$y $x.c -D$y -s
     done

--- a/PrimeC/solution_5/compile.sh
+++ b/PrimeC/solution_5/compile.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-CC="gcc -Ofast -march=native -mtune=native -funroll-all-loops -fno-asynchronous-unwind-tables -malign-data=cacheline" 
+CC="gcc -Ofast -march=native -mtune=native -funroll-all-loops -fno-asynchronous-unwind-tables"  
 PAR="-fopenmp"
 PAREXT="_epar"
 for x in sieve_extend; do

--- a/PrimeC/solution_5/compile.sh
+++ b/PrimeC/solution_5/compile.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-CC="gcc -Ofast -march=native -mtune=native -funroll-all-loops -fno-asynchronous-unwind-tables"  
+CC="gcc -Ofast -march=native -mtune=native -funroll-all-loops -fno-asynchronous-unwind-tables -malign-data=cacheline -fno-exceptions -fomit-frame-pointer"  
 PAR="-fopenmp"
 PAREXT="_epar"
 for x in sieve_extend; do

--- a/PrimeC/solution_5/compile.sh
+++ b/PrimeC/solution_5/compile.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
-CC="gcc -Ofast -march=native -mtune=native -funroll-all-loops -fno-asynchronous-unwind-tables -fno-exceptions -fomit-frame-pointer"  
+CC="gcc -Ofast -march=native -mtune=native -funroll-all-loops -fno-asynchronous-unwind-tables -fno-exceptions -fomit-frame-pointer -Wno-psabi"  
 PAR="-fopenmp"
 PAREXT="_epar"
 for x in sieve_extend; do
-    $CC -o $x $x.c -lm
-    $CC $PAR -o $x$PAREXT $x.c -lm
+    for y in u64_v2 u32_v4 u32_v8 u64_v4 u64_v8; do
+        $CC -o $x-$y $x.c -D$y -s
+        $CC $PAR -o $x$PAREXT-$y $x.c -D$y -s
+    done
 done

--- a/PrimeC/solution_5/run.sh
+++ b/PrimeC/solution_5/run.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
 for x in sieve_extend sieve_extend_epar; do
-    ./$x
+    for y in u64_v2 u32_v4 u32_v8 u64_v4 u64_v8; do
+        ./$x-$y
+    done
 done

--- a/PrimeC/solution_5/run.sh
+++ b/PrimeC/solution_5/run.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
-for x in sieve_extend; do
+for x in sieve_extend sieve_extend_epar; do
     ./$x
 done

--- a/PrimeC/solution_5/run.sh
+++ b/PrimeC/solution_5/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 for x in sieve_extend sieve_extend_epar; do
-    for y in u64_v2 u32_v4 u32_v8 u64_v4 u64_v8; do
+    for y in u32_v8 u64_v4 u64_v8; do
         ./$x-$y
     done
 done

--- a/PrimeC/solution_5/sieve_extend.c
+++ b/PrimeC/solution_5/sieve_extend.c
@@ -362,7 +362,7 @@ static void continuePattern_shiftright(bitword_t* bitstorage, const counter_t so
 
     for (; copy_word <= destination_stop_word; copy_word++, source_word++ ) 
         bitstorage[copy_word] = (bitstorage[source_word] >> shift_flipped) | (bitstorage[source_word+1] << shift);
-    // bitstorage[copy_word] &= chopmask(destination_stop);
+    bitstorage[copy_word] &= chopmask(destination_stop);
 
 
     // bitstorage[copy_word] |= ((bitstorage[source_word] << shift) |  (bitstorage[copy_word] >> shift_flipped)) & keepmask(copy_start);

--- a/PrimeC/solution_5/sieve_extend.c
+++ b/PrimeC/solution_5/sieve_extend.c
@@ -848,7 +848,7 @@ static void benchmark(tuning_result_t* tuning_result)
         passes++;
     }
     tuning_result->passes = passes;
-    tuning_result->elapsed_time = elapsed_time / CLOCKS_PER_SEC;
+    tuning_result->elapsed_time = elapsed_time / CLOCKS_PER_SEC / tuning_result->threads;
     tuning_result->avg = passes/elapsed_time;
 }
 

--- a/PrimeC/solution_5/sieve_extend.c
+++ b/PrimeC/solution_5/sieve_extend.c
@@ -350,7 +350,7 @@ static void continuePattern_shiftright(bitword_t* bitstorage, const counter_t so
 
     debug { printf("...start - %ju - %ju - end\n",(uintmax_t)wordindex(copy_start), (uintmax_t)destination_stop_word) ; }
 
-    for (; copy_word <= destination_stop_word; ++copy_word, ++source_word ) {
+    for (; copy_word <= destination_stop_word; copy_word++, source_word++ ) {
         bitstorage[copy_word] = (bitstorage[source_word] >> shift_flipped) | (bitstorage[source_word+1] << shift);
     }
 }

--- a/PrimeC/solution_5/sieve_extend.c
+++ b/PrimeC/solution_5/sieve_extend.c
@@ -14,6 +14,7 @@
 //add debug in front of a line to only compile it if the value below is set to 1 (or !=0)
 #define option_runonce 0
 #define debug if (option_runonce)
+// #define debug if (1) 
 #define verbose(level) if (option_verboselevel >= level)
 #define verbose_at(level) if (option_verboselevel == level)
 
@@ -109,6 +110,7 @@ static struct sieve_t *sieve_create(counter_t size) {
     sieve->bitstorage = aligned_alloc((size_t)anticiped_cache_line_bytesize, (size_t)ceiling(1+((size_t)size>>1), anticiped_cache_line_bytesize<<3) * anticiped_cache_line_bytesize );
     sieve->bits     = size >> 1;
     sieve->size     = size;
+    for (counter_t index_word = 0; index_word <= wordindex(sieve->bits); index_word++) sieve->bitstorage[index_word] = SAFE_ZERO;
     return sieve;
 }
 
@@ -473,7 +475,9 @@ static struct block sieve_block_extend(struct sieve_t *sieve, const counter_t bl
     counter_t range_stop       = block_start;
     struct block block = { .prime = 0, .pattern_start = 0, .pattern_size = 0 };
 
-    sieve->bitstorage[wordindex(block_start)] = SAFE_ZERO; // only the first word has to be cleared; the rest is populated by the extension procedure
+    // for (counter_t index_word=wordindex(block_start); index_word <= wordindex(block_stop); index_word++) {
+    //     sieve->bitstorage[wordindex(block_start)] = SAFE_ZERO; // only the first word has to be cleared; the rest is populated by the extension procedure
+    // }
     
     for (;range_stop < block_stop;) {
         prime = searchBitFalse(bitstorage, prime+1);
@@ -499,7 +503,7 @@ static struct block sieve_block_extend(struct sieve_t *sieve, const counter_t bl
         else                               setBitsTrue_largeRange(bitstorage, start, step, range_stop);
         block.prime = prime;
 
-        if (bitstorage[wordindex(2291)] & markmask_calc(2291)) { printf("Block_extend at prime %ju blocksize %ju\n",(uintmax_t)prime,(uintmax_t)block_stop); exit(0); }
+        // if (bitstorage[wordindex(2291)] & markmask_calc(2291)) { printf("2291 set with block_extend at prime %ju block %ju-%ju\n",(uintmax_t)prime,(uintmax_t)block_start,(uintmax_t)block_stop); exit(0); }
 
     } 
 
@@ -512,7 +516,9 @@ static struct sieve_t* sieve_shake(const counter_t maxints, const counter_t bloc
     struct sieve_t *sieve = sieve_create(maxints);
     bitword_t* bitstorage = sieve->bitstorage;
 
-    debug printf("Running sieve to find all primes up to %ju with blocksize %ju\n",(uintmax_t)maxints,(uintmax_t)blocksize);
+    debug printf("\nShaking sieve to find all primes up to %ju with blocksize %ju\n",(uintmax_t)maxints,(uintmax_t)blocksize);
+
+    // if (bitstorage[wordindex(2291)] & markmask_calc(2291)) { printf("2291 set with sieve_shake at startt\n"); exit(0); }
 
     // fill the whole sieve bij adding en copying incrementally
     struct block block = sieve_block_extend(sieve, 0, sieve->bits);

--- a/PrimeC/solution_5/sieve_extend.c
+++ b/PrimeC/solution_5/sieve_extend.c
@@ -631,9 +631,7 @@ static counter_t sieve_block_stripe(bitword_t* bitstorage, const counter_t block
         if unlikely(step < VECTORSTEP_FASTER)
             setBitsTrue_largeRange_vector(bitstorage, start, step, block_stop);
         else 
-        else 
             setBitsTrue_largeRange(bitstorage, start, step, block_stop);
-        prime = searchBitFalse(bitstorage, prime + 1 );
         prime = searchBitFalse(bitstorage, prime + 1 );
         step  = prime * 2 + 1;
     }

--- a/PrimeC/solution_5/sieve_extend.c
+++ b/PrimeC/solution_5/sieve_extend.c
@@ -281,21 +281,18 @@ static inline void setBitsTrue_largeRange_vector(bitword_t* __restrict bitstorag
         register const counter_t curent_vector_start = vectorstart(index);
 
         #pragma GCC ivdep
-        for(register counter_t vector_wordstart = (curent_vector_start            ); wordstart(index) == vector_wordstart; index += step) mask |= markmask(index);
-        quadmask[0] = mask;
-        mask = SAFE_ZERO;
+        for(register counter_t vector_wordstart = (curent_vector_start                        ); wordstart(index) == vector_wordstart; index += step) mask |= markmask(index);
+        quadmask[0] = mask; mask = SAFE_ZERO;
         #pragma GCC ivdep
-        for(register counter_t vector_wordstart = (curent_vector_start | (64     )); wordstart(index) == vector_wordstart; index += step) mask |= markmask(index);
-        quadmask[1] = mask;
-        mask = SAFE_ZERO;
+        for(register counter_t vector_wordstart = (curent_vector_start | (WORD_SIZE_counter  )); wordstart(index) == vector_wordstart; index += step) mask |= markmask(index);
+        quadmask[1] = mask; mask = SAFE_ZERO;
         #pragma GCC ivdep
-        for(register counter_t vector_wordstart = (curent_vector_start | (128    )); wordstart(index) == vector_wordstart; index += step) mask |= markmask(index);
-        quadmask[2] = mask;
-        mask = SAFE_ZERO;
+        for(register counter_t vector_wordstart = (curent_vector_start | (WORD_SIZE_counter*2)); wordstart(index) == vector_wordstart; index += step) mask |= markmask(index);
+        quadmask[2] = mask; mask = SAFE_ZERO;
         #pragma GCC ivdep
-        for(register counter_t vector_wordstart = (curent_vector_start | (128+64 )); wordstart(index) == vector_wordstart; index += step) mask |= markmask(index);
+        for(register counter_t vector_wordstart = (curent_vector_start | (WORD_SIZE_counter*3)); wordstart(index) == vector_wordstart; index += step) mask |= markmask(index);
         quadmask[3] = mask;
- 
+
         // use mask on all n*step multiples
         bitvector_t* __restrict bitstorage_vector = __builtin_assume_aligned( (bitvector_t*) bitstorage_word, anticiped_cache_line_bytesize);
         applyMask_vector(bitstorage_vector, step, range_stop, quadmask, current_vector);

--- a/PrimeC/solution_5/sieve_extend.c
+++ b/PrimeC/solution_5/sieve_extend.c
@@ -281,7 +281,6 @@ static inline void setBitsTrue_largeRange_vector(bitword_t* __restrict bitstorag
 
 static void continuePattern_smallSize(bitword_t* __restrict bitstorage, const counter_t source_start, const counter_t size, const counter_t destination_stop) {
     debug printf("Extending sieve size %ju in %ju bit range (%ju-%ju) using smallsize (%ju copies)\n", (uintmax_t)size, (uintmax_t)destination_stop-(uintmax_t)source_start,(uintmax_t)source_start,(uintmax_t)destination_stop, (uintmax_t)(((uintmax_t)destination_stop-(uintmax_t)source_start)/(uintmax_t)size));
-    // debug { printf("...At start. "); dump_bitstorage(bitstorage, 4); }
 
     const counter_t source_word = wordindex(source_start);
     register bitword_t pattern = ((bitstorage[source_word] >> bitindex(source_start)) | (bitstorage[source_word+1] << (WORD_SIZE_counter-bitindex_calc(source_start)))) & chopmask(size);
@@ -469,8 +468,6 @@ static void sieve_block_stripe(bitword_t* bitstorage, const counter_t block_star
             prime = searchBitFalse_longRange(bitstorage, prime+1 );
         }
 
-        if (bitstorage[wordindex(2291)] & markmask_calc(2291)) { printf("Block_stripe!"); exit(0); }
-
         step  = prime * 2 + 1;
     }
 }
@@ -518,9 +515,6 @@ static struct block sieve_block_extend(struct sieve_t *sieve, const counter_t bl
         else if (step < VECTORSTEP_FASTER) setBitsTrue_largeRange_vector(bitstorage, start, step, range_stop);
         else                               setBitsTrue_largeRange(bitstorage, start, step, range_stop);
         block.prime = prime;
-
-        // if (bitstorage[wordindex(2291)] & markmask_calc(2291)) { printf("2291 set with block_extend at prime %ju block %ju-%ju\n",(uintmax_t)prime,(uintmax_t)block_start,(uintmax_t)block_stop); exit(0); }
-
     } 
 
     return block;
@@ -533,8 +527,6 @@ static struct sieve_t* sieve_shake(const counter_t maxints, const counter_t bloc
     bitword_t* bitstorage = sieve->bitstorage;
 
     debug printf("\nShaking sieve to find all primes up to %ju with blocksize %ju\n",(uintmax_t)maxints,(uintmax_t)blocksize);
-
-    // if (bitstorage[wordindex(2291)] & markmask_calc(2291)) { printf("2291 set with sieve_shake at startt\n"); exit(0); }
 
     // fill the whole sieve bij adding en copying incrementally
     struct block block = sieve_block_extend(sieve, 0, sieve->bits);
@@ -600,7 +592,6 @@ static void deepAnalyzePrimes(struct sieve_t *sieve) {
 
 
 int validatePrimeCount(struct sieve_t *sieve, int option_verboselevel) {
-
     counter_t primecount = count_primes(sieve);
     counter_t valid_primes = 0;
     switch(sieve->size) {

--- a/PrimeC/solution_5/sieve_extend.c
+++ b/PrimeC/solution_5/sieve_extend.c
@@ -6,33 +6,33 @@
 #include <stdint.h>
 #include <time.h>
 #include <string.h>
-#include <immintrin.h>
+#if defined(__x86_64__)
+// #include <immintrin.h>
+#endif
 #ifdef _OPENMP
 #include <omp.h>
 #endif
 
-//set option_debuggable to 1 to enable explain plan
-#define option_debuggable 0
-#if option_debuggable
-int global_option_explain = 0;
-#define debug if (option_debuggable && global_option_explain)
+//set compile_debuggable to 1 to enable explain plan
+#define compile_debuggable 0
+#if compile_debuggable
+#define debug if (compile_debuggable && option.explain)
 #else
 #define debug if unlikely(0)
 #endif
-#define verbose(level) if (option_verboselevel >= level)
-#define verbose_at(level) if (option_verboselevel == level)
+#define verbose(level) if (option.verboselevel >= level)
+#define verbose_at(level) if (option.verboselevel == level)
 
 // defaults
 #define default_sieve_limit 1000000
 #define default_blocksize (32*1024*8)
-#define default_max_time 5
-#define default_sample_duration 0.1
-#define default_sample_max 5
-#define default_verbose_level 0
+#define default_maxTime 5
+#define default_sample_duration 0.001
+#define default_verbose_level 1
 #define default_tune_level 1
 #define default_check_level 0
 #define default_show_primes_on_error 100
-#define default_showMaxFactor (0 || option_debuggable?100:0)
+#define default_showMaxFactor (0 || compile_debuggable?100:0)
 #define anticiped_cache_line_bytesize 128
 
 // helper functions
@@ -69,9 +69,11 @@ typedef bitword_t bitvector_t __attribute__ ((vector_size(VECTOR_SIZE_bytes)));
 static counter_t global_SMALLSTEP_FASTER = 0ULL;
 static counter_t global_MEDIUMSTEP_FASTER = 16ULL;
 static counter_t global_VECTORSTEP_FASTER = 96ULL;
+static counter_t global_BLOCKSIZE_BITS = default_blocksize;
 #define SMALLSTEP_FASTER ((counter_t)global_SMALLSTEP_FASTER)
 #define MEDIUMSTEP_FASTER ((counter_t)global_MEDIUMSTEP_FASTER)
 #define VECTORSTEP_FASTER ((counter_t)global_VECTORSTEP_FASTER)
+#define BLOCKSIZE_BITS ((counter_t)global_BLOCKSIZE_BITS)
 
 // Patterns based on types
 #define SAFE_SHIFTBIT (bitshift_t)1ULL
@@ -104,12 +106,25 @@ struct sieve_t {
     counter_t  size;
 };
 
+struct options_t {
+    double    maxTime;
+    counter_t maxFactor;
+    counter_t blocksize_kB;
+    counter_t showMaxFactor;
+    int       verboselevel;
+    int       explain;
+    int       check;
+    int       tunelevel;
+    int       threads;
+} option;
+
 //#include "debugtools.h"
 
 // use cache lines as much as possible - alignment might be key
 // moved clearing the sieve with 0 to the sieve_block_extend - it gave weird malloc problems at this point
 #define ceiling(x,y) (((x) + (y) - 1) / (y)) // Return the smallest multiple N of y such that:  x <= y * N
-static struct sieve_t *sieve_create(counter_t size) {
+static struct sieve_t *sieve_create(counter_t size) 
+{
     struct sieve_t *sieve = aligned_alloc(8, sizeof(struct sieve_t));
     sieve->bitstorage = aligned_alloc((size_t)anticiped_cache_line_bytesize, (size_t)ceiling(1+((size_t)size>>1), anticiped_cache_line_bytesize<<3) * anticiped_cache_line_bytesize );
     sieve->bits     = size >> 1;
@@ -120,19 +135,22 @@ static struct sieve_t *sieve_create(counter_t size) {
     return sieve;
 }
 
-static void sieve_delete(struct sieve_t *sieve) {
+static void sieve_delete(struct sieve_t *sieve) 
+{
     free(sieve->bitstorage);
     free(sieve);
 }
 
 // search the next bit not set - for small expected distances
-static inline counter_t searchBitFalse(bitword_t* bitstorage, register counter_t index) {
+static inline counter_t searchBitFalse(bitword_t* bitstorage, register counter_t index) 
+{
     while (bitstorage[wordindex(index)] & markmask(index)) index++;
     return index;
 }
 
 // not much performance gain at smaller sieves, but its's nice to have an implementation
-static inline counter_t searchBitFalse_longRange(bitword_t* bitstorage, register counter_t index) {
+static inline counter_t searchBitFalse_longRange(bitword_t* bitstorage, register counter_t index)
+{
    const bitshift_t index_bit  = bitindex_calc(index);
    register counter_t index_word = wordindex(index);
    register bitshift_t distance = (bitshift_t) __builtin_ctzll( ~(bitstorage[index_word] >> index_bit));  // take inverse to be able to use ctz
@@ -151,9 +169,12 @@ static inline counter_t searchBitFalse_longRange(bitword_t* bitstorage, register
 // apply the same word mask at large ranges
 // manually unlooped - this here is where the main speed increase comes from
 // idea from PrimeRust/solution_1 by Michael Barber 
-static inline void applyMask_word(bitword_t* __restrict bitstorage, const counter_t step, const counter_t range_stop, const bitword_t mask, counter_t index_word) {
+static inline void applyMask_word(bitword_t* __restrict bitstorage, const counter_t step, const counter_t range_stop, const bitword_t mask, counter_t index_word) 
+{
     const counter_t range_stop_word = wordindex(range_stop);
     register bitword_t* __restrict index_ptr      =  __builtin_assume_aligned(&bitstorage[index_word],8);
+
+#if defined(__x86_64__) // unexplained (yet) 4k/s performance increase for this version
     register bitword_t* __restrict fast_loop_ptr  =  __builtin_assume_aligned(&bitstorage[((range_stop_word>step*5) ? (range_stop_word - step*5):0)],8);
     #pragma GCC ivdep
     while (index_ptr < fast_loop_ptr) {
@@ -163,18 +184,18 @@ static inline void applyMask_word(bitword_t* __restrict bitstorage, const counte
         *index_ptr |= mask;  index_ptr+=step;
         *index_ptr |= mask;  index_ptr+=step;
     }
-
-    // if likely(range_stop_word > index_word) {
-    //     #pragma GCC ivdep
-    //     for (counter_t i= ((range_stop_word - index_word)/(step*5));i>0; i--) {
-    //         *index_ptr |= mask;  index_ptr+=step;
-    //         *index_ptr |= mask;  index_ptr+=step;
-    //         *index_ptr |= mask;  index_ptr+=step;
-    //         *index_ptr |= mask;  index_ptr+=step;
-    //         *index_ptr |= mask;  index_ptr+=step;
-    //     }
-    // }
-
+#else
+    if likely(range_stop_word > index_word) {
+        #pragma GCC ivdep
+        for (counter_t i= ((range_stop_word - index_word)/(step*5));i>0; i--) {
+            *index_ptr |= mask;  index_ptr+=step;
+            *index_ptr |= mask;  index_ptr+=step;
+            *index_ptr |= mask;  index_ptr+=step;
+            *index_ptr |= mask;  index_ptr+=step;
+            *index_ptr |= mask;  index_ptr+=step;
+        }
+    }
+#endif
    register const bitword_t* __restrict range_stop_ptr = __builtin_assume_aligned(&bitstorage[(range_stop_word)],8);
    #pragma GCC ivdep
    while likely(index_ptr < range_stop_ptr) {
@@ -187,7 +208,8 @@ static inline void applyMask_word(bitword_t* __restrict bitstorage, const counte
 }
 
 // same as word mask, but at a vector level - uses the sse/avx extensions, hopefully
-static inline void applyMask_vector(bitvector_t* __restrict bitstorage, const counter_t step, const counter_t range_stop, const bitvector_t mask, counter_t index_vector) {
+static inline void applyMask_vector(bitvector_t* __restrict bitstorage, const counter_t step, const counter_t range_stop, const bitvector_t mask, counter_t index_vector) 
+{
     const counter_t range_stop_vector = vectorindex(range_stop);
     register bitvector_t* __restrict index_ptr      =  __builtin_assume_aligned(&bitstorage[index_vector],anticiped_cache_line_bytesize);
     register bitvector_t* __restrict fast_loop_ptr  =  __builtin_assume_aligned(&bitstorage[((range_stop_vector>step*4) ? (range_stop_vector - step*4):0)],anticiped_cache_line_bytesize);
@@ -211,7 +233,8 @@ static inline void applyMask_vector(bitvector_t* __restrict bitstorage, const co
 // By joining the masks and then writing to memory, we might save some time.
 // This is especially true for small steps over long ranges
 // but it needs tuning, because there is some overhead of checking if the next step is in the same word
-static void  setBitsTrue_mediumStep(bitword_t* __restrict bitstorage, const counter_t range_start, const counter_t step, const counter_t range_stop) {
+static void  setBitsTrue_mediumStep(bitword_t* __restrict bitstorage, const counter_t range_start, const counter_t step, const counter_t range_stop) 
+{
     const counter_t range_stop_unique =  range_start + WORD_SIZE_counter * step;
 
     if (range_stop_unique > range_stop) { // the range will not repeat itself; no need to try to resuse the mask
@@ -239,7 +262,8 @@ static void  setBitsTrue_mediumStep(bitword_t* __restrict bitstorage, const coun
 }
 
 // Large ranges (> WORD_SIZE * step) mean the same mask can be reused
-static inline void setBitsTrue_largeRange(bitword_t* __restrict bitstorage, const counter_t range_start, const counter_t step, const counter_t range_stop) {
+static inline void setBitsTrue_largeRange(bitword_t* __restrict bitstorage, const counter_t range_start, const counter_t step, const counter_t range_stop) 
+{
     debug printf("Setting bits step %ju in %ju bit range (%ju-%ju) using largerange (%ju occurances)\n", (uintmax_t)step, (uintmax_t)range_stop-(uintmax_t)range_start,(uintmax_t)range_start,(uintmax_t)range_stop, (uintmax_t)(((uintmax_t)range_stop-(uintmax_t)range_start)/(uintmax_t)step));
     const counter_t range_stop_unique =  range_start + WORD_SIZE_counter * step;
 
@@ -248,7 +272,8 @@ static inline void setBitsTrue_largeRange(bitword_t* __restrict bitstorage, cons
     }
 }
 
-static inline void setBitsTrue_largeRange_vector(bitword_t* __restrict bitstorage_word, counter_t range_start, const counter_t step, const counter_t range_stop) {
+static inline void setBitsTrue_largeRange_vector(bitword_t* __restrict bitstorage_word, counter_t range_start, const counter_t step, const counter_t range_stop) 
+{
     debug printf("Setting bits step %ju in %ju bit range (%ju-%ju) using largerange vector (%ju occurances)\n", (uintmax_t)step, (uintmax_t)range_stop-(uintmax_t)range_start,(uintmax_t)range_start,(uintmax_t)range_stop, (uintmax_t)(((uintmax_t)range_stop-(uintmax_t)range_start)/(uintmax_t)step));
 
     counter_t range_start_atvector = vectorstart(range_start);
@@ -299,7 +324,8 @@ static inline void setBitsTrue_largeRange_vector(bitword_t* __restrict bitstorag
     }
 }
 
-static void continuePattern_smallSize(bitword_t* __restrict bitstorage, const counter_t source_start, const counter_t size, const counter_t destination_stop) {
+static void continuePattern_smallSize(bitword_t* __restrict bitstorage, const counter_t source_start, const counter_t size, const counter_t destination_stop)
+{
     debug printf("Extending sieve size %ju in %ju bit range (%ju-%ju) using smallsize (%ju copies)\n", (uintmax_t)size, (uintmax_t)destination_stop-(uintmax_t)source_start,(uintmax_t)source_start,(uintmax_t)destination_stop, (uintmax_t)(((uintmax_t)destination_stop-(uintmax_t)source_start)/(uintmax_t)size));
 
     const counter_t source_word = wordindex(source_start);
@@ -330,7 +356,8 @@ static void continuePattern_smallSize(bitword_t* __restrict bitstorage, const co
     bitstorage[destination_stop_word] &= chopmask(destination_stop);
 }
 
-static void continuePattern_aligned(bitword_t* bitstorage, const counter_t source_start, const counter_t size, const counter_t destination_stop) {
+static void continuePattern_aligned(bitword_t* bitstorage, const counter_t source_start, const counter_t size, const counter_t destination_stop)
+{
     debug printf("Extending sieve size %ju in %ju bit range (%ju-%ju) using aligned (%ju copies)\n", (uintmax_t)size, (uintmax_t)destination_stop-(uintmax_t)source_start,(uintmax_t)source_start,(uintmax_t)destination_stop, (uintmax_t)(((uintmax_t)destination_stop-(uintmax_t)source_start)/(uintmax_t)size));
 
     const counter_t destination_stop_word = wordindex(destination_stop);
@@ -353,7 +380,8 @@ static void continuePattern_aligned(bitword_t* bitstorage, const counter_t sourc
 
 }
 
-static void continuePattern_shiftright(bitword_t* bitstorage, const counter_t source_start, const counter_t size, const counter_t destination_stop) {
+static void continuePattern_shiftright(bitword_t* bitstorage, const counter_t source_start, const counter_t size, const counter_t destination_stop)
+{
     debug printf("Extending sieve size %ju in %ju bit range (%ju-%ju) using shiftright (%ju copies)\n", (uintmax_t)size, (uintmax_t)destination_stop-(uintmax_t)source_start,(uintmax_t)source_start,(uintmax_t)destination_stop, (uintmax_t)(((uintmax_t)destination_stop-(uintmax_t)source_start)/(uintmax_t)size));
    
     const counter_t destination_stop_word = wordindex(destination_stop);
@@ -391,7 +419,8 @@ static void continuePattern_shiftright(bitword_t* bitstorage, const counter_t so
 
 
 
-static inline counter_t continuePattern_shiftleft_unrolled(bitword_t* __restrict bitstorage, const counter_t aligned_copy_word, const bitshift_t shift, counter_t copy_word, counter_t source_word) {
+static inline counter_t continuePattern_shiftleft_unrolled(bitword_t* __restrict bitstorage, const counter_t aligned_copy_word, const bitshift_t shift, counter_t copy_word, counter_t source_word) 
+{
     const counter_t fast_loop_stop_word = (aligned_copy_word>2) ? (aligned_copy_word - 2) : 0; // safe for unsigned ints
     register const bitshift_t shift_flipped = WORD_SIZE_bitshift-shift;
     counter_t distance = 0;
@@ -409,7 +438,8 @@ static inline counter_t continuePattern_shiftleft_unrolled(bitword_t* __restrict
     return distance;
 }
 
-static void continuePattern_shiftleft(bitword_t* bitstorage, const counter_t source_start, const counter_t size, const counter_t destination_stop) {
+static void continuePattern_shiftleft(bitword_t* bitstorage, const counter_t source_start, const counter_t size, const counter_t destination_stop)
+{
     debug printf("Extending sieve size %ju in %ju bit range (%ju-%ju) using shiftleft (%ju copies)\n", (uintmax_t)size, (uintmax_t)destination_stop-(uintmax_t)source_start,(uintmax_t)source_start,(uintmax_t)destination_stop, (uintmax_t)(((uintmax_t)destination_stop-(uintmax_t)source_start)/(uintmax_t)size));
 
     const counter_t destination_stop_word = wordindex(destination_stop);
@@ -448,14 +478,15 @@ static void continuePattern_shiftleft(bitword_t* bitstorage, const counter_t sou
         bitstorage[copy_word] = bitstorage[source_word];
 
 
- }
+}
 
 // continue a pattern that start at <source_start> with a size of <size>.
 // repeat this pattern up to <destination_stop>.
 // for small sizes, this is done on a word level
 // for larger sizes, we look at the offset / start bit and apply the appropriate algorithm.
 // note that these algorithms are general for bitstorage and have no specialized assumptions for the sieve application
-static inline void continuePattern(bitword_t* bitstorage, const counter_t source_start, const counter_t size, const counter_t destination_stop)	{
+static inline void continuePattern(bitword_t* bitstorage, const counter_t source_start, const counter_t size, const counter_t destination_stop)
+{
     if (size < WORD_SIZE_counter) return continuePattern_smallSize (bitstorage, source_start, size, destination_stop);
 
     const bitshift_t copy_bit   = bitindex_calc(source_start + size);
@@ -466,7 +497,8 @@ static inline void continuePattern(bitword_t* bitstorage, const counter_t source
     else                            continuePattern_aligned   (bitstorage, source_start, size, destination_stop);
 }
 
-static void sieve_block_stripe(bitword_t* bitstorage, const counter_t block_start, const counter_t block_stop, const counter_t prime_start) {
+static void sieve_block_stripe(bitword_t* bitstorage, const counter_t block_start, const counter_t block_stop, const counter_t prime_start)
+{
     counter_t prime = prime_start;
     counter_t start = 0;
     counter_t step  = prime * 2 + 1;
@@ -502,7 +534,8 @@ struct block {
 // returns prime that could not be handled:
 // start is too large
 // range is too big
-static struct block sieve_block_extend(struct sieve_t *sieve, const counter_t block_start, const counter_t block_stop) {
+static struct block sieve_block_extend(struct sieve_t *sieve, const counter_t block_start, const counter_t block_stop) 
+{
     bitword_t* bitstorage      = sieve->bitstorage;
     register counter_t prime   = 0;
     counter_t patternsize_bits = 1;
@@ -542,11 +575,12 @@ static struct block sieve_block_extend(struct sieve_t *sieve, const counter_t bl
 
 
 /* This is the main module that does all the work*/
-static struct sieve_t* sieve_shake(const counter_t maxints, const counter_t blocksize) {
-    struct sieve_t *sieve = sieve_create(maxints);
+static struct sieve_t* sieve_shake(const counter_t maxFactor, const counter_t blocksize) 
+{
+    struct sieve_t *sieve = sieve_create(maxFactor);
     bitword_t* bitstorage = sieve->bitstorage;
 
-    debug printf("\nShaking sieve to find all primes up to %ju with blocksize %ju\n",(uintmax_t)maxints,(uintmax_t)blocksize);
+    debug printf("\nShaking sieve to find all primes up to %ju with blocksize %ju\n",(uintmax_t)maxFactor,(uintmax_t)blocksize);
 
     // fill the whole sieve bij adding en copying incrementally
     struct block block = sieve_block_extend(sieve, 0, sieve->bits);
@@ -570,7 +604,8 @@ static struct sieve_t* sieve_shake(const counter_t maxints, const counter_t bloc
     return sieve;
 }
 
-static void show_primes(struct sieve_t *sieve, counter_t maxFactor) {
+static void show_primes(struct sieve_t *sieve, counter_t maxFactor) 
+{
     counter_t primeCount = 1;    // We already have 2
     for (counter_t factor=1; factor < sieve->bits; factor = searchBitFalse(sieve->bitstorage, factor+1)) {
         primeCount++;
@@ -588,7 +623,8 @@ static counter_t count_primes(struct sieve_t *sieve) {
     return primeCount;
 }
 
-static void deepAnalyzePrimes(struct sieve_t *sieve) {
+static void deepAnalyzePrimes(struct sieve_t *sieve) 
+{
     printf("DeepAnalyzing\n");
     counter_t warn_prime = 0;
     counter_t warn_nonprime = 0;
@@ -610,8 +646,8 @@ static void deepAnalyzePrimes(struct sieve_t *sieve) {
     }
 }
 
-
-int validatePrimeCount(struct sieve_t *sieve, int option_verboselevel) {
+static int validatePrimeCount(struct sieve_t *sieve) 
+{
     counter_t primecount = count_primes(sieve);
     counter_t valid_primes = 0;
     switch(sieve->size) {
@@ -628,24 +664,217 @@ int validatePrimeCount(struct sieve_t *sieve, int option_verboselevel) {
     }
 
     int valid = (valid_primes == primecount);
-    if (valid  && option_verboselevel >= 4) printf("Result: Sievesize %ju is expected to have %ju primes. algorithm produced %ju primes\n",(uintmax_t)sieve->size,(uintmax_t)valid_primes,(uintmax_t)primecount );
-    if (!valid && option_verboselevel >= 1) {
+    verbose(4) if (valid) printf("Result: Sievesize %ju is expected to have %ju primes. algorithm produced %ju primes\n",(uintmax_t)sieve->size,(uintmax_t)valid_primes,(uintmax_t)primecount );
+    verbose(1) if (!valid) {
         printf("No valid result. Sievesize %ju was expected to have %ju primes, but algorithm produced %ju primes\n",(uintmax_t)sieve->size,(uintmax_t)valid_primes,(uintmax_t)primecount );
-        if (!valid && option_verboselevel >= 2) show_primes(sieve, default_show_primes_on_error);
+        verbose(2) show_primes(sieve, default_show_primes_on_error);
+        verbose(2) deepAnalyzePrimes(sieve);
     }
-    if (!valid && option_verboselevel >= 2) deepAnalyzePrimes(sieve);
     return (valid);
 }
 
-void usage(char *name) {
+typedef struct  {
+    counter_t maxFactor;
+    counter_t blocksize_bits;
+    counter_t blocksize_kB;
+    counter_t free_bits;
+    counter_t smallstep_faster;
+    counter_t mediumstep_faster;
+    counter_t vectorstep_faster;
+    counter_t threads;
+    double    sample_duration;
+    counter_t passes;
+    double    elapsed_time;
+    double    avg;
+} tuning_result_t;
+
+int compare_tuning_result(const void *a, const void *b) 
+{
+    tuning_result_t *resultA = (tuning_result_t *)a;
+    tuning_result_t *resultB = (tuning_result_t *)b;
+    return (resultB->avg > resultA->avg ? 1 : -1);
+}
+
+static void benchmark(tuning_result_t* tuning_result) 
+{
+    counter_t passes = 0;
+    double elapsed_time = 0;
+    struct timespec start_time,end_time;
+    struct sieve_t *sieve;
+
+    global_SMALLSTEP_FASTER = tuning_result->smallstep_faster;
+    global_MEDIUMSTEP_FASTER = tuning_result->mediumstep_faster;
+    global_VECTORSTEP_FASTER = tuning_result->vectorstep_faster;
+    double sample_duration = tuning_result->sample_duration;
+
+    clock_gettime(CLOCK_MONOTONIC,&start_time);
+    #ifdef _OPENMP
+    omp_set_num_threads(tuning_result->threads);
+    #pragma omp parallel reduction(+:passes)
+    #endif
+    while (elapsed_time <= sample_duration) {
+        sieve = sieve_shake(tuning_result->maxFactor, tuning_result->blocksize_bits);
+        sieve_delete(sieve);
+        clock_gettime(CLOCK_MONOTONIC,&end_time);
+        elapsed_time = end_time.tv_sec + end_time.tv_nsec*1e-9 - start_time.tv_sec - start_time.tv_nsec*1e-9;
+        passes++;
+    }
+    tuning_result->passes = passes;
+    tuning_result->elapsed_time = elapsed_time;
+    tuning_result->avg = passes/elapsed_time;
+}
+
+static inline void tuning_result_print(tuning_result_t tuning_result) 
+{
+    printf("blocksize_bits %10ju; blocksize %4jukB; free_bits %5ju; small %2ju; medium %2ju; vector %3ju; passes %3ju; time %f/%f;average %f\n", 
+                            (uintmax_t)tuning_result.blocksize_bits, (uintmax_t)tuning_result.blocksize_kB,(uintmax_t)tuning_result.free_bits,
+                            (uintmax_t)tuning_result.smallstep_faster,(uintmax_t)tuning_result.mediumstep_faster,(uintmax_t)tuning_result.vectorstep_faster,
+                            (uintmax_t)tuning_result.passes, tuning_result.elapsed_time, tuning_result.sample_duration, tuning_result.avg);
+}
+
+static tuning_result_t tune(int tune_level, counter_t maxFactor, counter_t threads, counter_t option_blocksize_kB) 
+{
+    counter_t best_blocksize_bits = default_blocksize;
+
+    double best_avg = 0;
+    best_blocksize_bits = 0;
+    counter_t best_smallstep_faster = 0;
+    counter_t best_mediumstep_faster = 0;
+    counter_t best_vectorstep_faster = 0;
+    counter_t smallstep_faster_steps = 4;
+    counter_t mediumstep_faster_steps = 4;
+    counter_t vectorstep_faster_steps = 32;
+    counter_t freebits_steps = anticiped_cache_line_bytesize;
+    double sample_duration = default_sample_duration;
+
+    // determines the size of the resultset
+    switch (tune_level) {
+        case 1:
+            smallstep_faster_steps  = WORD_SIZE/4;
+            mediumstep_faster_steps = WORD_SIZE/4;
+            vectorstep_faster_steps = WORD_SIZE/4;
+            freebits_steps = anticiped_cache_line_bytesize*8*2;
+            sample_duration = 0.001;
+            break;
+        case 2:
+            smallstep_faster_steps  = WORD_SIZE/8;
+            mediumstep_faster_steps = WORD_SIZE/16;
+            vectorstep_faster_steps = WORD_SIZE/4;
+            freebits_steps = anticiped_cache_line_bytesize*8;
+            sample_duration = 0.002;
+            break;
+        case 3:
+            smallstep_faster_steps  = WORD_SIZE/16;
+            mediumstep_faster_steps = WORD_SIZE/16;
+            vectorstep_faster_steps = WORD_SIZE/16;
+            freebits_steps = anticiped_cache_line_bytesize/2;
+            sample_duration = 0.004;
+            break;
+    }
+    
+    verbose(1) { 
+        verbose(2) printf("\n");
+        printf("Tuning..."); 
+        verbose(2) printf(".. best options (shown when found):\n");
+        fflush(stdout);
+    }
+    const size_t max_results = ((size_t)(WORD_SIZE_counter/smallstep_faster_steps)+1) * ((size_t)(WORD_SIZE_counter/mediumstep_faster_steps)+1) * ((size_t)(VECTOR_SIZE_counter/vectorstep_faster_steps)+1) * 32 * (size_t)(anticiped_cache_line_bytesize*8*4/freebits_steps);
+    tuning_result_t* tuning_result = malloc(max_results * sizeof(tuning_result));
+    counter_t tuning_results=0;
+    counter_t tuning_result_index=0;
+    
+    for (counter_t smallstep_faster = 0; smallstep_faster <= 0; smallstep_faster += smallstep_faster_steps) {
+        for (counter_t mediumstep_faster = smallstep_faster; mediumstep_faster <= WORD_SIZE_counter; mediumstep_faster += mediumstep_faster_steps) {
+            for (counter_t vectorstep_faster = mediumstep_faster; vectorstep_faster <= VECTOR_SIZE_counter; vectorstep_faster += vectorstep_faster_steps) {
+                for (counter_t blocksize_kB=256; blocksize_kB>=8; blocksize_kB /= 2) {
+                    for (counter_t free_bits=0; (free_bits < (anticiped_cache_line_bytesize*8*4) && (free_bits < blocksize_kB * 1024 * 8)); free_bits += freebits_steps) {
+
+                        // hack to ovrrule tuning of user setting
+                        if (option_blocksize_kB) { blocksize_kB=option_blocksize_kB; free_bits=0; }
+
+                        counter_t blocksize_bits = (blocksize_kB * 1024 * 8) - free_bits;
+
+                        // set variables
+                        tuning_results++;
+                        tuning_result[tuning_result_index].maxFactor = maxFactor;
+                        tuning_result[tuning_result_index].sample_duration = sample_duration;
+                        tuning_result[tuning_result_index].blocksize_kB = blocksize_kB;
+                        tuning_result[tuning_result_index].free_bits = free_bits;
+                        tuning_result[tuning_result_index].blocksize_bits = blocksize_bits;
+                        tuning_result[tuning_result_index].smallstep_faster = smallstep_faster;
+                        tuning_result[tuning_result_index].mediumstep_faster = mediumstep_faster;
+                        tuning_result[tuning_result_index].vectorstep_faster = vectorstep_faster;
+                        tuning_result[tuning_result_index].threads = threads;
+                        benchmark(&tuning_result[tuning_result_index]);
+
+                        if ( tuning_result[tuning_result_index].avg > best_avg) {
+                            best_avg = tuning_result[tuning_result_index].avg;
+                            best_blocksize_bits = blocksize_bits;
+                            best_smallstep_faster = smallstep_faster;
+                            best_mediumstep_faster = mediumstep_faster;
+                            best_vectorstep_faster = vectorstep_faster;
+                            verbose(2) { printf(".(<)"); tuning_result_print(tuning_result[tuning_result_index]); fflush(stdout); }
+                        }
+                        if (option.verboselevel >= 3) { printf("...."); tuning_result_print(tuning_result[tuning_result_index]); }
+                        tuning_result_index++;
+                        verbose_at(1) { printf("\rTuning...tuning %ju options..in %lf seconds  ",(uintmax_t)tuning_results, (double)tuning_results*sample_duration ); fflush(stdout); }
+                        if (option_blocksize_kB) break;
+                    }
+                    if (option_blocksize_kB) break;
+                }
+            }
+        }
+    }
+    verbose_at(1) { printf("\rTuning...tuned %ju options..",(uintmax_t)tuning_results); }
+    verbose(2) {
+        printf("Finished scan of \033[1;33m%ju\033[0m options. Inital best blocksize: %ju; best smallstep %ju; best mediumstep %ju; best vectorstep %ju\n",(uintmax_t)tuning_results,(uintmax_t)best_blocksize_bits, (uintmax_t)best_smallstep_faster,(uintmax_t)best_mediumstep_faster, (uintmax_t)best_vectorstep_faster);
+        printf("Finding the best option by reevaluating the top options with a longer sample duration.\n");
+    }
+
+    counter_t tuning_results_max = tuning_results; // keep this value for verbose messages
+    for (counter_t step=0; tuning_results>4; step++) {
+        qsort(tuning_result, (size_t)tuning_results, sizeof(tuning_result_t), compare_tuning_result);
+        verbose(2) {
+            tuning_result_index = 0;
+            printf("\r(iteration %1ju) ",(uintmax_t)step); tuning_result_print(tuning_result[tuning_result_index]); fflush(stdout);
+            verbose(3) {
+                for (counter_t tuning_result_index=0; tuning_result_index<min(40,tuning_results); tuning_result_index++) {
+                    printf("..."); tuning_result_print(tuning_result[tuning_result_index]);
+                }
+            }
+        }
+
+        tuning_results = tuning_results / 4;
+        sample_duration *= 2;
+
+        for (counter_t i=0; i<tuning_results; i++) {
+            tuning_result[i].sample_duration = sample_duration;
+            verbose(1) { printf("\rTuning...found %ju options..benchmarking step %ju - tuning %3ju options in %lf seconds",(uintmax_t)tuning_results_max,(uintmax_t)step,i, (double)tuning_results*sample_duration); fflush(stdout); }
+            benchmark(&tuning_result[i]);
+        }
+    }
+
+    // take best result
+    tuning_result_t best_result = tuning_result[0];
+    free(tuning_result);
+    verbose(1) {
+        printf("\33[2K\r");
+        verbose(2) { printf("Best result:  "); tuning_result_print(best_result); printf("\n"); }
+    }
+    return best_result;
+}
+
+void usage(char *name) 
+{
     fprintf(stderr, "Usage: %s [options] [maximum]\n", name);
     fprintf(stderr, "Options:\n");
+    fprintf(stderr, "  --block <kilobyte> Set the block size to a specific <size> in kilobytes\n");
     fprintf(stderr, "  --check            Check the correctness of the algorithm\n");
-    #if option_debuggable
+    #if compile_debuggable
     fprintf(stderr, "  --explain          Explain the steps of the algorithm - only when compiled for debug\n");
     #endif
     fprintf(stderr, "  --help             This help function\n");
-    fprintf(stderr, "  --show <maximum>   Show the primes found up to the maximum\n");
+    fprintf(stderr, "  --show  <maximum>  Show the primes found up to the maximum\n");
     #ifdef _OPENMP
     fprintf(stderr, "  --threads <count>  Set the maximum number of threads to be used (only when compiled for openmp)\n");
     fprintf(stderr, "                     Use 'all' to use all available threads or 'half' for /2 (e.g. for no hyperthreading)\n");
@@ -662,373 +891,224 @@ void usage(char *name) {
     exit(1);
 }
 
-typedef struct  {
-    counter_t maxints;
-    counter_t blocksize_bits;
-    counter_t blocksize_kb;
-    counter_t free_bits;
-    counter_t smallstep_faster;
-    counter_t mediumstep_faster;
-    counter_t vectorstep_faster;
-    counter_t threads;
-    counter_t sample_max;
-    double    sample_duration;
-    counter_t passes;
-    double    elapsed_time;
-    double    avg;
-} tuning_result_type;
-
-int compare_tuning_result(const void *a, const void *b) {
-    tuning_result_type *resultA = (tuning_result_type *)a;
-    tuning_result_type *resultB = (tuning_result_type *)b;
-    return (resultB->avg > resultA->avg ? 1 : -1);
-}
-
-static void tune_benchmark(tuning_result_type* tuning_result, counter_t tuning_result_index) {
-    counter_t passes = 0;
-    double elapsed_time = 0;
-    struct timespec start_time,end_time;
-    struct sieve_t *sieve;
-
-    global_SMALLSTEP_FASTER = tuning_result[tuning_result_index].smallstep_faster;
-    global_MEDIUMSTEP_FASTER = tuning_result[tuning_result_index].mediumstep_faster;
-    global_VECTORSTEP_FASTER = tuning_result[tuning_result_index].vectorstep_faster;
-
-    clock_gettime(CLOCK_MONOTONIC,&start_time);
-    #ifdef _OPENMP
-    omp_set_num_threads(tuning_result[tuning_result_index].threads);
-    #pragma omp parallel reduction(+:passes)
-    #endif
-    while (elapsed_time <= tuning_result[tuning_result_index].sample_duration && passes < tuning_result[tuning_result_index].sample_max) {
-        sieve = sieve_shake(tuning_result[tuning_result_index].maxints, tuning_result[tuning_result_index].blocksize_bits);//blocksize_bits);
-        sieve_delete(sieve);
-        passes++;
-        clock_gettime(CLOCK_MONOTONIC,&end_time);
-        elapsed_time = end_time.tv_sec + end_time.tv_nsec*1e-9 - start_time.tv_sec - start_time.tv_nsec*1e-9;
-    }
-    tuning_result[tuning_result_index].passes = passes;
-    tuning_result[tuning_result_index].elapsed_time = elapsed_time;
-    tuning_result[tuning_result_index].avg = passes/elapsed_time;
-}
-
-static inline void tuning_result_print(tuning_result_type tuning_result) {
-    printf("blocksize_bits %10ju; blocksize %4jukb; free_bits %5ju; small %2ju; medium %2ju; vector %3ju; passes %3ju/%3ju; time %f/%f;average %f\n", 
-                            (uintmax_t)tuning_result.blocksize_bits, (uintmax_t)tuning_result.blocksize_kb,(uintmax_t)tuning_result.free_bits,
-                            (uintmax_t)tuning_result.smallstep_faster,(uintmax_t)tuning_result.mediumstep_faster,(uintmax_t)tuning_result.vectorstep_faster,
-                            (uintmax_t)tuning_result.passes, (uintmax_t) tuning_result.sample_max,
-                            tuning_result.elapsed_time, tuning_result.sample_duration, tuning_result.avg);
-}
-
-static tuning_result_type tune(int tune_level, counter_t maxints, counter_t threads, int option_verboselevel) {
-    counter_t best_blocksize_bits = default_blocksize;
-
-    double best_avg = 0;
-    best_blocksize_bits = 0;
-    counter_t best_smallstep_faster = 0;
-    counter_t best_mediumstep_faster = 0;
-    counter_t best_vectorstep_faster = 0;
-    counter_t smallstep_faster_steps = 4;
-    counter_t mediumstep_faster_steps = 4;
-    counter_t vectorstep_faster_steps = 32;
-    counter_t freebits_steps = anticiped_cache_line_bytesize;
-    counter_t sample_max = default_sample_max;
-    double sample_duration = default_sample_duration;
-
-    // determines the size of the resultset
-    switch (tune_level) {
-        case 1:
-            smallstep_faster_steps  = WORD_SIZE/4;
-            mediumstep_faster_steps = WORD_SIZE/4;
-            vectorstep_faster_steps = WORD_SIZE/4;
-            freebits_steps = anticiped_cache_line_bytesize*8*2;
-            sample_max = 16;
-            sample_duration = 0.1;
-            break;
-        case 2:
-            smallstep_faster_steps  = WORD_SIZE/8;
-            mediumstep_faster_steps = WORD_SIZE/16;
-            vectorstep_faster_steps = WORD_SIZE/4;
-            freebits_steps = anticiped_cache_line_bytesize*8;
-            sample_max = 16;
-            sample_duration = 0.2;
-            break;
-        case 3:
-            smallstep_faster_steps  = WORD_SIZE/16;
-            mediumstep_faster_steps = WORD_SIZE/16;
-            vectorstep_faster_steps = WORD_SIZE/16;
-            freebits_steps = anticiped_cache_line_bytesize/2;
-            sample_max = 16;
-            sample_duration = 0.2;
-            break;
-    }
-    
-    verbose(2) printf("\n");
-    verbose_at(1) { printf("Tuning..."); fflush(stdout); }
-    verbose(2) printf("\n");
-    const size_t max_results = ((size_t)(WORD_SIZE_counter/smallstep_faster_steps)+1) * ((size_t)(WORD_SIZE_counter/mediumstep_faster_steps)+1) * ((size_t)(VECTOR_SIZE_counter/vectorstep_faster_steps)+1) * 32 * (size_t)(anticiped_cache_line_bytesize*8*4/freebits_steps);
-    tuning_result_type* tuning_result = malloc(max_results * sizeof(tuning_result));
-    counter_t tuning_results=0;
-    counter_t tuning_result_index=0;
-    
-    for (counter_t smallstep_faster = 0; smallstep_faster <= 0; smallstep_faster += smallstep_faster_steps) {
-        for (counter_t mediumstep_faster = smallstep_faster; mediumstep_faster <= WORD_SIZE_counter; mediumstep_faster += mediumstep_faster_steps) {
-            for (counter_t vectorstep_faster = mediumstep_faster; vectorstep_faster <= VECTOR_SIZE_counter; vectorstep_faster += vectorstep_faster_steps) {
-                for (counter_t blocksize_kb=256; blocksize_kb>=8; blocksize_kb /= 2) {
-                    for (counter_t free_bits=0; (free_bits < (anticiped_cache_line_bytesize*8*4) && (free_bits < blocksize_kb * 1024 * 8)); free_bits += freebits_steps) {
-                        counter_t blocksize_bits = (blocksize_kb * 1024 * 8) - free_bits;
-
-                        // set variables
-                        tuning_results++;
-                        tuning_result[tuning_result_index].maxints = maxints;
-                        tuning_result[tuning_result_index].sample_duration = sample_duration;
-                        tuning_result[tuning_result_index].sample_max = sample_max;
-                        tuning_result[tuning_result_index].blocksize_kb = blocksize_kb;
-                        tuning_result[tuning_result_index].free_bits = free_bits;
-                        tuning_result[tuning_result_index].blocksize_bits = blocksize_bits;
-                        tuning_result[tuning_result_index].smallstep_faster = smallstep_faster;
-                        tuning_result[tuning_result_index].mediumstep_faster = mediumstep_faster;
-                        tuning_result[tuning_result_index].vectorstep_faster = vectorstep_faster;
-                        tuning_result[tuning_result_index].threads = threads;
-                        tune_benchmark(tuning_result, tuning_result_index);
-
-                        if ( tuning_result[tuning_result_index].avg > best_avg) {
-                            best_avg = tuning_result[tuning_result_index].avg;
-                            best_blocksize_bits = blocksize_bits;
-                            best_smallstep_faster = smallstep_faster;
-                            best_mediumstep_faster = mediumstep_faster;
-                            best_vectorstep_faster = vectorstep_faster;
-                            verbose(2) { printf(".(>)"); tuning_result_print(tuning_result[tuning_result_index]); }
-                        }
-                        if (option_verboselevel >= 3) { printf("...."); tuning_result_print(tuning_result[tuning_result_index]); }
-                        tuning_result_index++;
-                        verbose_at(1) { printf("\rTuning...tuning %ju options..",(uintmax_t)tuning_results); fflush(stdout); }
-                    }
-                }
-            }
-        }
-    }
-    verbose_at(1) { printf("\rTuning...tuned %ju options..",(uintmax_t)tuning_results); }
-    verbose_at(2) { printf("Tuning...tuned %ju options..\n",(uintmax_t)tuning_results); }
-    verbose(2) {
-        printf("%ju options. Inital best blocksize: %ju; best smallstep %ju; best mediumstep %ju; best vectorstep %ju\n",(uintmax_t)tuning_results,(uintmax_t)best_blocksize_bits, (uintmax_t)best_smallstep_faster,(uintmax_t)best_mediumstep_faster, (uintmax_t)best_vectorstep_faster);
-        printf("Best options\n");
-    }
-
-    counter_t step=0;
-    counter_t tuning_results_max = tuning_results;
-    while (tuning_results>4) {
-        qsort(tuning_result, (size_t)tuning_results, sizeof(tuning_result_type), compare_tuning_result);
-        step++;
-        verbose(2) {
-            tuning_result_index = 0;
-            printf("(%ju) ",(uintmax_t)step); tuning_result_print(tuning_result[tuning_result_index]);
-            fflush(stdout);
-            verbose(3) {
-                for (counter_t tuning_result_index=0; tuning_result_index<min(40,tuning_results); tuning_result_index++) {
-                    printf("..."); tuning_result_print(tuning_result[tuning_result_index]);
-                }
-            }
-        }
-
-        tuning_results = tuning_results / 2;
-
-        for (counter_t i=0; i<tuning_results; i++) {
-            verbose(1) { printf("\rTuning...found %ju options..benchmarking step %ju - tuning %3ju options",(uintmax_t)tuning_results_max,(uintmax_t)step,i); fflush(stdout); }
-            tune_benchmark(tuning_result, i);
-            tuning_result[i].sample_max += sample_max;
-            tuning_result[i].sample_duration += 0.05;
-        }
-        verbose(2) printf("\n");
-        
-    }
-    tuning_result_type best_result = tuning_result[0];
-    verbose(2) {
-        printf(".Best result:"); tuning_result_print(best_result);
-    }
-    verbose(1) printf("\n");
-
-    free(tuning_result);
-    return best_result;
-}
-
-
-int main(int argc, char *argv[]) {
-    
-    // initialize options
-    double option_max_time = default_max_time;
-    counter_t option_maxFactor  = default_sieve_limit;
-    counter_t option_showMaxFactor = default_showMaxFactor;
-    int option_verboselevel = default_verbose_level;
-    int option_check = default_check_level;
-    int option_tunelevel = default_tune_level;
-    int option_threads = 1;
-    #ifdef _OPENMP
-    int max_threads = omp_get_max_threads();
-    option_threads = max_threads;
-    #endif
-
+struct options_t parseCommandLine(int argc, char *argv[], struct options_t option)
+{
     // processing command line changes to options
     for (int arg=1; arg < argc; arg++) {
         if (strcmp(argv[arg], "--help")==0) { usage(argv[0]); }
         else if (strcmp(argv[arg], "--verbose")==0) {
             if (++arg >= argc) { fprintf(stderr, "No verbose level specified\n"); usage(argv[0]); }
-            if (sscanf(argv[arg], "%d", &option_verboselevel) != 1 || option_verboselevel > 4) {
+            if (sscanf(argv[arg], "%d", &option.verboselevel) != 1 || option.verboselevel > 4) {
                 fprintf(stderr, "Error: Invalid measurement time: %s\n", argv[arg]); usage(argv[0]);
             }
-            verbose(1) printf("Verbose level set to %d\n",option_verboselevel);
+            verbose(1) printf("Verbose level set to %d\n",option.verboselevel);
         } 
-        #if option_debuggable
-        else if (strcmp(argv[arg], "--explain")==0) { global_option_explain=1; }
+        else if (strcmp(argv[arg], "--block")==0) {
+            if (++arg >= argc) { fprintf(stderr, "No block size specified\n"); usage(argv[0]); }
+            if (sscanf(argv[arg], "%ju", &option.blocksize_kB) != 1) {
+                fprintf(stderr, "Error: Invalid size in kilobyte: %s\n", argv[arg]); usage(argv[0]);
+            }
+            counter_t sieve_bits = option.maxFactor >> 1;
+            if ((option.blocksize_kB*1024*8) > (sieve_bits)) option.blocksize_kB = (sieve_bits / (1024*8))+1;
+            verbose(1) printf("Blocksize set to %ju kB\n",option.blocksize_kB);
+        } 
+        #if compile_debuggable
+        else if (strcmp(argv[arg], "--explain")==0) { option.explain=1; }
         #endif
-        else if (strcmp(argv[arg], "--check")==0) { option_check=1; }
-        else if (strcmp(argv[arg], "--nocheck")==0) { option_check=0; }
-        else if (strcmp(argv[arg], "--tune")==0) { option_tunelevel=0;
+        else if (strcmp(argv[arg], "--check")==0) { option.check=1; }
+        else if (strcmp(argv[arg], "--nocheck")==0) { option.check=0; }
+        else if (strcmp(argv[arg], "--tune")==0) { option.tunelevel=0;
             if (++arg >= argc) { fprintf(stderr, "No tune level specified\n"); usage(argv[0]); }
-            if (sscanf(argv[arg], "%d", &option_tunelevel) != 1 || option_tunelevel > 4) {
+            if (sscanf(argv[arg], "%d", &option.tunelevel) != 1 || option.tunelevel > 4) {
                 fprintf(stderr, "Error: Invalid tune level: %s\n", argv[arg]); usage(argv[0]);
             }
-            verbose(1) printf("Tune level set to %d\n",option_tunelevel);
+            verbose(1) printf("Tune level set to %d\n",option.tunelevel);
         }
-        else if (strcmp(argv[arg], "--time")==0) { option_max_time=0;
+        else if (strcmp(argv[arg], "--time")==0) { option.maxTime=0;
             if (++arg >= argc) { fprintf(stderr, "No time specified\n"); usage(argv[0]); }
-            if (sscanf(argv[arg], "%lf", &option_max_time) != 1 ) {
+            if (sscanf(argv[arg], "%lf", &option.maxTime) != 1 ) {
                 fprintf(stderr, "Error: Invalid max time: %s\n", argv[arg]); usage(argv[0]);
             }
-            verbose(1) printf("Max time is set to %d seconds\n",option_tunelevel);
+            verbose(1) printf("Max time is set to %d seconds\n",option.tunelevel);
         }
-        else if (strcmp(argv[arg], "--show")==0) { option_showMaxFactor=0;
+        else if (strcmp(argv[arg], "--show")==0) { option.showMaxFactor=0;
             if (++arg >= argc) { fprintf(stderr, "No show maximum specified\n"); usage(argv[0]); }
-            if (sscanf(argv[arg], "%ju", (uintmax_t*)&option_showMaxFactor) != 1 || option_showMaxFactor > option_maxFactor) {
+            if (sscanf(argv[arg], "%ju", (uintmax_t*)&option.showMaxFactor) != 1 || option.showMaxFactor > option.maxFactor) {
                 fprintf(stderr, "Error: Invalid show maximum: %s\n", argv[arg]); usage(argv[0]);
             }
-            verbose(1) printf("Show maximum set to %ju\n",(uintmax_t)option_showMaxFactor);
+            verbose(1) printf("Show maximum set to %ju\n",(uintmax_t)option.showMaxFactor);
         }
         else if (strcmp(argv[arg], "--threads")==0) { 
             if (++arg >= argc) { fprintf(stderr, "No thread maximum specified\n"); usage(argv[0]); }
         #ifdef _OPENMP
-            if (strcmp(argv[arg], "all")==0) option_threads = max_threads;
-            else if (strcmp(argv[arg], "half")==0) option_threads = max_threads>>1;
-            else if (sscanf(argv[arg], "%d", &option_threads) != 1 ) { fprintf(stderr, "Error: Invalid max threads: %s\n", argv[arg]); usage(argv[0]); }
-            if (option_threads <1)  option_threads = 1;
-            if (option_threads > max_threads)  option_threads = max_threads;
-            verbose(1) printf("Thread maximum set to %ju\n",(uintmax_t)option_threads);
+            int max_threads = omp_get_max_threads();
+            if (strcmp(argv[arg], "all")==0) option.threads = max_threads;
+            else if (strcmp(argv[arg], "half")==0) option.threads = max_threads>>1;
+            else if (sscanf(argv[arg], "%d", &option.threads) != 1 ) { fprintf(stderr, "Error: Invalid max threads: %s\n", argv[arg]); usage(argv[0]); }
+            if (option.threads <1)  option.threads = 1;
+            if (option.threads > max_threads)  option.threads = max_threads;
+            verbose(1) printf("Thread maximum set to %ju\n",(uintmax_t)option.threads);
         #else
             verbose(1) printf("This is the version without multithreading - ignoring threads\n");
         #endif
         }
-        else if (sscanf(argv[arg], "%ju", (uintmax_t*)&option_maxFactor) != 1) {
+        else if (sscanf(argv[arg], "%ju", (uintmax_t*)&option.maxFactor) != 1) {
             fprintf(stderr, "Invalid size %s\n",argv[arg]); usage(argv[0]); 
-            printf("Maximum set to %ju\n",(uintmax_t)option_maxFactor);
+            printf("Maximum set to %ju\n",(uintmax_t)option.maxFactor);
         }
-    }
 
-    // for debugging
-    #if option_debuggable
-    if (global_option_explain) { // used for stats and debugging
-        struct sieve_t* sieve = sieve_shake(option_maxFactor, default_blocksize);
-        printf("\nResult set:\n");
-        show_primes(sieve, option_showMaxFactor);
-        int valid = validatePrimeCount(sieve,3);
-        if (!valid) printf("The sieve is NOT valid...\n");
-        else printf("The sieve is VALID\n");
-        sieve_delete(sieve);
-        exit(0);
-    }
-    #endif
-
-    // command line --check can be used to check the algorithm for all sieve/blocksize combinations
-    if (option_check) {
-        // Count the number of primes and validate the result
-        verbose(1) { printf("Validating..."); fflush(stdout); }
-        verbose(2) printf("\n");
-
-        // validate algorithm - run one time for all sizes
-        for (counter_t sieveSize_check = 100; sieveSize_check <= 10000000; sieveSize_check *=10) {
-            verbose(2) { printf("...Checking size %ju ...",(uintmax_t)sieveSize_check); fflush(stdout); }
-            struct sieve_t *sieve_check;
-            for (counter_t blocksize_bits=1024; blocksize_bits<=256*1024*8; blocksize_bits *= 2) {
-                verbose(3) printf(".blocksize %ju-",(uintmax_t)blocksize_bits);
-                sieve_check = sieve_shake(sieveSize_check, blocksize_bits);
-                int valid = validatePrimeCount(sieve_check,option_verboselevel);
-                sieve_delete(sieve_check);
-                if (!valid) {
-                    printf("Settings used: blocksize %ju, %ju/%ju/%ju\n",blocksize_bits,global_SMALLSTEP_FASTER,global_MEDIUMSTEP_FASTER,global_VECTORSTEP_FASTER);
-                    return 0; 
-                }
-                else verbose(3) printf("valid;");
-            }
-            verbose(2) printf("valid\n");
+        counter_t sieve_bits = option.maxFactor >> 1;
+        if ((option.blocksize_kB*1024*8) > (sieve_bits)) {
+            option.blocksize_kB = (sieve_bits / (1024*8))+1;
+            verbose(1) printf("Blocksize corrected to %ju kB\n",option.blocksize_kB);
         }
-        verbose(1) printf("valid algorithm\n");
-    }
-    
-    // tuning - try combinations of different settings and apply these
-    counter_t best_blocksize_bits = default_blocksize;
-    if (option_tunelevel) {
-        tuning_result_type tuning_result = tune(option_tunelevel, option_maxFactor, option_threads, option_verboselevel);
-        global_SMALLSTEP_FASTER = tuning_result.smallstep_faster;
-        global_MEDIUMSTEP_FASTER = tuning_result.mediumstep_faster;
-        global_VECTORSTEP_FASTER = tuning_result.vectorstep_faster;
-        best_blocksize_bits = tuning_result.blocksize_bits;
-    }
 
-    // time the algorithm using the best settings
-    struct timespec start_time,end_time;
-    counter_t used_threads = 1;
+    }
+    return option;
+}
 
-    // this section will only by linked in if the -fopenmp option is used.
-    // will default to max threads and then device by 2 for a non-hyperthreading option
+struct options_t setDefaultOptions() {
+    option.maxTime      = default_maxTime;
+    option.maxFactor     = default_sieve_limit;
+    option.showMaxFactor = default_showMaxFactor;
+    option.verboselevel  = default_verbose_level;
+    option.explain       = 0;
+    option.check         = default_check_level;
+    option.tunelevel     = default_tune_level;
+    option.threads       = 1;
+    option.blocksize_kB  = 0; // this is what the user entered
     #ifdef _OPENMP
-    counter_t max_tries = 4;
-    for(counter_t threads=option_threads; threads>=1; threads= (threads>>1)  ) {
-        omp_set_num_threads(threads);
-        used_threads=threads;
-        if (--max_tries ==1) threads = 2;
+    option.threads = omp_get_max_threads();
     #endif
+
+    return option;
+}
+
+#if compile_debuggable
+void explainSieveShake() 
+{
+    struct sieve_t* sieve = sieve_shake(option.maxFactor, default_blocksize);
+    printf("\nResult set:\n");
+    show_primes(sieve, option.showMaxFactor);
+    int valid = validatePrimeCount(sieve,3);
+    if (!valid) printf("The sieve is NOT valid...\n");
+    else printf("The sieve is VALID\n");
+    sieve_delete(sieve);
+    exit(0);
+}
+#endif
+
+void checkSieveAlgorithm()
+{
+    verbose(1) { 
+        printf("Validating..."); 
         verbose(2) printf("\n");
-        verbose(1) printf("Benchmarking... with blocksize %ju steps: %ju/%ju/%ju and %ju threads for %.1f seconds - Results:\n", (uintmax_t)best_blocksize_bits,(uintmax_t)global_SMALLSTEP_FASTER, (uintmax_t)global_MEDIUMSTEP_FASTER,(uintmax_t)global_VECTORSTEP_FASTER,(uintmax_t)used_threads,option_max_time );
-        counter_t blocksize_bits = best_blocksize_bits;
+        fflush(stdout); 
+    }
+
+    // validate algorithm - run one time for all sizes
+    for (counter_t sieveSize_check = 100; sieveSize_check <= 10000000; sieveSize_check *=10) {
+        verbose(2) {
+            printf("..Checking size %ju ...",(uintmax_t)sieveSize_check); 
+            verbose(3) printf("\n");
+            fflush(stdout); 
+        }
+        struct sieve_t *sieve_check;
+        for (counter_t blocksize_bits=1024; blocksize_bits<=256*1024*8; blocksize_bits *= 2) {
+            verbose(3) printf("....Blocksize %ju:",(uintmax_t)blocksize_bits);
+            sieve_check = sieve_shake(sieveSize_check, blocksize_bits);
+            int valid = validatePrimeCount(sieve_check);
+            sieve_delete(sieve_check);
+            if (!valid) {
+                printf("Settings used: blocksize %ju, %ju/%ju/%ju\n",blocksize_bits,global_SMALLSTEP_FASTER,global_MEDIUMSTEP_FASTER,global_VECTORSTEP_FASTER);
+                exit(1); 
+            }
+            else verbose(3) printf("valid\n");
+        }
+        verbose(2) printf("valid\n");
+    }
+    verbose(1) printf("valid algorithm\n");
+}
+
+int main(int argc, char *argv[]) 
+{
+    option = setDefaultOptions();
+    option = parseCommandLine(argc, argv, option);
+    
+    verbose(1) {
+        printf("\nRunning sieve algorithm by Rogier van Dam with the following target:\n");
+        printf("Count all primes up to \033[1;33m%ju\033[0m using the sieve of Eratosthenes\n", option.maxFactor);
+        printf("\n");
+    }
+
+    #if compile_debuggable
+    if (option.explain) explainSieveShake();
+    #endif
+    
+    // command line --check can be used to check the algorithm for all sieve/blocksize combinations
+    if (option.check) checkSieveAlgorithm(); 
+
+    tuning_result_t benchmark_result;
+    benchmark_result.sample_duration   = option.maxTime;
+    benchmark_result.blocksize_bits    = global_BLOCKSIZE_BITS;
+    benchmark_result.smallstep_faster  = global_SMALLSTEP_FASTER;
+    benchmark_result.mediumstep_faster = global_MEDIUMSTEP_FASTER;
+    benchmark_result.vectorstep_faster = global_VECTORSTEP_FASTER; 
+    benchmark_result.maxFactor = option.maxFactor;
+
+    // tuning - try combinations of different settings and apply these
+    if (option.tunelevel) { 
+        tuning_result_t tuning_result = tune(option.tunelevel, option.maxFactor, option.threads, option.blocksize_kB);
+        benchmark_result.smallstep_faster  = tuning_result.smallstep_faster;
+        benchmark_result.mediumstep_faster = tuning_result.mediumstep_faster;
+        benchmark_result.vectorstep_faster = tuning_result.vectorstep_faster;
+        benchmark_result.blocksize_bits    = tuning_result.blocksize_bits;
+    }
+
+    if (option.blocksize_kB) benchmark_result.blocksize_bits = option.blocksize_kB*1024*8; // overrule all settings with user specified blocksize
+
+    for(counter_t threads=option.threads; threads >= 1; threads = (threads>>1) ) {
+        verbose(1) {
+            printf("Benchmarking... with blocksize %ju steps: %ju/%ju/%ju and %ju threads for %.1f seconds - Results: (wait %.1lf seconds)...\n", 
+                  (uintmax_t)benchmark_result.blocksize_bits,(uintmax_t)benchmark_result.smallstep_faster, (uintmax_t)benchmark_result.mediumstep_faster, (uintmax_t)benchmark_result.vectorstep_faster, (uintmax_t)threads, benchmark_result.sample_duration, benchmark_result.sample_duration );
+            fflush(stdout);
+        }
 
         // one last check to make sure this is a valid algorithm for these settings
-        struct sieve_t* sieve_check = sieve_shake(option_maxFactor, blocksize_bits);
-        int valid = validatePrimeCount(sieve_check,option_verboselevel);
+        struct sieve_t* sieve_check = sieve_shake(benchmark_result.maxFactor, global_BLOCKSIZE_BITS);
+        int valid = validatePrimeCount(sieve_check);
         sieve_delete(sieve_check);
-        if (!valid) {
-            verbose(1) printf("The sieve is not valid for these settings\n");
-            return 0; 
-        }
-        else verbose(3) printf("valid;");
+        if (!valid) { fprintf(stderr, "The sieve is not valid for these settings\n"); exit(1); }
+        else verbose(3) printf("valid;\n");
 
-        counter_t passes = 0;
-        double elapsed_time = 0;
-        struct sieve_t *sieve;
-        clock_gettime(CLOCK_MONOTONIC,&start_time);
+        // prepare for a clean result
+        benchmark_result.threads = threads;
+        benchmark_result.elapsed_time = 0;
+        benchmark_result.passes = 0;
+        benchmark_result.avg = 0;
+
+        // perform benchmark
+        benchmark(&benchmark_result);
+
+        // report results
         #ifdef _OPENMP
-        #pragma omp parallel reduction(+:passes)
-        #endif
-        for (;elapsed_time <= option_max_time;) {
-            sieve = sieve_shake(option_maxFactor, blocksize_bits);//blocksize_bits);
-            sieve_delete(sieve);
-            passes++;
-            clock_gettime(CLOCK_MONOTONIC,&end_time);
-            elapsed_time = end_time.tv_sec + end_time.tv_nsec*1e-9 - start_time.tv_sec - start_time.tv_nsec*1e-9;
-        }
-        #ifdef _OPENMP
-        printf("rogiervandam_extend_epar;%ju;%f;%ju;algorithm=other,faithful=yes,bits=1\n", (uintmax_t)passes,elapsed_time,(uintmax_t)used_threads);
+        printf("rogiervandam_extend_epar;%ju;%f;%ju;algorithm=other,faithful=yes,bits=1\n", (uintmax_t)benchmark_result.passes,benchmark_result.elapsed_time,(uintmax_t)threads);
         #else
-        printf("rogiervandam_extend;%ju;%f;%ju;algorithm=other,faithful=yes,bits=1\n", (uintmax_t)passes,elapsed_time,(uintmax_t)used_threads);
+        printf("rogiervandam_extend;%ju;%f;%ju;algorithm=other,faithful=yes,bits=1\n", (uintmax_t)benchmark_result.passes,benchmark_result.elapsed_time,(uintmax_t)threads);
         #endif
-        verbose(1) printf("\033[0;32m(Passes - per %.1f seconds: %f - per second \033[1;33m%.1f\033[0;32m)\033[0m\n", option_max_time, option_max_time*passes/elapsed_time, passes/elapsed_time);
-        verbose(1) if (used_threads>1) printf("\033[0;32m(Passes per thread (total %ju) - per %.1f seconds: %.1f - per second \033[1;33m%.1f\033[0;32m)\033[0m\n", (uintmax_t)used_threads,  option_max_time, option_max_time*passes/elapsed_time/used_threads, passes/elapsed_time/used_threads);
-    #ifdef _OPENMP
+        verbose(1) {
+            printf("\033[0;32m(Passes - per %.1f seconds: \033[1;33m%f\033[0m - per second \033[1;33m%.1f\033[0;32m)\033[0m\n", option.maxTime, option.maxTime*benchmark_result.passes/benchmark_result.elapsed_time, benchmark_result.passes/benchmark_result.elapsed_time);
+            if (threads>1) printf("\033[0;32m(Passes per thread (total %ju) - per %.1f seconds: %.1f - per second \033[1;33m%.1f\033[0;32m)\033[0m\n", 
+                                 (uintmax_t)threads,  option.maxTime, option.maxTime*benchmark_result.passes/benchmark_result.elapsed_time/threads, benchmark_result.passes/benchmark_result.elapsed_time/threads);
+            fflush(stdout);
+        }
     }
-    #endif
 
     // show results for --show command line option
-    if (option_showMaxFactor > 0) {
+    if (option.showMaxFactor > 0) {
         printf("Show result set:\n");
-        struct sieve_t* sieve = sieve_shake(option_maxFactor, option_maxFactor);
-        show_primes(sieve, option_showMaxFactor);
+        struct sieve_t* sieve = sieve_shake(option.maxFactor, option.maxFactor);
+        show_primes(sieve, option.showMaxFactor);
         sieve_delete(sieve);
     }
 }

--- a/PrimeC/solution_5/sieve_extend.c
+++ b/PrimeC/solution_5/sieve_extend.c
@@ -498,6 +498,9 @@ static struct block sieve_block_extend(struct sieve_t *sieve, const counter_t bl
         else if (step < VECTORSTEP_FASTER) setBitsTrue_largeRange_vector(bitstorage, start, step, range_stop);
         else                               setBitsTrue_largeRange(bitstorage, start, step, range_stop);
         block.prime = prime;
+
+        if (bitstorage[wordindex(2291)] & markmask_calc(2291)) { printf("Block_extend at prime %ju blocksize %ju\n",(uintmax_t)prime,(uintmax_t)block_stop); exit(0); }
+
     } 
 
     return block;

--- a/PrimeC/solution_5/sieve_extend.c
+++ b/PrimeC/solution_5/sieve_extend.c
@@ -13,9 +13,6 @@
 #include <omp.h>
 #endif
 
-int debuginfo[100];
-int debuginfo2[100];
-
 //set compile_debuggable to 1 to enable explain plan
 #define compile_debuggable 0
 #if compile_debuggable
@@ -154,10 +151,9 @@ static inline counter_t __attribute__((always_inline)) searchBitFalse(bitword_t*
             + (((bitword& 3)+1)>>2) // fast track for larger intervals
             + (((bitword& 7)+1)>>3) // account for that this also matches smaller ranges
             + (((bitword&15)+1)>>4) // account for that this also matches smaller ranges
-            // + (((bitword&31)+1)>>5) // account for that this also matches smaller ranges
             ;
 
-    // reset for the new index, because we could also be at a word bound at the previous step
+    // reset to the new index, because we could also be at a word bound at the previous step
     bitword = bitstorage[wordindex(index)] >> bitindex(index);
     if ((bitword & 1)==0) return index; // fast exit if we are done
 

--- a/PrimeC/solution_5/sieve_extend.c
+++ b/PrimeC/solution_5/sieve_extend.c
@@ -33,7 +33,7 @@ int debuginfo2[100];
 #define default_sample_duration 0.001
 #define default_explain_level 0
 #define default_verbose_level 0
-#define default_tune_level 0
+#define default_tune_level 1
 #define default_check_level 1
 #define default_show_primes_on_error 100
 #define default_showMaxFactor (0 || compile_debuggable?100:0)

--- a/PrimeC/solution_5/sieve_extend.c
+++ b/PrimeC/solution_5/sieve_extend.c
@@ -449,6 +449,8 @@ static void sieve_block_stripe(bitword_t* bitstorage, const counter_t block_star
             prime = searchBitFalse_longRange(bitstorage, prime+1 );
         }
 
+        if (bitstorage[wordindex(2291)] & markmask_calc(2291)) { printf("Block_stripe!"); exit(0); }
+
         step  = prime * 2 + 1;
     }
 }

--- a/PrimeC/solution_5/sieve_extend.c
+++ b/PrimeC/solution_5/sieve_extend.c
@@ -916,7 +916,11 @@ int main(int argc, char *argv[]) {
                 sieve_check = sieve_shake(sieveSize_check, blocksize_bits);
                 int valid = validatePrimeCount(sieve_check,option_verboselevel);
                 sieve_delete(sieve_check);
-                if (!valid) return 0; else verbose(3) printf("valid;");
+                if (!valid) {
+                    printf("Settings used: blocksize %ju, %ju/%ju%ju\n",blocksize_bits,global_SMALLSTEP_FASTER,global_MEDIUMSTEP_FASTER,global_VECTORSTEP_FASTER);
+                    return 0; 
+                }
+                else verbose(3) printf("valid;");
             }
             verbose(2) printf("valid\n");
         }

--- a/PrimeC/solution_5/sieve_extend.c
+++ b/PrimeC/solution_5/sieve_extend.c
@@ -1,479 +1,459 @@
-// Serial code prime sieve by Rogier van Dam
+// Sieve algorithm by Rogier van Dam - 2022
+// Find all primes up to <max int> using the Sieve of Eratosthenes (https://en.wikipedia.org/wiki/Sieve_of_Eratosthenes)
+
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
 #include <time.h>
 #include <math.h>
 #include <string.h>
+#ifdef _OPENMP
+#include <omp.h>
+#endif
 
-#define debug if (0)
+//add debug in front of a line to only compile it if the value below is set to 1 (or !=0)
+#define option_runonce 0
+#define debug if (option_runonce)
+#define verbose(level) if (option_verboselevel >= level)
+#define verbose_at(level) if (option_verboselevel == level)
+
+// defaults
 #define default_sieve_limit 1000000
-#define default_blocksize (30*1024*8)
-#define default_sieve_duration 5
+#define default_blocksize (32*1024*8)
+#define default_max_time 5
 #define default_sample_duration 0.1
 #define default_sample_max 5
 #define default_verbose_level 0
 #define default_tune_level 1
-#define default_check_level 0
-#define option_runonce 0
-
+#define default_check_level 1
+#define default_show_primes_on_error 100
+#define default_showMaxFactor (0 || option_runonce?100:0)
 #define anticiped_cache_line_bytesize 128
 
-// 64 bit
-#define TYPE uint64_t
+// helper functions
+#define pow(base,pow) (pow*((base>>pow)&1U))
+#define min(a,b) ((a<b) ? a : b)
+#define uintsafeminus(a,b) ((a>b)?(a-b):0)
+#define likely(x)       (__builtin_expect((x),1))
+#define unlikely(x)     (__builtin_expect((x),0))
 
-// calculate the rest dynamically
-#define counter_t int64_t
-#define bitword_t TYPE
+// types
+#define bitword_t uint64_t
+#define TYPE uint64_t
+#define counter_t TYPE
 #define bitshift_t TYPE
 
-#define WORD_SIZE (sizeof(TYPE)*8)
-#define pow(base,pow) (pow*((base>>pow)&1U))
-#define SHIFT ((bitshift_t)(pow(WORD_SIZE,1)+pow(WORD_SIZE,2)+pow(WORD_SIZE,3)+pow(WORD_SIZE,4)+pow(WORD_SIZE,5)+pow(WORD_SIZE,6)+pow(WORD_SIZE,7)+pow(WORD_SIZE,8)))
+// masks and mask helpers
+#define WORD_SIZE (sizeof(bitword_t)*8)
+#define WORD_SIZE_counter ((counter_t)WORD_SIZE)
+#define WORD_SIZE_bitshift ((bitshift_t)WORD_SIZE)
+#define SHIFT_WORD ((bitshift_t)(pow(WORD_SIZE,1)+pow(WORD_SIZE,2)+pow(WORD_SIZE,3)+pow(WORD_SIZE,4)+pow(WORD_SIZE,5)+pow(WORD_SIZE,6)+pow(WORD_SIZE,7)+pow(WORD_SIZE,8)+pow(WORD_SIZE,9)+pow(WORD_SIZE,10)))
+#define VECTOR_ELEMENTS 4
+#define VECTOR_SIZE_bytes (sizeof(bitword_t)*VECTOR_ELEMENTS)
+#define VECTOR_SIZE_counter ((counter_t)VECTOR_SIZE_bytes*8)
+#define VECTOR_SIZE (VECTOR_SIZE_bytes*8)
+#define SHIFT_VECTOR ((bitshift_t)(pow(VECTOR_SIZE,1)+pow(VECTOR_SIZE,2)+pow(VECTOR_SIZE,3)+pow(VECTOR_SIZE,4)+pow(VECTOR_SIZE,5)+pow(VECTOR_SIZE,6)+pow(VECTOR_SIZE,7)+pow(VECTOR_SIZE,8)+pow(VECTOR_SIZE,9)+pow(VECTOR_SIZE,10)))
+
+// types (II) - calculated
+typedef bitword_t bitvector_t __attribute__ ((vector_size(VECTOR_SIZE_bytes)));
 
 // globals for tuning
-counter_t global_SMALLSTEP_FASTER = WORD_SIZE/4;
-counter_t global_MEDIUMSTEP_FASTER = WORD_SIZE;
-
-#define SAFE_SHIFTBIT (bitword_t)1U
-#define SAFE_ZERO  (bitword_t)0U
+// #define SMALLSTEP_FASTER ((counter_t)0)
+// #define MEDIUMSTEP_FASTER ((counter_t)16)
+// #define VECTORSTEP_FASTER ((counter_t)128)
+counter_t global_SMALLSTEP_FASTER = 0;
+counter_t global_MEDIUMSTEP_FASTER = 32;
+counter_t global_VECTORSTEP_FASTER = 96;
 #define SMALLSTEP_FASTER ((counter_t)global_SMALLSTEP_FASTER)
 #define MEDIUMSTEP_FASTER ((counter_t)global_MEDIUMSTEP_FASTER)
-#define wordindex(index) (((counter_t)index) >> (bitshift_t)SHIFT)
-#define bitindex(index) (((counter_t)index)&((bitword_t)(WORD_SIZE-1)))
-#define  markmask(index) (SAFE_SHIFTBIT << bitindex(index))
-#define chopmask(index) ((SAFE_SHIFTBIT << bitindex(index))-SAFE_SHIFTBIT)
-#define chopmask2(index) (((bitword_t)2U << bitindex(index))-SAFE_SHIFTBIT)
-#define min(a,b) ((a<b) ? a : b)
+#define VECTORSTEP_FASTER ((counter_t)global_VECTORSTEP_FASTER)
 
-struct sieve_state {
-    bitword_t* bitarray;
+// Patterns based on types
+#define SAFE_SHIFTBIT (bitshift_t)1U
+#define SAFE_ZERO  (bitword_t)0U
+#define BITWORD_SHIFTBIT (bitword_t)1U
+#define WORDMASK ((~SAFE_ZERO)>>(WORD_SIZE_bitshift-SHIFT_WORD))
+#define VECTORMASK ((~SAFE_ZERO)>>(WORD_SIZE_bitshift-SHIFT_VECTOR))
+
+// helpder functions for word/vector indexing
+#define wordindex(index) (((counter_t)index) >> (bitshift_t)SHIFT_WORD)
+#define wordend(index) ((counter_t)index|WORDMASK)
+#define wordstart(index) ((counter_t)(index)&(counter_t)(~WORDMASK))
+#define vectorindex(index) (((counter_t)index) >> (bitshift_t)SHIFT_VECTOR)
+#define vectorstart(index) (((counter_t)index) & (counter_t)~VECTORMASK)
+#define vectorfromword(word) ((counter_t)(word)>>(SHIFT_VECTOR-SHIFT_WORD))
+#define wordinvector(index) ((counter_t)(index) & (counter_t)VECTORMASK)
+
+// modern processors do a & over the shiftssize, so we only have to do that ourselve when using the shiftsize in calculations. 
+#define bitindex(index) ((bitshift_t)(index))
+#define bitindex_calc(index) ((bitshift_t)(index)&((bitshift_t)(WORDMASK)))
+#define markmask(index) (BITWORD_SHIFTBIT << bitindex(index))
+#define markmask_calc(index) (BITWORD_SHIFTBIT << bitindex_calc(index))
+// #define chopmask(index) ((SAFE_SHIFTBIT << bitindex(index))-SAFE_SHIFTBIT)
+#define chopmask(index) (~SAFE_ZERO >> (WORD_SIZE-1-bitindex_calc(index)))
+#define keepmask(index) (~SAFE_ZERO << (bitindex_calc(index)))
+
+struct sieve_t {
+    bitword_t* bitstorage;
     counter_t  bits;
     counter_t  size;
 };
 
+//#include "debugtools.h"
+
 // use cache lines as much as possible - alignment might be key
+// moved clearing the sieve with 0 to the sieve_block_extend - it gave weird malloc problems at this point
 #define ceiling(x,y) (((x) + (y) - 1) / (y)) // Return the smallest multiple N of y such that:  x <= y * N
-static struct sieve_state *create_sieve(counter_t maxints) {
-    struct sieve_state *sieve = malloc(sizeof *sieve);//aligned_alloc(8, sizeof(struct sieve_state));
-    size_t memSize = ceiling(1+((size_t)maxints/2), anticiped_cache_line_bytesize*8) * anticiped_cache_line_bytesize; //make multiple of 8
-
-    sieve->bitarray = aligned_alloc((size_t)anticiped_cache_line_bytesize, (size_t)memSize );
-    sieve->bits     = maxints >> SAFE_SHIFTBIT;
-    sieve->size     = maxints;
-
-    // moved clearing the sieve with 0 to the sieve_block_extend
-    // it gave weird malloc problems at this point
+static struct sieve_t *sieve_create(counter_t size) {
+    struct sieve_t *sieve = aligned_alloc(8, sizeof(struct sieve_t));
+    sieve->bitstorage = aligned_alloc((size_t)anticiped_cache_line_bytesize, (size_t)ceiling(1+((size_t)size>>1), anticiped_cache_line_bytesize<<3) * anticiped_cache_line_bytesize );
+    sieve->bits     = size >> 1;
+    sieve->size     = size;
     return sieve;
 }
 
-static void delete_sieve(struct sieve_state *sieve) {
-    free(sieve->bitarray);
+static void sieve_delete(struct sieve_t *sieve) {
+    free(sieve->bitstorage);
     free(sieve);
 }
 
-// not much performance gain at smaller sieves, but its's nice to have an implementation
-static inline counter_t searchBitFalse(struct sieve_state *sieve, counter_t index) {
-    counter_t index_word = wordindex(index);
-    bitshift_t index_bit  = bitindex(index);
-    counter_t distance = (counter_t) __builtin_ctzll( ~(sieve->bitarray[index_word] >> index_bit));  // take inverse to be able to use ctz
-    index += distance;
-    distance += index_bit;
-
-    while (distance >= WORD_SIZE) {
-        index_word++;
-        distance = __builtin_ctzll(~(sieve->bitarray[index_word]));
-        index += distance;
-    }
-
+// search the next bit not set - for small expected distances
+static inline counter_t searchBitFalse(bitword_t* bitstorage, register counter_t index) {
+    while (bitstorage[wordindex(index)] & markmask(index)) index++;
     return index;
 }
 
-static void inline applyMask(struct sieve_state *sieve, const counter_t range_start_word, const counter_t step, const counter_t range_stop, const bitword_t mask) {
-    const counter_t range_stop_word = wordindex(range_stop);
-    counter_t index_word = range_start_word;
+// not much performance gain at smaller sieves, but its's nice to have an implementation
+static inline counter_t searchBitFalse_longRange(bitword_t* bitstorage, register counter_t index) {
+   const bitshift_t index_bit  = bitindex_calc(index);
+   register counter_t index_word = wordindex(index);
+   register bitshift_t distance = (bitshift_t) __builtin_ctzll( ~(bitstorage[index_word] >> index_bit));  // take inverse to be able to use ctz
+   index += distance;
+   distance += index_bit;
 
-    const counter_t step_2 = step * 2;
-    const counter_t step_3 = step * 3;
-    const counter_t step_4 = step * 4;
-    const counter_t fast_loop_stop_word = (range_stop_word>step_3) ? (range_stop_word - step_3) : 0;
+   while unlikely(distance == WORD_SIZE_bitshift) { // to prevent a bug from optimzer
+       index_word++;
+       distance = (bitshift_t) __builtin_ctzll(~(bitstorage[index_word]));
+       index += distance;
+   }
 
-    while (index_word < fast_loop_stop_word) {
-        sieve->bitarray[index_word         ] |= mask;
-        sieve->bitarray[index_word + step  ] |= mask;
-        sieve->bitarray[index_word + step_2] |= mask;
-        sieve->bitarray[index_word + step_3] |= mask;
-        index_word += step_4;
-    }
-   
-    while (index_word < range_stop_word) {
-        sieve->bitarray[index_word] |= mask;
-        index_word += step;
-    }
-
-    if (index_word == range_stop_word) {
-        sieve->bitarray[range_stop_word] |= (mask & chopmask2(range_stop));
-    }
+   return index;
 }
 
-// set bits by creating a pattern and then extending it to word and range size
-static void inline setBitsTrue_smallStep(struct sieve_state *sieve, const counter_t range_start, const bitshift_t step, const counter_t range_stop) {
+// apply the same word mask at large ranges
+// manually unlooped - this here is where the main speed increase comes from
+// idea from PrimeRust/solution_1 by Michael Barber 
+static inline void applyMask_word(bitword_t* __restrict bitstorage, const counter_t step, const counter_t range_stop, const bitword_t mask, counter_t index_word) {
+   const counter_t range_stop_word = wordindex(range_stop);
+   register bitword_t* __restrict index_ptr      =  __builtin_assume_aligned(&bitstorage[index_word],8);
+   register bitword_t* __restrict fast_loop_ptr  =  __builtin_assume_aligned(&bitstorage[((range_stop_word>step*5) ? (range_stop_word - step*5):0)],8);
 
-    // build the pattern in a word
-	bitword_t pattern = SAFE_SHIFTBIT;
-    for (counter_t patternsize = step; patternsize <= WORD_SIZE; patternsize += patternsize) {
-        pattern |= (pattern << patternsize);
-    }
+   //#pragma GCC unroll 10
+   #pragma GCC ivdep
+   while likely(index_ptr < fast_loop_ptr) {
+       *index_ptr |= mask;  index_ptr+=step;
+       *index_ptr |= mask;  index_ptr+=step;
+       *index_ptr |= mask;  index_ptr+=step;
+       *index_ptr |= mask;  index_ptr+=step;
+       *index_ptr |= mask;  index_ptr+=step;
+   }
 
-    const counter_t range_stop_word = wordindex(range_stop);
-    counter_t copy_word = wordindex(range_start);
- 
-    if (copy_word == range_stop_word) { // shortcut
-       sieve->bitarray[copy_word] |= ((pattern << bitindex(range_start)) & chopmask2(range_stop)) ;
-       return;
-    }
+   register const bitword_t* __restrict range_stop_ptr = __builtin_assume_aligned(&bitstorage[(range_stop_word)],8);
+   while likely(index_ptr < range_stop_ptr) {
+       *index_ptr |= mask;  index_ptr+=step;
+   }
 
-    // from now on, we are before range_stop_word
-    // first word is special, because it should not set bits before the range_start_bit
-    sieve->bitarray[copy_word] |= (pattern << bitindex(range_start));
-    pattern = (pattern << (bitindex(range_start) % step)); // correct for inital offset  
-
-    bitshift_t pattern_shift = (bitshift_t) WORD_SIZE % step;
-    bitshift_t pattern_shift_flipped = (bitshift_t)WORD_SIZE - pattern_shift - pattern_shift;
-    copy_word++;
-
-    while (copy_word < range_stop_word) {
-        pattern = (pattern >> pattern_shift) | (pattern << pattern_shift_flipped);
-        sieve->bitarray[copy_word] |= pattern;
-        copy_word++;
-    } 
-
-    pattern = (pattern >> pattern_shift) | (pattern << pattern_shift_flipped);
-    sieve->bitarray[copy_word] |= pattern & chopmask2(range_stop);
+   if (index_ptr == range_stop_ptr) { // index_ptr could also end above range_stop_ptr, depending on steps. Then a chop is not needed
+      *index_ptr |= (mask & chopmask(range_stop));
+   }
 }
 
-// Medium steps could be within the same word.
-// By joining the masks and then writing to memory, we might save some time.
-// This is especially true for longer ranges
-static void inline setBitsTrue_mediumStep(struct sieve_state *sieve, const counter_t range_start, const counter_t step, const counter_t range_stop) {
-    const counter_t range_stop_unique =  range_start + WORD_SIZE * step;
-
-    if (range_stop_unique > range_stop) {
-        for (counter_t index = range_start; index <= range_stop;) {
-            counter_t index_word = wordindex(index);
-            bitword_t mask = SAFE_ZERO;
-            do {
-                mask |= markmask(index);
-                index += step;
-            } while (index_word == wordindex(index));
-            sieve->bitarray[index_word] |= mask;
-        }
-    }
-    else {
-        for (counter_t index = range_start; index <= range_stop_unique;) {
-            counter_t index_word = wordindex(index);
-            bitword_t mask = SAFE_ZERO;
-            do {
-                mask |= markmask(index);
-                index += step;
-            } while (index_word == wordindex(index));
-            applyMask(sieve, index_word, step, range_stop, mask);
-        }
-    }
-}
-
-// small ranges (< WORD_SIZE * step) mean the mask is unique
-static inline void setBitsTrue_smallRange(struct sieve_state *sieve, const counter_t range_start, const counter_t step, const counter_t range_stop) {
-    for (counter_t index = range_start; index <= range_stop; index += step) {
-        sieve->bitarray[wordindex(index)] |= markmask(index);
-    }
-}
-
-// small ranges (< WORD_SIZE * step) mean the mask is unique
-static void setBitsTrue_race(struct sieve_state *sieve, counter_t index1, counter_t index2, const counter_t step1, const counter_t step2, const counter_t range_stop) {
-
-    counter_t index1_word = wordindex(index1);
-    counter_t index2_word = wordindex(index2);
+// same as word mask, but at a vector level - uses the sse/avx extensions, hopefully
+static inline void applyMask_vector(bitvector_t* __restrict bitstorage, const counter_t step, const counter_t range_stop, const bitvector_t mask, counter_t index_vector) {
+    const counter_t range_stop_vector = vectorindex(range_stop);
+    register bitvector_t* __restrict index_ptr      =  __builtin_assume_aligned(&bitstorage[index_vector],anticiped_cache_line_bytesize);
+    register bitvector_t* __restrict fast_loop_ptr  =  __builtin_assume_aligned(&bitstorage[((range_stop_vector>step*4) ? (range_stop_vector - step*4):0)],anticiped_cache_line_bytesize);
     
-    while (1) {
-        if (index1_word == index2_word) {
-            bitword_t mask = SAFE_ZERO;
-            counter_t index_word = index1_word;
-            do {
-                mask |= markmask(index1);
-                index1 += step1;
-                index1_word = wordindex(index1);
-            } while (index1_word == index_word);
-            do {
-                mask |= markmask(index2);
-                index2 += step2;
-                index2_word = wordindex(index2);
-            } while (index2_word == index_word);
-            sieve->bitarray[index_word] |= mask;
-        }
+    #pragma GCC ivdep
+    while likely(index_ptr < fast_loop_ptr) {
+        *index_ptr |= mask; index_ptr+=step;
+        *index_ptr |= mask; index_ptr+=step;
+        *index_ptr |= mask; index_ptr+=step;
+        *index_ptr |= mask; index_ptr+=step;
+    }
+    
+    register const bitvector_t* __restrict range_stop_ptr = __builtin_assume_aligned(&bitstorage[(range_stop_vector)],anticiped_cache_line_bytesize);
+    while likely(index_ptr <= range_stop_ptr) {
+        *index_ptr |= mask; index_ptr+=step;
+    }
+}
 
-        // because step is larger, index2 is the most likely to get out of bounds first
-        if (index2 > range_stop) {
-            while (index1 <= range_stop) {
-                sieve->bitarray[wordindex(index1)] |= markmask(index1);
-                index1 += step1;
-            }
-            return;
-        }
+// Medium steps could be within the same word (e.g. less than 64 bits apart).
+// By joining the masks and then writing to memory, we might save some time.
+// This is especially true for small steps over long ranges
+// but it needs tuning, because there is some overhead of checking if the next step is in the same word
+static void  setBitsTrue_mediumStep(bitword_t* __restrict bitstorage, const counter_t range_start, const counter_t step, const counter_t range_stop) {
+    const counter_t range_stop_unique =  range_start + WORD_SIZE_counter * step;
 
-        if (index1 > range_stop) {
-            while (index2 <= range_stop) {
-                sieve->bitarray[wordindex(index2)] |= markmask(index2);
-                index2 += step2;
-            }
-            return;
-        }
+    if (range_stop_unique > range_stop) { // the range will not repeat itself; no need to try to resuse the mask
+        debug printf("Setting bits step %ju in %ju bit range (%ju-%ju) using mediumstep-unique (%ju occurances)\n", (uintmax_t)step, (uintmax_t)range_stop-(uintmax_t)range_start,(uintmax_t)range_start,(uintmax_t)range_stop, (uintmax_t)(((uintmax_t)range_stop-(uintmax_t)range_start)/(uintmax_t)step));
 
-        while (index1_word < index2_word) {
-            sieve->bitarray[index1_word] |= markmask(index1);
-            index1 += step1;
-            index1_word = wordindex(index1);
+        for (register counter_t index = range_start; index <= range_stop;) {
+            register counter_t index_word = wordindex(index);
+            register bitword_t mask = SAFE_ZERO;
+            for(; index_word == wordindex(index); index += step) mask |= markmask(index);
+            bitstorage[index_word] |= mask;
         }
+    }
+    else { // this mask will reoccur at a interval of step words -> fill mask and reapply as a interval of step
+        debug printf("Setting bits step %ju in %ju bit range (%ju-%ju) using mediumstep-repeat (%ju occurances)\n", (uintmax_t)step, (uintmax_t)range_stop-(uintmax_t)range_start,(uintmax_t)range_start,(uintmax_t)range_stop, (uintmax_t)(((uintmax_t)range_stop-(uintmax_t)range_start)/(uintmax_t)step));
         
-        while (index2_word < index1_word){
-            sieve->bitarray[index2_word] |= markmask(index2);
-            index2 += step2;
-            index2_word = wordindex(index2);
+        for (register counter_t index = range_start; index <= range_stop_unique;) {
+            register counter_t index_word = wordindex(index);
+            register bitword_t mask = SAFE_ZERO;
+            for(; index_word == wordindex(index); index += step) mask |= markmask(index);
+            applyMask_word(bitstorage, step, range_stop, mask, index_word);
         }
-
     }
 }
 
 // Large ranges (> WORD_SIZE * step) mean the same mask can be reused
-static inline void setBitsTrue_largeRange(struct sieve_state *sieve, const counter_t range_start, const counter_t step, const counter_t range_stop) {
-    counter_t range_stop_unique =  range_start + WORD_SIZE * step;
-    for (counter_t index = range_start; index <= range_stop_unique; index += step) {
-        bitword_t mask = markmask(index);
-        applyMask(sieve, wordindex(index), step, range_stop, mask);
+static inline void setBitsTrue_largeRange(bitword_t* __restrict bitstorage, const counter_t range_start, const counter_t step, const counter_t range_stop) {
+    debug printf("Setting bits step %ju in %ju bit range (%ju-%ju) using largerange (%ju occurances)\n", (uintmax_t)step, (uintmax_t)range_stop-(uintmax_t)range_start,(uintmax_t)range_start,(uintmax_t)range_stop, (uintmax_t)(((uintmax_t)range_stop-(uintmax_t)range_start)/(uintmax_t)step));
+    const counter_t range_stop_unique =  range_start + WORD_SIZE_counter * step;
+
+    #pragma GCC ivdep
+    for (register counter_t index = range_start; index < range_stop_unique; index += step) {
+        applyMask_word(bitstorage, step, range_stop, markmask(index), wordindex(index));
     }
 }
 
-static void extendSieve_smallSize(struct sieve_state *sieve, const counter_t source_start, const counter_t size, const counter_t destination_stop) {
-    counter_t source_word = wordindex(source_start);
-    bitword_t pattern = ((sieve->bitarray[source_word] >> bitindex(source_start)) | (sieve->bitarray[source_word+1] << (WORD_SIZE-bitindex(source_start)))) & chopmask2(size);
-    for (bitshift_t pattern_size = size; pattern_size <= WORD_SIZE; pattern_size += pattern_size) pattern |= (pattern << pattern_size);
+static inline void setBitsTrue_largeRange_vector(bitword_t* __restrict bitstorage_word, counter_t range_start, const counter_t step, const counter_t range_stop) {
+    debug printf("Setting bits step %ju in %ju bit range (%ju-%ju) using largerange vector (%ju occurances)\n", (uintmax_t)step, (uintmax_t)range_stop-(uintmax_t)range_start,(uintmax_t)range_start,(uintmax_t)range_stop, (uintmax_t)(((uintmax_t)range_stop-(uintmax_t)range_start)/(uintmax_t)step));
 
-    counter_t copy_start = source_start + size;
-    counter_t copy_word = wordindex(copy_start);
-    sieve->bitarray[copy_word] |= (pattern << bitindex(copy_start));
+    counter_t range_start_atvector = vectorstart(range_start);
+    if likely(( range_start_atvector + step) < range_start) { // not the first step possible in this vector
+        debug printf("..Range start+step %ju not at start of vector %ju\n",(uintmax_t)range_start+(uintmax_t)step, (uintmax_t)range_start_atvector); 
 
+        range_start_atvector += VECTOR_SIZE; // find next vector
+        if (unlikely(range_start_atvector > range_stop)) { // we should not be here; just handle without vector
+            for (counter_t index = range_start; index <= range_stop; index += step) 
+                bitstorage_word[wordindex(index)] |= markmask(index);
+            return;
+        }
+
+        for (; range_start <= range_start_atvector; range_start += step) 
+            bitstorage_word[wordindex(range_start)] |= markmask(range_start);
+    }
+    
+    const counter_t range_stop_unique =  range_start + VECTOR_SIZE_counter * step;
+    if (range_stop_unique >= range_stop) {
+        setBitsTrue_largeRange(bitstorage_word, range_start, step, range_stop);
+        return;
+    }
+
+    debug printf("..building masks in range %ju-%ju\n", (uintmax_t)range_start, (uintmax_t)range_stop_unique);
+    for (counter_t index = range_start; index < range_stop_unique;) {
+        const counter_t current_vector =  vectorindex(index);
+        const counter_t current_vector_start_word =  current_vector << (SHIFT_VECTOR - SHIFT_WORD);
+        register counter_t word = wordindex(index) - current_vector_start_word;
+        register bitvector_t quadmask = { };
+
+        // build a quadmask
+        #pragma GCC ivdep 
+        do {
+            quadmask[word] |= markmask(index);
+            index += step;
+            word = wordindex(index) - current_vector_start_word;
+        } while (word < (VECTOR_ELEMENTS));// && index <= range_stop_unique);
+
+        // use mask on all n*step multiples
+        // register counter_t current_vector = current_vector_start_word >> (SHIFT_VECTOR - SHIFT_WORD);
+        bitvector_t* __restrict bitstorage_vector = __builtin_assume_aligned( (bitvector_t*) bitstorage_word, anticiped_cache_line_bytesize);
+        applyMask_vector(bitstorage_vector, step, range_stop, quadmask, current_vector);
+    }
+}
+
+static void continuePattern_smallSize(bitword_t* __restrict bitstorage, const counter_t source_start, const counter_t size, const counter_t destination_stop) {
+    debug printf("Extending sieve size %ju in %ju bit range (%ju-%ju) using smallsize (%ju copies)\n", (uintmax_t)size, (uintmax_t)destination_stop-(uintmax_t)source_start,(uintmax_t)source_start,(uintmax_t)destination_stop, (uintmax_t)(((uintmax_t)destination_stop-(uintmax_t)source_start)/(uintmax_t)size));
+    // debug { printf("...At start. "); dump_bitstorage(bitstorage, 4); }
+
+    const counter_t source_word = wordindex(source_start);
+    register bitword_t pattern = ((bitstorage[source_word] >> bitindex(source_start)) | (bitstorage[source_word+1] << (WORD_SIZE_counter-bitindex_calc(source_start)))) & chopmask(size);
+    for (bitshift_t pattern_size = (bitshift_t)size; pattern_size <= WORD_SIZE_bitshift; pattern_size += pattern_size)
+        pattern |= (pattern << pattern_size);
+
+    const counter_t destination_start = source_start + size;
+    counter_t destination_start_word = wordindex(destination_start);
     counter_t destination_stop_word = wordindex(destination_stop);
-    if (copy_word == destination_stop_word) return;
-
-    bitshift_t pattern_shift = WORD_SIZE % size;
-    bitshift_t pattern_size = WORD_SIZE - pattern_shift;
-    bitshift_t shift = (bitshift_t) WORD_SIZE - bitindex(copy_start);
-
-    while (copy_word < destination_stop_word) { // = will be handled as well because increment is after this 
-        copy_word++;
-        sieve->bitarray[copy_word] = (pattern << (pattern_size-shift)) | (pattern >> shift);
-        shift = bitindex(shift + pattern_shift);  // alternative, but faster
+    if (destination_start_word >= destination_stop_word) {
+        bitstorage[destination_start_word] |= (pattern << bitindex(destination_start)) & chopmask(destination_stop);
+        return;
     }
+
+    bitstorage[destination_start_word] |= (pattern << bitindex(destination_start));
+
+    register const bitshift_t pattern_shift = WORD_SIZE_counter % size;
+    register const bitshift_t pattern_size = WORD_SIZE_bitshift - pattern_shift;
+    register bitshift_t shift = (WORD_SIZE_bitshift - bitindex_calc(destination_start)) & WORDMASK; // be sure this stays > 0
+    register counter_t loop_range = destination_stop_word - destination_start_word;
+    destination_start_word++;
+    
+    #pragma GCC ivdep
+    for (counter_t i=0; i<=loop_range; ++i ) {
+        bitstorage[destination_start_word+i] = (pattern << (pattern_size - ((shift+i*pattern_shift) & WORDMASK)  ) ) | (pattern >> ((shift+i*pattern_shift) & WORDMASK));
+    }
+    bitstorage[destination_stop_word] &= chopmask(destination_stop);
 }
 
-static void extendSieve_aligned(struct sieve_state *sieve, const counter_t source_start, const counter_t size, const counter_t destination_stop) {
+static void continuePattern_aligned(bitword_t* bitstorage, const counter_t source_start, const counter_t size, const counter_t destination_stop) {
+    debug printf("Extending sieve size %ju in %ju bit range (%ju-%ju) using aligned (%ju copies)\n", (uintmax_t)size, (uintmax_t)destination_stop-(uintmax_t)source_start,(uintmax_t)source_start,(uintmax_t)destination_stop, (uintmax_t)(((uintmax_t)destination_stop-(uintmax_t)source_start)/(uintmax_t)size));
+
     const counter_t destination_stop_word = wordindex(destination_stop);
     const counter_t copy_start = source_start + size;
     counter_t source_word = wordindex(source_start);
     counter_t copy_word = wordindex(copy_start);
     
-    sieve->bitarray[copy_word] = sieve->bitarray[source_word] & ~chopmask(bitindex(copy_start));
+    bitstorage[copy_word] = bitstorage[source_word] & ~chopmask(copy_start);
 
     while (copy_word + size <= destination_stop_word) {
-        memcpy(&sieve->bitarray[copy_word], &sieve->bitarray[source_word], size*sizeof(bitword_t) );
+        memcpy(&bitstorage[copy_word], &bitstorage[source_word], (uintmax_t)size*sizeof(bitword_t) );
         copy_word += size;
     }
 
    while (copy_word < destination_stop_word) {
-        sieve->bitarray[copy_word] = sieve->bitarray[source_word];
+        bitstorage[copy_word] = bitstorage[source_word];
         source_word++;
         copy_word++;
     }
 
 }
 
-static void extendSieve_shiftright(struct sieve_state *sieve, const counter_t source_start, const counter_t size, const counter_t destination_stop) {
+static void continuePattern_shiftright(bitword_t* bitstorage, const counter_t source_start, const counter_t size, const counter_t destination_stop) {
+    debug printf("Extending sieve size %ju in %ju bit range (%ju-%ju) using shiftright (%ju copies)\n", (uintmax_t)size, (uintmax_t)destination_stop-(uintmax_t)source_start,(uintmax_t)source_start,(uintmax_t)destination_stop, (uintmax_t)(((uintmax_t)destination_stop-(uintmax_t)source_start)/(uintmax_t)size));
+   
     const counter_t destination_stop_word = wordindex(destination_stop);
     const counter_t copy_start = source_start + size;
-    const bitshift_t shift = bitindex(copy_start) - bitindex(source_start);
-    const bitshift_t shift_flipped = WORD_SIZE-shift;
-    counter_t source_word = wordindex(source_start);
-    counter_t copy_word = wordindex(copy_start);
-    counter_t source_lastword = wordindex(copy_start);
-    sieve->bitarray[copy_word] |= ((sieve->bitarray[source_word] << shift)  // or the start in to not lose data
-                                | (sieve->bitarray[source_lastword] >> shift_flipped))
-                                & ~chopmask(bitindex(copy_start));
-    copy_word++;
-    source_word++;
+    register const bitshift_t shift = bitindex_calc(copy_start) - bitindex_calc(source_start);
+    register const bitshift_t shift_flipped = WORD_SIZE_bitshift-shift;
+    register counter_t source_word = wordindex(source_start);
+    register counter_t copy_word = wordindex(copy_start);
 
-    const counter_t aligned_copy_word = min(source_word + size, destination_stop_word); // after <<size>> words, just copy at word level
-    const counter_t fast_loop_stop_word = (aligned_copy_word>4) ? (aligned_copy_word - 4) : 0; // safe for unsigned ints
-    while (copy_word < fast_loop_stop_word) {
-            bitword_t sourcen = sieve->bitarray[source_word-1];
-            bitword_t source0 = sieve->bitarray[source_word  ];
+    bitstorage[copy_word] |= ((bitstorage[source_word] << shift) |  (bitstorage[copy_word] >> shift_flipped)) & keepmask(copy_start);
+    if unlikely(++copy_word > destination_stop_word) return; // rapid exit for one word variant
 
-            sieve->bitarray[copy_word  ] = (source0 << shift) | (sourcen >> shift_flipped);
-            bitword_t source1 = sieve->bitarray[source_word+1];
-            sieve->bitarray[copy_word+1] = (source1 << shift) | (source0 >> shift_flipped);
-            bitword_t source2 = sieve->bitarray[source_word+2];
-            sieve->bitarray[copy_word+2] = (source2 << shift) | (source1 >> shift_flipped);
-            bitword_t source3 = sieve->bitarray[source_word+3];
-            sieve->bitarray[copy_word+3] = (source3 << shift) | (source2 >> shift_flipped);
-            copy_word += 4;
-            source_word += 4;
+    debug { printf("...start - %ju - %ju - end\n",(uintmax_t)wordindex(copy_start), (uintmax_t)destination_stop_word) ; }
+
+    for (; copy_word <= destination_stop_word; ++copy_word, ++source_word ) {
+        bitstorage[copy_word] = (bitstorage[source_word] >> shift_flipped) | (bitstorage[source_word+1] << shift);
     }
-
-    while (copy_word <= aligned_copy_word) {
-        sieve->bitarray[copy_word] = (sieve->bitarray[source_word-1] >> shift_flipped) | (sieve->bitarray[source_word] << shift);
-        copy_word++;
-        source_word++;
-    }
-    
-    if (copy_word >= destination_stop_word) return;
-
-    source_word = copy_word - size;
-    while (copy_word + size <= destination_stop_word) {
-        memcpy(&sieve->bitarray[copy_word], &sieve->bitarray[source_word], size*sizeof(bitword_t) );
-        copy_word += size;
-    }
-
-    while (copy_word <= destination_stop_word) {
-        sieve->bitarray[copy_word] = sieve->bitarray[source_word];
-        copy_word++;
-        source_word++;
-    }
-
 }
 
-static void extendSieve_shiftleft(struct sieve_state *sieve, const counter_t source_start, const counter_t size, const counter_t destination_stop) {
+
+static inline counter_t continuePattern_shiftleft_unrolled(bitword_t* __restrict bitstorage, const counter_t aligned_copy_word, const bitshift_t shift, counter_t copy_word, counter_t source_word) {
+    const counter_t fast_loop_stop_word = (aligned_copy_word>2) ? (aligned_copy_word - 2) : 0; // safe for unsigned ints
+    register const bitshift_t shift_flipped = WORD_SIZE_bitshift-shift;
+    counter_t distance = 0;
+    while (copy_word < fast_loop_stop_word) {
+        bitword_t source0 = bitstorage[source_word  ];
+        bitword_t source1 = bitstorage[source_word+1];
+        bitstorage[copy_word  ] = (source0 >> shift) | (source1 << shift_flipped);
+        bitword_t source2 = bitstorage[source_word+2];
+        bitstorage[copy_word+1] = (source1 >> shift) | (source2 << shift_flipped);
+        copy_word += 2;
+        source_word += 2;
+        distance += 2;
+    }
+    return distance;
+}
+
+static void continuePattern_shiftleft(bitword_t* bitstorage, const counter_t source_start, const counter_t size, const counter_t destination_stop) {
+    debug printf("Extending sieve size %ju in %ju bit range (%ju-%ju) using shiftleft (%ju copies)\n", (uintmax_t)size, (uintmax_t)destination_stop-(uintmax_t)source_start,(uintmax_t)source_start,(uintmax_t)destination_stop, (uintmax_t)(((uintmax_t)destination_stop-(uintmax_t)source_start)/(uintmax_t)size));
+
     const counter_t destination_stop_word = wordindex(destination_stop);
     const counter_t copy_start = source_start + size;
-    const bitshift_t shift = bitindex(source_start) - bitindex(copy_start);
-    const bitshift_t shift_flipped = WORD_SIZE-shift;
-    counter_t source_word = wordindex(source_start);
-    counter_t copy_word = wordindex(copy_start);
-    sieve->bitarray[copy_word] |= ((sieve->bitarray[source_word] >> shift)
-                                | (sieve->bitarray[source_word+1] << shift_flipped))
-                                & ~chopmask(bitindex(copy_start)); // because this is the first word, dont copy the extra bits in front of the source
+    register const bitshift_t shift = bitindex_calc(source_start) - bitindex_calc(copy_start);
+    register const bitshift_t shift_flipped = WORD_SIZE_bitshift-shift;
+    register counter_t source_word = wordindex(source_start);
+    register counter_t copy_word = wordindex(copy_start);
+    bitstorage[copy_word] |= ((bitstorage[source_word] >> shift)
+                             | (bitstorage[source_word+1] << shift_flipped))
+                             & ~chopmask(copy_start); // because this is the first word, dont copy the extra bits in front of the source
 
     copy_word++;
     source_word++;
 
     const counter_t aligned_copy_word = min(source_word + size, destination_stop_word); // after <<size>> words, just copy at word level
-    const counter_t fast_loop_stop_word = (aligned_copy_word>4) ? (aligned_copy_word - 4) : 0; // safe for unsigned ints
-    while (copy_word < fast_loop_stop_word) {
-        bitword_t source0 = sieve->bitarray[source_word  ];
-        bitword_t source1 = sieve->bitarray[source_word+1];
+    const counter_t distance  = continuePattern_shiftleft_unrolled(bitstorage, aligned_copy_word, shift, copy_word, source_word);
+    source_word += distance;
+    copy_word += distance;
 
-        sieve->bitarray[copy_word  ] = (source0 >> shift) | (source1 << shift_flipped);
-        bitword_t source2 = sieve->bitarray[source_word+2];
-        sieve->bitarray[copy_word+1] = (source1 >> shift) | (source2 << shift_flipped);
-        bitword_t source3 = sieve->bitarray[source_word+3];
-        sieve->bitarray[copy_word+2] = (source2 >> shift) | (source3 << shift_flipped);
-        bitword_t source4 = sieve->bitarray[source_word+4];
-        sieve->bitarray[copy_word+3] = (source3 >> shift) | (source4 << shift_flipped);
-        copy_word += 4;
-        source_word += 4;
-    }
+    debug { counter_t fast_loop_stop_word = uintsafeminus(aligned_copy_word,2); printf("...start - %ju - end fastloop - %ju - start alignment - %ju - end\n", (uintmax_t)fast_loop_stop_word - (uintmax_t)wordindex(copy_start), (uintmax_t)aligned_copy_word - (uintmax_t)fast_loop_stop_word, (uintmax_t)destination_stop_word - (uintmax_t)aligned_copy_word); }
 
-    while (copy_word <= aligned_copy_word) {
-        sieve->bitarray[copy_word] = (sieve->bitarray[source_word] >> shift) | (sieve->bitarray[source_word+1] << shift_flipped);
-        copy_word++;
-        source_word++;
+    #pragma GCC ivdep
+    for (;copy_word <= aligned_copy_word; copy_word++,source_word++) {
+        bitstorage[copy_word] = (bitstorage[source_word  ] >> shift) | (bitstorage[source_word+1 ] << shift_flipped);
     }
 
     if (copy_word >= destination_stop_word) return;
 
     source_word = copy_word - size; // recalibrate
-    while (copy_word + size <= destination_stop_word) {
-        memcpy(&sieve->bitarray[copy_word], &sieve->bitarray[source_word], size*sizeof(bitword_t) );
-        copy_word += size;
-    }
+    const size_t memsize = (size_t)size*sizeof(bitword_t);
 
-    while (copy_word <= destination_stop_word) {
-        sieve->bitarray[copy_word] = sieve->bitarray[source_word];
-        copy_word++;
-        source_word++;
-    }
+    #pragma GCC ivdep
+    for (;copy_word + size <= destination_stop_word; copy_word += size) 
+        memcpy(&bitstorage[copy_word], &bitstorage[source_word],memsize );
 
+    #pragma GCC ivdep
+    for (;copy_word <= destination_stop_word;  copy_word++,source_word++)
+        bitstorage[copy_word] = bitstorage[source_word];
+
+
+ }
+
+// continue a pattern that start at <source_start> with a size of <size>.
+// repeat this pattern up to <destination_stop>.
+// for small sizes, this is done on a word level
+// for larger sizes, we look at the offset / start bit and apply the appropriate algorithm.
+// note that these algorithms are general for bitstorage and have no specialized assumptions for the sieve application
+static inline void continuePattern(bitword_t* bitstorage, const counter_t source_start, const counter_t size, const counter_t destination_stop)	{
+    if (size < WORD_SIZE_counter) return continuePattern_smallSize (bitstorage, source_start, size, destination_stop);
+
+    const bitshift_t copy_bit   = bitindex_calc(source_start + size);
+    const bitshift_t source_bit = bitindex_calc(source_start);
+
+    if      (source_bit > copy_bit) continuePattern_shiftleft (bitstorage, source_start, size, destination_stop);
+    else if (source_bit < copy_bit) continuePattern_shiftright(bitstorage, source_start, size, destination_stop);
+    else                            continuePattern_aligned   (bitstorage, source_start, size, destination_stop);
 }
 
-static inline void extendSieve(struct sieve_state *sieve, const counter_t source_start, const counter_t size, const counter_t destination_stop)	{
-    if (size < WORD_SIZE)           extendSieve_smallSize (sieve, source_start, size, destination_stop);
-
-    const counter_t copy_start  = source_start + size;
-    const bitshift_t copy_bit   = bitindex(copy_start);
-    const bitshift_t source_bit = bitindex(source_start);
-
-    if      (source_bit > copy_bit) extendSieve_shiftleft (sieve, source_start, size, destination_stop);
-    else if (source_bit < copy_bit) extendSieve_shiftright(sieve, source_start, size, destination_stop);
-    else                            extendSieve_aligned   (sieve, source_start, size, destination_stop);
-}
-
-static void sieve_block_stripe(struct sieve_state *sieve, const counter_t block_start, const counter_t block_stop, const counter_t prime_start) {
+static void sieve_block_stripe(bitword_t* bitstorage, const counter_t block_start, const counter_t block_stop, const counter_t prime_start) {
     counter_t prime = prime_start;
-    counter_t start = prime * prime * 2 + prime * 2;
+    counter_t start = 0;
     counter_t step  = prime * 2 + 1;
-    
-    while (start <= block_stop) {
-        step  = prime * 2 + 1;
-        if (step > SMALLSTEP_FASTER) break;
-        if (block_start >= (prime + 1)) start = block_start + prime + prime - ((block_start + prime) % step);
-        setBitsTrue_smallStep(sieve, start, step, block_stop);
-        prime = searchBitFalse(sieve, prime+1 );
-        start = prime * prime * 2 + prime * 2;
-    }
-    
-    while (start <= block_stop) {
-        step  = prime * 2 + 1;
-        if (step > MEDIUMSTEP_FASTER) break;
-        if (block_start >= (prime + 1)) start = block_start + prime + prime - ((block_start + prime) % step);
-        setBitsTrue_mediumStep(sieve, start, step, block_stop);
-        prime = searchBitFalse(sieve, prime+1 );
-        start = prime * prime * 2 + prime * 2;
-    }
 
-    counter_t start1 = 0; // save value
-    counter_t step1 = 0; // save value
-    while (start <= block_stop) {
-        step  = prime * 2 + 1;
-        if (step > 64) break;
-        if (block_start >= (prime + 1)) start = block_start + prime + prime - ((block_start + prime) % step);
-        start1 = start; // save value
-        step1 = step; // save value
-        prime = searchBitFalse(sieve, prime+1 );
-        start = prime * prime * 2 + prime * 2;
-        step  = prime * 2 + 1;
-        if (block_start >= (prime + 1)) start = block_start + prime + prime - ((block_start + prime) % step);
-        if (start <= block_stop) setBitsTrue_race(sieve, start1, start, step1, step, block_stop);
-        else                     setBitsTrue_smallRange(sieve, start1, step1, block_stop);
-        prime = searchBitFalse(sieve, prime+1 );
-        start = prime * prime * 2 + prime * 2;
-    }
+    debug printf("Block strip for block %ju - %ju\n",(uintmax_t)block_start,(uintmax_t)block_stop);
     
-    while (start <= block_stop) {
-        step  = prime * 2 + 1;
-        if (block_start >= (prime + 1)) start = block_start + prime + prime - ((block_start + prime) % step);
-        if (start + step * WORD_SIZE > block_stop) break;
-        setBitsTrue_largeRange(sieve, start, step, block_stop);
-        prime = searchBitFalse(sieve, prime+1 );
-        start = prime * prime * 2 + prime * 2;
-    }
+    while (prime*step <= block_stop) {
+        if likely(block_start >= (prime + 1)) 
+            start = block_start + prime + prime - ((block_start + prime) % step);
+        else 
+            start = prime * prime * 2 + prime * 2;
 
-    while (start <= block_stop) {
+        if unlikely(step < VECTORSTEP_FASTER) {
+            setBitsTrue_largeRange_vector(bitstorage, start, step, block_stop);
+            prime = searchBitFalse(bitstorage, prime+1 );
+        }
+        else {
+            setBitsTrue_largeRange(bitstorage, start, step, block_stop);
+            prime = searchBitFalse_longRange(bitstorage, prime+1 );
+        }
+
         step  = prime * 2 + 1;
-        if (block_start >= (prime + 1)) start = block_start + prime + prime - ((block_start + prime) % step);
-        setBitsTrue_smallRange(sieve, start, step, block_stop);
-        prime = searchBitFalse(sieve, prime+1 );
-        start = prime * prime * 2 + prime * 2;
     }
 }
 
+// structure to help sieve_block_extend report back to the main module
 struct block {
     counter_t pattern_size; // size of pattern applied 
     counter_t pattern_start; // start of pattern
@@ -483,19 +463,20 @@ struct block {
 // returns prime that could not be handled:
 // start is too large
 // range is too big
-static struct block sieve_block_extend(struct sieve_state *sieve, const counter_t block_start, const counter_t block_stop) {
-    counter_t prime            = 0;
+static struct block sieve_block_extend(struct sieve_t *sieve, const counter_t block_start, const counter_t block_stop) {
+    bitword_t* bitstorage      = sieve->bitstorage;
+    register counter_t prime   = 0;
     counter_t patternsize_bits = 1;
     counter_t pattern_start    = 0;
-    counter_t range_stop       = block_stop;
+    counter_t range_stop       = block_start;
     struct block block = { .prime = 0, .pattern_start = 0, .pattern_size = 0 };
 
-    sieve->bitarray[0] = SAFE_ZERO; // only the first word has to be cleared; the rest is populated by the extension procedure
+    sieve->bitstorage[wordindex(block_start)] = SAFE_ZERO; // only the first word has to be cleared; the rest is populated by the extension procedure
     
-    do {
-        prime = searchBitFalse(sieve, prime+1);
+    for (;range_stop < block_stop;) {
+        prime = searchBitFalse(bitstorage, prime+1);
         counter_t start = prime * prime * 2 + prime * 2;
-        if (start > block_stop) break;
+        if unlikely(start > block_stop) break;
 
         const counter_t step  = prime * 2 + 1;
         if (block_start >= (prime + 1)) start = block_start + prime + prime - ((block_start + prime) % step);
@@ -503,126 +484,98 @@ static struct block sieve_block_extend(struct sieve_state *sieve, const counter_
         range_stop = block_start + patternsize_bits * step * 2;  // range is x2 so the second block cointains all multiples of primes
         block.pattern_size = patternsize_bits;
         block.pattern_start = pattern_start;
-        if (range_stop > block_stop) return block; //range_stop = block_stop;
+        if unlikely(range_stop > block_stop) break;//return block; //range_stop = block_stop;
 
-        if (patternsize_bits>1) {
+        if likely(patternsize_bits>1) {
             pattern_start = block_start | patternsize_bits;
-            extendSieve(sieve, pattern_start, patternsize_bits, range_stop);
+            continuePattern(bitstorage, pattern_start, patternsize_bits, range_stop);
         }
         patternsize_bits *= step;
 
-        if      (step < SMALLSTEP_FASTER)  setBitsTrue_smallStep (sieve, start, step, range_stop);
-        else if (step < MEDIUMSTEP_FASTER) setBitsTrue_mediumStep(sieve, start, step, range_stop);
-        else                               setBitsTrue_largeRange(sieve, start, step, range_stop);
+        if (step < MEDIUMSTEP_FASTER)      setBitsTrue_mediumStep(bitstorage, start, step, range_stop);
+        else if (step < VECTORSTEP_FASTER) setBitsTrue_largeRange_vector(bitstorage, start, step, range_stop);
+        else                               setBitsTrue_largeRange(bitstorage, start, step, range_stop);
         block.prime = prime;
-    } while (range_stop < block_stop);
+    } 
 
     return block;
 }
 
-static struct sieve_state *sieve(const counter_t maxints, const counter_t blocksize) {
-    struct sieve_state *sieve = create_sieve(maxints);
-    counter_t prime         = 0;
-    counter_t block_start   = 0;
-    counter_t block_stop    = blocksize-1;
+
+/* This is the main module that does all the work*/
+static struct sieve_t* sieve_shake(const counter_t maxints, const counter_t blocksize) {
+    struct sieve_t *sieve = sieve_create(maxints);
+    bitword_t* bitstorage = sieve->bitstorage;
+
+    debug printf("Running sieve to find all primes up to %ju with blocksize %ju\n",(uintmax_t)maxints,(uintmax_t)blocksize);
 
     // fill the whole sieve bij adding en copying incrementally
     struct block block = sieve_block_extend(sieve, 0, sieve->bits);
-    extendSieve(sieve, block.pattern_start, block.pattern_size, sieve->bits);
-    prime = block.prime;
 
-    do {
-        if (block_stop > sieve->bits) block_stop = sieve->bits;
-        prime = searchBitFalse(sieve, prime);
-        sieve_block_stripe(sieve, block_start, block_stop, prime);
-        // sieve_block_stripe(sieve, block_start, block_stop, prime+1);
-        block_start += blocksize;
-        block_stop += blocksize;
-    } while (block_start <= sieve->bits);
+    // returns the max prime that was processed in the pattern
+    counter_t startprime = block.prime;
 
+    // continue the found pattern to the entire sieve
+    continuePattern(bitstorage, block.pattern_start, block.pattern_size, sieve->bits);
+
+    // in the sieve all bits for the multiples of primes up to startprime have been set
+    // process the sieve and stripe all the multiples of primes > start_prime
+    // do this block by block to minimize cache misses
+    for (counter_t block_start = 0,  block_stop = blocksize-1;block_start <= sieve->bits; block_start += blocksize, block_stop += blocksize) {
+        if unlikely(block_stop > sieve->bits) block_stop = sieve->bits;
+        counter_t prime = searchBitFalse(bitstorage, startprime);
+        sieve_block_stripe(bitstorage, block_start, block_stop, prime);
+    } 
+
+    // retunr the completed sieve
     return sieve;
 }
 
-// https://stackoverflow.com/questions/31117497/fastest-integer-square-root-in-the-least-amount-of-instructions
-static inline counter_t isqrt(unsigned long val) {
-    unsigned long temp, g=0, b = 0x8000, bshft = 15;
-    do {
-        if (val >= (temp = (((g << 1) + b)<<bshft--))) {
-           g += b;
-           val -= temp;
-        }
-    } while (b >>= 1);
-    return g;
-}
-
-static void show_primes(struct sieve_state *sieve) {
-    counter_t       bits = sieve->bits;
-    bitword_t  *bitarray = sieve->bitarray;
-    counter_t primecount = 1;    // We already have 2
-    for (counter_t factor=1; factor < bits; factor++) {
-        if ((bitarray[wordindex(factor)] & markmask(factor))==0) {
-            if (primecount < 100) {
-                printf("%3ju ",(uintmax_t)factor*2+1);
-                if (primecount % 10 == 0) printf("\n");
-                printf(" \b"); 
-            }
-            primecount++;
+static void show_primes(struct sieve_t *sieve, counter_t maxFactor) {
+    counter_t primeCount = 1;    // We already have 2
+    for (counter_t factor=1; factor < sieve->bits; factor = searchBitFalse(sieve->bitstorage, factor+1)) {
+        primeCount++;
+        if (factor < maxFactor/2) {
+            printf("%3ju ",(uintmax_t)factor*2+1);
+            if (primeCount % 10 == 0) printf("\n");
         }
     }
-    puts("");
+    printf("\nFound %ju primes until %ju\n",(uintmax_t)primeCount, (uintmax_t)sieve->bits*2+1);
 }
 
-static counter_t count_primes(struct sieve_state *sieve) {
-    counter_t       bits = sieve->bits;
-    bitword_t  *bitarray = sieve->bitarray;
-    counter_t primecount = 1;    // We already have 2
-    for (counter_t factor=1; factor < bits; factor++) {
-        if ((bitarray[wordindex(factor)] & markmask(factor))==0) {
-            primecount++;
-        }
-    }
-    return primecount;
+static counter_t count_primes(struct sieve_t *sieve) {
+    counter_t primeCount = 1;
+    for (counter_t factor=1; factor < sieve->bits; factor = searchBitFalse(sieve->bitstorage, factor+1)) primeCount++;
+    return primeCount;
 }
 
-static void deepAnalyzePrimes(struct sieve_state *sieve) {
+static void deepAnalyzePrimes(struct sieve_t *sieve) {
     printf("DeepAnalyzing\n");
-    counter_t range_to =  sieve->bits;
     counter_t warn_prime = 0;
     counter_t warn_nonprime = 0;
-    for (counter_t prime = 1; prime < range_to; prime++ ) {
-        if ((sieve->bitarray[wordindex(prime)] & markmask(prime))==0) { // is this a prime?
-            counter_t q = (isqrt(prime*2+1)|1)*2+1;
-            for(counter_t c=1; c<=q; c++) {
+    for (counter_t prime = 1; prime < sieve->bits; prime++ ) {
+        if ((sieve->bitstorage[wordindex(prime)] & markmask_calc(prime))==0) { // is this a prime?
+            for(counter_t c=1; c<=sieve->bits && c*c <= prime*2+1; c++) {
                 if ((prime*2+1) % (c*2+1) == 0 && (c*2+1) != (prime*2+1)) {
-                    if (warn_prime++ < 30) {
-                        printf("Number %ju (%ju) was marked prime, but %ju * %ju = %ju\n", (uintmax_t)prime*2+1, (uintmax_t)prime, (uintmax_t)c*2+1, (uintmax_t)((prime*2+1)/(c*2+1)), (uintmax_t)prime*2+1 );
-                    }
+                    if (warn_prime++ < 30) printf("Number %ju (%ju) was marked prime, but %ju * %ju = %ju\n", (uintmax_t)prime*2+1, (uintmax_t)prime, (uintmax_t)c*2+1, (uintmax_t)((prime*2+1)/(c*2+1)), (uintmax_t)prime*2+1 );
                 }
             }
         }
         else {
-            counter_t q = (isqrt(prime*2+1)|1)*2+1;
             counter_t c_prime = 0;
-            for(counter_t c=1; c<=q; c++) {
-                if ((prime*2+1) % (c*2+1) == 0 && (c*2+1) != (prime*2+1)) {
-                    c_prime++;
-                    break;
-                }
+            for(counter_t c=1; c<=sieve->bits && c*c <= prime*2+1; c++) {
+                if ((prime*2+1) % (c*2+1) == 0 && (c*2+1) != (prime*2+1)) c_prime++;
             }
-            if (c_prime==0) {
-                if (warn_nonprime++ < 30) {
-                    printf("Number %ju (%ju) was marked non-prime, but no factors found. So it is prime\n", (uintmax_t)prime*2+1,(uintmax_t) prime);
-                }
-            }
+            if (c_prime==0 && warn_nonprime++ < 30) printf("Number %ju (%ju) was marked non-prime, but no factors found. So it is prime\n", (uintmax_t)prime*2+1,(uintmax_t) prime);
         }
     }
 }
 
 
-int validatePrimeCount(struct sieve_state *sieve, int option_verboselevel) {
+int validatePrimeCount(struct sieve_t *sieve, int option_verboselevel) {
 
     counter_t primecount = count_primes(sieve);
-    counter_t valid_primes;
+    counter_t valid_primes = 0;
     switch(sieve->size) {
         case 10:            valid_primes = 4;        break;
         case 100:           valid_primes = 25;       break;
@@ -633,31 +586,38 @@ int validatePrimeCount(struct sieve_state *sieve, int option_verboselevel) {
         case 10000000:      valid_primes = 664579;   break;
         case 100000000:     valid_primes = 5761455;  break;
         case 1000000000:    valid_primes = 50847534; break;
-        default:            valid_primes=-1;
+        default:            valid_primes= 0;
     }
 
     int valid = (valid_primes == primecount);
     if (valid  && option_verboselevel >= 4) printf("Result: Sievesize %ju is expected to have %ju primes. algorithm produced %ju primes\n",(uintmax_t)sieve->size,(uintmax_t)valid_primes,(uintmax_t)primecount );
-    if (!valid && option_verboselevel >= 2) {
+    if (!valid && option_verboselevel >= 1) {
         printf("No valid result. Sievesize %ju was expected to have %ju primes, but algorithm produced %ju primes\n",(uintmax_t)sieve->size,(uintmax_t)valid_primes,(uintmax_t)primecount );
-        show_primes(sieve);
+        if (!valid && option_verboselevel >= 2) show_primes(sieve, default_show_primes_on_error);
     }
-    if (!valid && option_verboselevel >= 3) deepAnalyzePrimes(sieve);
+    if (!valid && option_verboselevel >= 2) deepAnalyzePrimes(sieve);
     return (valid);
 }
 
 void usage(char *name) {
     fprintf(stderr, "Usage: %s [options] [maximum]\n", name);
     fprintf(stderr, "Options:\n");
-    fprintf(stderr, "  --verbose <level> Show more output to a certain level:\n");
-    fprintf(stderr, "                    1 - show phase progress\n");
-    fprintf(stderr, "                    2 - show general progress within the phase\n");
-    fprintf(stderr, "                    3 - show actual work\n");
-    fprintf(stderr, "  --check           check the correctness of the algorithm\n");
-    fprintf(stderr, "  --tune  <level>   find the best settings for the current os and hardware\n");
-    fprintf(stderr, "                    1 - fast tuning\n");
-    fprintf(stderr, "                    2 - refined tuning\n");
-    fprintf(stderr, "                    3 - maximum tuning (takes long)\n");
+    fprintf(stderr, "  --check            check the correctness of the algorithm\n");
+    fprintf(stderr, "  --help             This help function\n");
+    fprintf(stderr, "  --show <maximum>   Show the primes found up to the maximum\n");
+    #ifdef _OPENMP
+    fprintf(stderr, "  --threads <count>  Set the maximum number of threads to be used\n");
+    fprintf(stderr, "                     Use 'all' to use all available threads or 'half' for /2 (e.g. for no hyperthreading)\n");
+    #endif
+    fprintf(stderr, "  --time  <seconds>  The maximum time (in seconds) to run passes of the sieve algorithm\n");
+    fprintf(stderr, "  --tune  <level>    find the best settings for the current os and hardware\n");
+    fprintf(stderr, "                     1 - fast tuning\n");
+    fprintf(stderr, "                     2 - refined tuning\n");
+    fprintf(stderr, "                     3 - maximum tuning (takes long)\n");
+    fprintf(stderr, "  --verbose <level>  Show more output to a certain level:\n");
+    fprintf(stderr, "                     1 - show phase progress\n");
+    fprintf(stderr, "                     2 - show general progress within the phase\n");
+    fprintf(stderr, "                     3 - show actual work\n");
     exit(1);
 }
 
@@ -668,6 +628,8 @@ typedef struct  {
     counter_t free_bits;
     counter_t smallstep_faster;
     counter_t mediumstep_faster;
+    counter_t vectorstep_faster;
+    counter_t threads;
     counter_t sample_max;
     double    sample_duration;
     counter_t passes;
@@ -678,22 +640,27 @@ typedef struct  {
 int compare_tuning_result(const void *a, const void *b) {
     tuning_result_type *resultA = (tuning_result_type *)a;
     tuning_result_type *resultB = (tuning_result_type *)b;
-    return (resultB->avg - resultA->avg);
+    return (resultB->avg > resultA->avg ? 1 : -1);
 }
 
 static void tune_benchmark(tuning_result_type* tuning_result, counter_t tuning_result_index) {
     counter_t passes = 0;
     double elapsed_time = 0;
     struct timespec start_time,end_time;
-    struct sieve_state *sieve_instance;
+    struct sieve_t *sieve;
 
     global_SMALLSTEP_FASTER = tuning_result[tuning_result_index].smallstep_faster;
     global_MEDIUMSTEP_FASTER = tuning_result[tuning_result_index].mediumstep_faster;
+    global_VECTORSTEP_FASTER = tuning_result[tuning_result_index].vectorstep_faster;
 
     clock_gettime(CLOCK_MONOTONIC,&start_time);
+    #ifdef _OPENMP
+    omp_set_num_threads(tuning_result[tuning_result_index].threads);
+    #pragma omp parallel reduction(+:passes)
+    #endif
     while (elapsed_time <= tuning_result[tuning_result_index].sample_duration && passes < tuning_result[tuning_result_index].sample_max) {
-        sieve_instance = sieve(tuning_result[tuning_result_index].maxints, tuning_result[tuning_result_index].blocksize_bits);//blocksize_bits);
-        delete_sieve(sieve_instance);
+        sieve = sieve_shake(tuning_result[tuning_result_index].maxints, tuning_result[tuning_result_index].blocksize_bits);//blocksize_bits);
+        sieve_delete(sieve);
         passes++;
         clock_gettime(CLOCK_MONOTONIC,&end_time);
         elapsed_time = end_time.tv_sec + end_time.tv_nsec*1e-9 - start_time.tv_sec - start_time.tv_nsec*1e-9;
@@ -703,16 +670,26 @@ static void tune_benchmark(tuning_result_type* tuning_result, counter_t tuning_r
     tuning_result[tuning_result_index].avg = passes/elapsed_time;
 }
 
-static tuning_result_type tune(counter_t tune_level, counter_t maxints, counter_t option_verboselevel) {
+static inline void tuning_result_print(tuning_result_type tuning_result) {
+    printf("blocksize_bits %10ju; blocksize %4jukb; free_bits %5ju; small %2ju; medium %2ju; vector %3ju; passes %3ju/%3ju; time %f/%f;average %f\n", 
+                            (uintmax_t)tuning_result.blocksize_bits, (uintmax_t)tuning_result.blocksize_kb,(uintmax_t)tuning_result.free_bits,
+                            (uintmax_t)tuning_result.smallstep_faster,(uintmax_t)tuning_result.mediumstep_faster,(uintmax_t)tuning_result.vectorstep_faster,
+                            (uintmax_t)tuning_result.passes, (uintmax_t) tuning_result.sample_max,
+                            tuning_result.elapsed_time, tuning_result.sample_duration, tuning_result.avg);
+}
+
+static tuning_result_type tune(int tune_level, counter_t maxints, counter_t threads, int option_verboselevel) {
     counter_t best_blocksize_bits = default_blocksize;
 
     double best_avg = 0;
     best_blocksize_bits = 0;
     counter_t best_smallstep_faster = 0;
     counter_t best_mediumstep_faster = 0;
+    counter_t best_vectorstep_faster = 0;
     counter_t smallstep_faster_steps = 4;
     counter_t mediumstep_faster_steps = 4;
-    counter_t freebits_steps = anticiped_cache_line_bytesize*4;
+    counter_t vectorstep_faster_steps = 32;
+    counter_t freebits_steps = anticiped_cache_line_bytesize;
     counter_t sample_max = default_sample_max;
     double sample_duration = default_sample_duration;
 
@@ -721,131 +698,136 @@ static tuning_result_type tune(counter_t tune_level, counter_t maxints, counter_
         case 1:
             smallstep_faster_steps  = WORD_SIZE/4;
             mediumstep_faster_steps = WORD_SIZE/4;
+            vectorstep_faster_steps = WORD_SIZE/4;
             freebits_steps = anticiped_cache_line_bytesize*8*2;
-            sample_max = 4;
+            sample_max = 16;
             sample_duration = 0.1;
             break;
         case 2:
             smallstep_faster_steps  = WORD_SIZE/8;
-            mediumstep_faster_steps = WORD_SIZE/8;
+            mediumstep_faster_steps = WORD_SIZE/16;
+            vectorstep_faster_steps = WORD_SIZE/4;
             freebits_steps = anticiped_cache_line_bytesize*8;
-            sample_max = 4;
+            sample_max = 16;
             sample_duration = 0.2;
             break;
         case 3:
             smallstep_faster_steps  = WORD_SIZE/16;
             mediumstep_faster_steps = WORD_SIZE/16;
+            vectorstep_faster_steps = WORD_SIZE/16;
             freebits_steps = anticiped_cache_line_bytesize/2;
-            sample_max = 4;
-            sample_duration = 0.4;
+            sample_max = 16;
+            sample_duration = 0.2;
             break;
     }
     
-    if (option_verboselevel >= 1) printf("Tuning..."); if (option_verboselevel >= 2) printf("\n");
-    const counter_t max_results = ((WORD_SIZE/smallstep_faster_steps)+1) * ((WORD_SIZE / mediumstep_faster_steps)+1) * 32 * (anticiped_cache_line_bytesize*8*4/freebits_steps);
+    verbose(2) printf("\n");
+    verbose_at(1) { printf("Tuning..."); fflush(stdout); }
+    verbose(2) printf("\n");
+    const size_t max_results = ((size_t)(WORD_SIZE_counter/smallstep_faster_steps)+1) * ((size_t)(WORD_SIZE_counter/mediumstep_faster_steps)+1) * ((size_t)(VECTOR_SIZE_counter/vectorstep_faster_steps)+1) * 32 * (size_t)(anticiped_cache_line_bytesize*8*4/freebits_steps);
     tuning_result_type* tuning_result = malloc(max_results * sizeof(tuning_result));
     counter_t tuning_results=0;
     counter_t tuning_result_index=0;
     
-    for (counter_t smallstep_faster = 0; smallstep_faster <= WORD_SIZE/2; smallstep_faster += smallstep_faster_steps) {
-        for (counter_t mediumstep_faster = smallstep_faster; mediumstep_faster <= WORD_SIZE; mediumstep_faster += mediumstep_faster_steps) {
-            for (counter_t blocksize_kb=256; blocksize_kb>=8; blocksize_kb /= 2) {
-                for (counter_t free_bits=0; (free_bits < (anticiped_cache_line_bytesize*8*4) && (free_bits < blocksize_kb * 1024 * 8)); free_bits += freebits_steps) {
-                    counter_t blocksize_bits = (blocksize_kb * 1024 * 8) - free_bits;
+    for (counter_t smallstep_faster = 0; smallstep_faster <= 0; smallstep_faster += smallstep_faster_steps) {
+        for (counter_t mediumstep_faster = smallstep_faster; mediumstep_faster <= WORD_SIZE_counter; mediumstep_faster += mediumstep_faster_steps) {
+            for (counter_t vectorstep_faster = mediumstep_faster; vectorstep_faster <= VECTOR_SIZE_counter; vectorstep_faster += vectorstep_faster_steps) {
+                for (counter_t blocksize_kb=256; blocksize_kb>=8; blocksize_kb /= 2) {
+                    for (counter_t free_bits=0; (free_bits < (anticiped_cache_line_bytesize*8*4) && (free_bits < blocksize_kb * 1024 * 8)); free_bits += freebits_steps) {
+                        counter_t blocksize_bits = (blocksize_kb * 1024 * 8) - free_bits;
 
-                    // set variables
-                    tuning_results++;
-                    tuning_result[tuning_result_index].maxints = maxints;
-                    tuning_result[tuning_result_index].sample_duration = sample_duration;
-                    tuning_result[tuning_result_index].sample_max = sample_max;
-                    tuning_result[tuning_result_index].blocksize_kb = blocksize_kb;
-                    tuning_result[tuning_result_index].free_bits = free_bits;
-                    tuning_result[tuning_result_index].blocksize_bits = blocksize_bits;
-                    tuning_result[tuning_result_index].smallstep_faster = smallstep_faster;
-                    tuning_result[tuning_result_index].mediumstep_faster = mediumstep_faster;
-                    tune_benchmark(tuning_result, tuning_result_index);
+                        // set variables
+                        tuning_results++;
+                        tuning_result[tuning_result_index].maxints = maxints;
+                        tuning_result[tuning_result_index].sample_duration = sample_duration;
+                        tuning_result[tuning_result_index].sample_max = sample_max;
+                        tuning_result[tuning_result_index].blocksize_kb = blocksize_kb;
+                        tuning_result[tuning_result_index].free_bits = free_bits;
+                        tuning_result[tuning_result_index].blocksize_bits = blocksize_bits;
+                        tuning_result[tuning_result_index].smallstep_faster = smallstep_faster;
+                        tuning_result[tuning_result_index].mediumstep_faster = mediumstep_faster;
+                        tuning_result[tuning_result_index].vectorstep_faster = vectorstep_faster;
+                        tuning_result[tuning_result_index].threads = threads;
+                        tune_benchmark(tuning_result, tuning_result_index);
 
-                    if ( tuning_result[tuning_result_index].avg > best_avg) {
-                        best_avg = tuning_result[tuning_result_index].avg;
-                        best_blocksize_bits = blocksize_bits;
-                        best_smallstep_faster = smallstep_faster;
-                        best_mediumstep_faster = mediumstep_faster;
-                        if (option_verboselevel >=2) printf(".(>)blocksize_bits %10ju; blocksize %4jukb; free_bits %5ju; smallstep: %2ju; mediumstep %2ju; passes %3ju/%3ju; time %f/%f;average %f\n", 
-                        (uintmax_t)tuning_result[tuning_result_index].blocksize_bits, (uintmax_t)tuning_result[tuning_result_index].blocksize_kb,(uintmax_t)tuning_result[tuning_result_index].free_bits,
-                        (uintmax_t)tuning_result[tuning_result_index].smallstep_faster,(uintmax_t)tuning_result[tuning_result_index].mediumstep_faster,
-                        (uintmax_t)tuning_result[tuning_result_index].passes, (uintmax_t) tuning_result[tuning_result_index].sample_max,
-                        tuning_result[tuning_result_index].elapsed_time, tuning_result[tuning_result_index].sample_duration, tuning_result[tuning_result_index].avg);
+                        if ( tuning_result[tuning_result_index].avg > best_avg) {
+                            best_avg = tuning_result[tuning_result_index].avg;
+                            best_blocksize_bits = blocksize_bits;
+                            best_smallstep_faster = smallstep_faster;
+                            best_mediumstep_faster = mediumstep_faster;
+                            best_vectorstep_faster = vectorstep_faster;
+                            if (option_verboselevel >=2) { printf(".(>)"); tuning_result_print(tuning_result[tuning_result_index]); }
+                        }
+                        if (option_verboselevel >= 3) { printf("...."); tuning_result_print(tuning_result[tuning_result_index]); }
+                        tuning_result_index++;
+                        verbose_at(1) { printf("\rTuning...tuning %ju options..",(uintmax_t)tuning_results); fflush(stdout); }
                     }
-                    if (option_verboselevel >= 3) printf("...blocksize_bits %10ju; blocksize %4jukb; free_bits %5ju; smallstep: %2ju; mediumstep %2ju; passes %3ju/%3ju; time %f/%f;average %f\n", 
-                        (uintmax_t)tuning_result[tuning_result_index].blocksize_bits, (uintmax_t)tuning_result[tuning_result_index].blocksize_kb,(uintmax_t)tuning_result[tuning_result_index].free_bits,
-                        (uintmax_t)tuning_result[tuning_result_index].smallstep_faster,(uintmax_t)tuning_result[tuning_result_index].mediumstep_faster,
-                        (uintmax_t)tuning_result[tuning_result_index].passes, (uintmax_t) tuning_result[tuning_result_index].sample_max,
-                        tuning_result[tuning_result_index].elapsed_time, tuning_result[tuning_result_index].sample_duration, tuning_result[tuning_result_index].avg);
-                    tuning_result_index++;
                 }
             }
         }
     }
-    if (option_verboselevel >= 2) {
-        printf("%ju results. Inital best blocksize: %ju; best smallstep %ju; best mediumstep %ju\n",(uintmax_t)tuning_results,(uintmax_t)best_blocksize_bits, (uintmax_t)best_smallstep_faster,(uintmax_t)best_mediumstep_faster);
+    verbose_at(1) { printf("\rTuning...tuned %ju options..",(uintmax_t)tuning_results); }
+    verbose(2) { printf("Tuning...tuned %ju options..\n",(uintmax_t)tuning_results); }
+    verbose(2) {
+        printf("%ju options. Inital best blocksize: %ju; best smallstep %ju; best mediumstep %ju; best vectorstep %ju\n",(uintmax_t)tuning_results,(uintmax_t)best_blocksize_bits, (uintmax_t)best_smallstep_faster,(uintmax_t)best_mediumstep_faster, (uintmax_t)best_vectorstep_faster);
         printf("Best options\n");
     }
+
     counter_t step=0;
+    counter_t tuning_results_max = tuning_results;
     while (tuning_results>4) {
-        qsort(tuning_result, tuning_results, sizeof(tuning_result_type), compare_tuning_result);
+        qsort(tuning_result, (size_t)tuning_results, sizeof(tuning_result_type), compare_tuning_result);
         step++;
-        if (option_verboselevel >= 2) {
+        verbose(2) {
             tuning_result_index = 0;
-            printf("(%ju) blocksize_bits %10ju; blocksize %4jukb; free_bits %5ju; smallstep: %2ju; mediumstep %2ju; passes %3ju/%3ju; time %f/%f;average %f\n", (uintmax_t)step,
-                            (uintmax_t)tuning_result[tuning_result_index].blocksize_bits, (uintmax_t)tuning_result[tuning_result_index].blocksize_kb,(uintmax_t)tuning_result[tuning_result_index].free_bits,
-                            (uintmax_t)tuning_result[tuning_result_index].smallstep_faster,(uintmax_t)tuning_result[tuning_result_index].mediumstep_faster,
-                            (uintmax_t)tuning_result[tuning_result_index].passes, (uintmax_t) tuning_result[tuning_result_index].sample_max,
-                            tuning_result[tuning_result_index].elapsed_time, tuning_result[tuning_result_index].sample_duration, tuning_result[tuning_result_index].avg);
-            if (option_verboselevel >= 3) {
-                for (counter_t tuning_result_index=0; tuning_result_index<min(10,tuning_results); tuning_result_index++) {
-                    printf("...blocksize_bits %10ju; blocksize %4jukb; free_bits %5ju; smallstep: %2ju; mediumstep %2ju; passes %3ju/%3ju; time %f/%f;average %f\n", 
-                            (uintmax_t)tuning_result[tuning_result_index].blocksize_bits, (uintmax_t)tuning_result[tuning_result_index].blocksize_kb,(uintmax_t)tuning_result[tuning_result_index].free_bits,
-                            (uintmax_t)tuning_result[tuning_result_index].smallstep_faster,(uintmax_t)tuning_result[tuning_result_index].mediumstep_faster,
-                            (uintmax_t)tuning_result[tuning_result_index].passes, (uintmax_t) tuning_result[tuning_result_index].sample_max,
-                            tuning_result[tuning_result_index].elapsed_time, tuning_result[tuning_result_index].sample_duration, tuning_result[tuning_result_index].avg);
+            printf("(%ju) ",(uintmax_t)step); tuning_result_print(tuning_result[tuning_result_index]);
+            fflush(stdout);
+            verbose(3) {
+                for (counter_t tuning_result_index=0; tuning_result_index<min(40,tuning_results); tuning_result_index++) {
+                    printf("..."); tuning_result_print(tuning_result[tuning_result_index]);
                 }
             }
         }
 
         tuning_results = tuning_results / 2;
 
-        for (counter_t tuning_result_index=0; tuning_result_index<tuning_results; tuning_result_index++) {
-            tune_benchmark(tuning_result, tuning_result_index);
-            tuning_result[tuning_result_index].sample_max += sample_max;
+        verbose(2) printf("\n");
+        for (counter_t i=0; i<tuning_results; i++) {
+            verbose(1) { printf("\rTuning...found %ju options..benchmarking step %ju - tuning %3ju options",(uintmax_t)tuning_results_max,(uintmax_t)step,i); fflush(stdout); }
+            tune_benchmark(tuning_result, i);
+            tuning_result[i].sample_max += sample_max;
+            tuning_result[i].sample_duration += 0.05;
         }
+        verbose(2) printf("\n");
         
     }
     tuning_result_type best_result = tuning_result[0];
-    if (option_verboselevel >= 1) {
-        tuning_result_index = 0;
-        printf(".Best result: blocksize %4jukb; free_bits %ju; smallstep: %ju; mediumstep %ju; passes %3ju/%3ju; time %f/%f;average %f\n", 
-                 (uintmax_t)tuning_result[tuning_result_index].blocksize_kb,(uintmax_t)tuning_result[tuning_result_index].free_bits,
-                (uintmax_t)tuning_result[tuning_result_index].smallstep_faster,(uintmax_t)tuning_result[tuning_result_index].mediumstep_faster,
-                (uintmax_t)tuning_result[tuning_result_index].passes, (uintmax_t) tuning_result[tuning_result_index].sample_max,
-                tuning_result[tuning_result_index].elapsed_time, tuning_result[tuning_result_index].sample_duration, tuning_result[tuning_result_index].avg);
+    verbose(2) {
+        printf(".Best result:"); tuning_result_print(best_result);
     }
+    verbose(1) printf("\n");
 
     free(tuning_result);
     return best_result;
 }
 
+
 int main(int argc, char *argv[]) {
     
-    uintmax_t maxints  = default_sieve_limit;
-    if (option_runonce) { // used for stats and debugging
-        struct sieve_state* sieve_instance = sieve(maxints, maxints);
-        delete_sieve(sieve_instance);
-        exit(0);
-    }
-
+    // initialize options
+    double option_max_time = default_max_time;
+    counter_t option_maxFactor  = default_sieve_limit;
+    counter_t option_showMaxFactor = default_showMaxFactor;
     int option_verboselevel = default_verbose_level;
     int option_check = default_check_level;
     int option_tunelevel = default_tune_level;
+    int option_threads = 1;
+    #ifdef _OPENMP
+    int max_threads = omp_get_max_threads();
+    option_threads = max_threads;
+    #endif
+
+    // processing command line changes to options
     for (int arg=1; arg < argc; arg++) {
         if (strcmp(argv[arg], "--help")==0) { usage(argv[0]); }
         else if (strcmp(argv[arg], "--verbose")==0) {
@@ -853,7 +835,7 @@ int main(int argc, char *argv[]) {
             if (sscanf(argv[arg], "%d", &option_verboselevel) != 1 || option_verboselevel > 4) {
                 fprintf(stderr, "Error: Invalid measurement time: %s\n", argv[arg]); usage(argv[0]);
             }
-            printf("Verbose level set to %d\n",option_verboselevel);
+            verbose(1) printf("Verbose level set to %d\n",option_verboselevel);
         } 
         else if (strcmp(argv[arg], "--check")==0) { option_check=1; }
         else if (strcmp(argv[arg], "--tune")==0) { option_tunelevel=0;
@@ -861,60 +843,131 @@ int main(int argc, char *argv[]) {
             if (sscanf(argv[arg], "%d", &option_tunelevel) != 1 || option_tunelevel > 4) {
                 fprintf(stderr, "Error: Invalid tune level: %s\n", argv[arg]); usage(argv[0]);
             }
-            printf("Tune level set to %d\n",option_tunelevel);
+            verbose(1) printf("Tune level set to %d\n",option_tunelevel);
         }
-        else if (sscanf(argv[arg], "%ju", &maxints) != 1) {
+        else if (strcmp(argv[arg], "--time")==0) { option_max_time=0;
+            if (++arg >= argc) { fprintf(stderr, "No time specified\n"); usage(argv[0]); }
+            if (sscanf(argv[arg], "%lf", &option_max_time) != 1 ) {
+                fprintf(stderr, "Error: Invalid max time: %s\n", argv[arg]); usage(argv[0]);
+            }
+            verbose(1) printf("Max time is set to %d seconds\n",option_tunelevel);
+        }
+        else if (strcmp(argv[arg], "--show")==0) { option_showMaxFactor=0;
+            if (++arg >= argc) { fprintf(stderr, "No show maximum specified\n"); usage(argv[0]); }
+            if (sscanf(argv[arg], "%ju", (uintmax_t*)&option_showMaxFactor) != 1 || option_showMaxFactor > option_maxFactor) {
+                fprintf(stderr, "Error: Invalid show maximum: %s\n", argv[arg]); usage(argv[0]);
+            }
+            verbose(1) printf("Show maximum set to %ju\n",(uintmax_t)option_showMaxFactor);
+        }
+        else if (strcmp(argv[arg], "--threads")==0) { 
+            if (++arg >= argc) { fprintf(stderr, "No thread maximum specified\n"); usage(argv[0]); }
+        #ifdef _OPENMP
+            if (strcmp(argv[arg], "all")==0) option_threads = max_threads;
+            else if (strcmp(argv[arg], "half")==0) option_threads = max_threads>>1;
+            else if (sscanf(argv[arg], "%d", &option_threads) != 1 ) { fprintf(stderr, "Error: Invalid max threads: %s\n", argv[arg]); usage(argv[0]); }
+            if (option_threads <1)  option_threads = 1;
+            if (option_threads > max_threads)  option_threads = max_threads;
+            verbose(1) printf("Thread maximum set to %ju\n",(uintmax_t)option_threads);
+        #else
+            verbose(1) printf("This is the version without multithreading - ignoring threads\n");
+        #endif
+        }
+        else if (sscanf(argv[arg], "%ju", (uintmax_t*)&option_maxFactor) != 1) {
             fprintf(stderr, "Invalid size %s\n",argv[arg]); usage(argv[0]); 
-            printf("Maximum set to %ju\n",(uintmax_t)maxints);
+            printf("Maximum set to %ju\n",(uintmax_t)option_maxFactor);
         }
     }
 
-    struct timespec start_time,end_time;
-
+    // for debugging
+    if (option_runonce) { // used for stats and debugging
+        struct sieve_t* sieve = sieve_shake(option_maxFactor, default_blocksize);
+        printf("\nResult set:\n");
+        show_primes(sieve, option_showMaxFactor);
+        int valid = validatePrimeCount(sieve,3);
+        if (!valid) printf("The sieve is NOT valid\n");
+        else printf("The sieve is VALID\n");
+        sieve_delete(sieve);
+        exit(0);
+    }
+        
+    // if --check is needed
     if (option_check) {
         // Count the number of primes and validate the result
-        if (option_verboselevel >= 1) printf("Validating... ");
-        if (option_verboselevel >= 2) printf("\n");
+        verbose(1) { printf("Validating..."); fflush(stdout); }
+        verbose(2) printf("\n");
 
         // validate algorithm - run one time for all sizes
-        for (counter_t sieveSize_check = 100; sieveSize_check <= 100000000; sieveSize_check *=10) {
-            if (option_verboselevel >= 2) printf("...Checking size %ju ...",(uintmax_t)sieveSize_check);
-            struct sieve_state *sieve_instance_check;
+        for (counter_t sieveSize_check = 100; sieveSize_check <= 10000000; sieveSize_check *=10) {
+            verbose(2) { printf("...Checking size %ju ...",(uintmax_t)sieveSize_check); fflush(stdout); }
+            struct sieve_t *sieve_check;
             for (counter_t blocksize_bits=1024; blocksize_bits<=2*1024*8; blocksize_bits *= 2) {
-                if (option_verboselevel >= 3) printf(".blocksize %ju-",(uintmax_t)blocksize_bits);
-                sieve_instance_check = sieve(sieveSize_check, blocksize_bits);
-                int valid = validatePrimeCount(sieve_instance_check,option_verboselevel);
-                delete_sieve(sieve_instance_check);
-                if (!valid) return 0; else if (option_verboselevel >= 3) printf("valid;");
+                verbose(3) printf(".blocksize %ju-",(uintmax_t)blocksize_bits);
+                sieve_check = sieve_shake(sieveSize_check, blocksize_bits);
+                int valid = validatePrimeCount(sieve_check,option_verboselevel);
+                sieve_delete(sieve_check);
+                if (!valid) return 0; else verbose(3) printf("valid;");
             }
-            if (option_verboselevel >= 2) printf("\n");
+            verbose(2) printf("valid\n");
         }
-        if (option_verboselevel >= 1) printf("...Valid algorithm\n");
+        verbose(1) printf("valid algorithm\n");
     }
     
+    // tuning - try combinations of different settings and apply these
     counter_t best_blocksize_bits = default_blocksize;
     if (option_tunelevel) {
-        tuning_result_type tuning_result = tune(option_tunelevel, maxints, option_verboselevel);
+        tuning_result_type tuning_result = tune(option_tunelevel, option_maxFactor, option_threads, option_verboselevel);
         global_SMALLSTEP_FASTER = tuning_result.smallstep_faster;
         global_MEDIUMSTEP_FASTER = tuning_result.mediumstep_faster;
+        global_VECTORSTEP_FASTER = tuning_result.vectorstep_faster;
         best_blocksize_bits = tuning_result.blocksize_bits;
     }
 
-    double max_time = default_sieve_duration;
-    if (best_blocksize_bits > 0) {
-        if (option_verboselevel >= 1) printf("Benchmarking...\n");
+    // time the algorithm using the best settings
+    struct timespec start_time,end_time;
+    counter_t used_threads = 1;
+
+    // this section will only by linked in if the -fopenmp option is used.
+    // will default to max threads and then device by 2 for a non-hyperthreading option
+    #ifdef _OPENMP
+    counter_t max_tries = 4;
+    for(counter_t threads=option_threads; threads>=1; threads= (threads>>1)  ) {
+        omp_set_num_threads(threads);
+        used_threads=threads;
+        if (--max_tries ==1) threads = 2;
+    #endif
+        verbose(2) printf("\n");
+        verbose(1) printf("Benchmarking... with blocksize %ju steps: %ju/%ju/%ju and %ju threads for %.1f seconds - Results:\n", (uintmax_t)best_blocksize_bits,(uintmax_t)global_SMALLSTEP_FASTER, (uintmax_t)global_MEDIUMSTEP_FASTER,(uintmax_t)global_VECTORSTEP_FASTER,(uintmax_t)used_threads,option_max_time );
         counter_t passes = 0;
         counter_t blocksize_bits = best_blocksize_bits;
         double elapsed_time = 0;
-        struct sieve_state *sieve_instance;
+        struct sieve_t *sieve;
         clock_gettime(CLOCK_MONOTONIC,&start_time);
-        while (elapsed_time <= max_time) {
-            sieve_instance = sieve(maxints, blocksize_bits);//blocksize_bits);
-            delete_sieve(sieve_instance);
+        #ifdef _OPENMP
+        #pragma omp parallel reduction(+:passes)
+        #endif
+        for (;elapsed_time <= option_max_time;) {
+            sieve = sieve_shake(option_maxFactor, blocksize_bits);//blocksize_bits);
+            sieve_delete(sieve);
             passes++;
             clock_gettime(CLOCK_MONOTONIC,&end_time);
             elapsed_time = end_time.tv_sec + end_time.tv_nsec*1e-9 - start_time.tv_sec - start_time.tv_nsec*1e-9;
         }
-        printf("rogiervandam_extend;%ju;%f;1;algorithm=other,faithful=yes,bits=1\n", (uintmax_t)passes,elapsed_time);
+        #ifdef _OPENMP
+        printf("rogiervandam_extend_epar;%ju;%f;%ju;algorithm=other,faithful=yes,bits=1\n", (uintmax_t)passes,elapsed_time,(uintmax_t)used_threads);
+        #else
+        printf("rogiervandam_extend;%ju;%f;%ju;algorithm=other,faithful=yes,bits=1\n", (uintmax_t)passes,elapsed_time,(uintmax_t)used_threads);
+        #endif
+        verbose(1) printf("\033[0;32m(Passes - per %.1f seconds: %f - per second \033[1;33m%.1f\033[0;32m)\033[0m\n", option_max_time, option_max_time*passes/elapsed_time, passes/elapsed_time);
+        verbose(1) if (used_threads>1) printf("\033[0;32m(Passes per thread (total %ju) - per %.1f seconds: %.1f - per second \033[1;33m%.1f\033[0;32m)\033[0m\n", (uintmax_t)used_threads,  option_max_time, option_max_time*passes/elapsed_time/used_threads, passes/elapsed_time/used_threads);
+    #ifdef _OPENMP
+    }
+    #endif
+
+    // show results for --show command line option
+    if (option_showMaxFactor > 0) {
+        printf("Show result set:\n");
+        struct sieve_t* sieve = sieve_shake(option_maxFactor, option_maxFactor);
+        show_primes(sieve, option_showMaxFactor);
+        sieve_delete(sieve);
     }
 }

--- a/PrimeC/solution_5/sieve_extend.c
+++ b/PrimeC/solution_5/sieve_extend.c
@@ -30,11 +30,6 @@
 #define verbose(level)    if (level < compile_verboselevel) if (option.verboselevel >= level) 
 #define verbose_at(level) if (level < compile_verboselevel) if (option.verboselevel == level)
 
-// set this to the level of verbose messages that will be compiled
-#define compile_verboselevel 4 
-#define verbose(level)    if (level < compile_verboselevel) if (option.verboselevel >= level) 
-#define verbose_at(level) if (level < compile_verboselevel) if (option.verboselevel == level)
-
 // defaults
 #define default_sieve_limit 1000000
 #define default_blocksize (32*1024*8)
@@ -44,9 +39,7 @@
 #define default_verbose_level 0
 #define default_tune_level 1
 #define default_check_level 0
-#define default_check_level 0
 #define default_show_primes_on_error 100
-#define default_showMaxFactor 0
 #define default_showMaxFactor 0
 #define anticiped_cache_line_bytesize 128
 
@@ -380,7 +373,7 @@ static inline void  __attribute__((always_inline)) setBitsTrue_largeRange_vector
             for(register counter_t vector_wordstart = (current_vector_start | (WORD_SIZE_counter*3)); wordstart(index) == vector_wordstart; index += step) mask |= markmask(index);
             quadmask[3] = mask;
         #else
-            for(int qw = 0; qw < 4; qw++) {
+            for(int qw = 0; qw < VECTOR_ELEMENTS; qw++) {
                 register bitword_t mask = SAFE_ZERO;
                 #pragma GCC ivdep
                 for(register counter_t vector_wordstart = (current_vector_start | (WORD_SIZE_counter*qw)); wordstart(index) == vector_wordstart; index += step) mask |= markmask(index);

--- a/PrimeC/solution_5/sieve_extend.c
+++ b/PrimeC/solution_5/sieve_extend.c
@@ -201,10 +201,10 @@ static inline void __attribute__((always_inline)) applyMask_word(bitword_t* __re
     register const counter_t step_3 = step_2 + step;
     register const counter_t step_4 = step << 2;
 
-    register bitword_t* __restrict index_ptr            =  __builtin_assume_aligned(&bitstorage[index_word],8);
+    register bitword_t* __restrict index_ptr            =  &bitstorage[index_word];
 
     const counter_t range_stop_word = wordindex(range_stop);
-    register const bitword_t* __restrict fast_loop_ptr  =  __builtin_assume_aligned(&bitstorage[((range_stop_word>step_4) ? (range_stop_word - step_4):0)],8);
+    register const bitword_t* __restrict fast_loop_ptr  =  &bitstorage[((range_stop_word>step_4) ? (range_stop_word - step_4):0)];
 
     #pragma GCC ivdep
     while (index_ptr < fast_loop_ptr) {
@@ -214,7 +214,7 @@ static inline void __attribute__((always_inline)) applyMask_word(bitword_t* __re
         *(index_ptr + step_3) |= mask; 
         index_ptr += step_4;
     }
-    register const bitword_t* __restrict range_stop_ptr = __builtin_assume_aligned(&bitstorage[(range_stop_word)],8);
+    register const bitword_t* __restrict range_stop_ptr = &bitstorage[(range_stop_word)];
 
     for (counter_t i=4; i-- && likely(index_ptr < range_stop_ptr);  index_ptr += step) { // signal compiler that only <4 iterations are left
         *index_ptr |= mask; 
@@ -229,8 +229,6 @@ static inline void __attribute__((always_inline)) applyMask_word(bitword_t* __re
 // same as word mask, but at a vector level - uses the sse/avx extensions, hopefully
 static inline void __attribute__((always_inline)) applyMask_vector(bitvector_t* __restrict bitstorage, const counter_t step, const counter_t range_stop, const bitvector_t mask, counter_t index_vector) 
 {
-    bitstorage = __builtin_assume_aligned(bitstorage, anticiped_cache_line_bytesize);
-
     const counter_t range_stop_vector = vectorindex(range_stop);
     register const counter_t step_4 = step << 2;
     register bitvector_t* __restrict index_ptr      =  &bitstorage[index_vector];
@@ -435,7 +433,6 @@ static inline void __attribute__((always_inline)) continuePattern_smallSize(bitw
 
 static inline void  __attribute__((always_inline)) continuePattern_aligned(bitword_t* bitstorage, const counter_t source_start, const counter_t size, const counter_t destination_stop)
 {
-    bitstorage = __builtin_assume_aligned(bitstorage, anticiped_cache_line_bytesize);
     debug printf("Extending sieve size %ju in %ju bit range (%ju-%ju) using aligned (%ju copies)\n", (uintmax_t)size, (uintmax_t)destination_stop-(uintmax_t)source_start,(uintmax_t)source_start,(uintmax_t)destination_stop, (uintmax_t)(((uintmax_t)destination_stop-(uintmax_t)source_start)/(uintmax_t)size));
     debug timerLapStart();
 
@@ -461,7 +458,6 @@ static inline void  __attribute__((always_inline)) continuePattern_aligned(bitwo
 
 static inline void  __attribute__((always_inline)) continuePattern_shiftright(bitword_t* __restrict bitstorage, const counter_t source_start, const counter_t size, const counter_t destination_stop)
 {
-    bitstorage = __builtin_assume_aligned(bitstorage, anticiped_cache_line_bytesize);
     debug printf("Extending sieve size %ju in %ju bit range (%ju-%ju) using shiftright (%ju copies)\n", (uintmax_t)size, (uintmax_t)destination_stop-(uintmax_t)source_start,(uintmax_t)source_start,(uintmax_t)destination_stop, (uintmax_t)(((uintmax_t)destination_stop-(uintmax_t)source_start)/(uintmax_t)size));
     debug timerLapStart();
 
@@ -531,7 +527,6 @@ static inline void  __attribute__((always_inline)) continuePattern_shiftright(bi
 
 static inline counter_t  __attribute__((always_inline)) continuePattern_shiftleft_unrolled(bitword_t* __restrict bitstorage, const counter_t aligned_copy_word, const bitshift_t shift, counter_t copy_word, counter_t source_word) 
 {
-    bitstorage = __builtin_assume_aligned(bitstorage, anticiped_cache_line_bytesize);
     const counter_t fast_loop_stop_word = (aligned_copy_word>2) ? (aligned_copy_word - 2) : 0; // safe for unsigned ints
     register const bitshift_t shift_flipped = WORD_SIZE_bitshift-shift;
     counter_t distance = 0;
@@ -551,7 +546,6 @@ static inline counter_t  __attribute__((always_inline)) continuePattern_shiftlef
 
 static inline void __attribute__((always_inline)) continuePattern_shiftleft(bitword_t* bitstorage, const counter_t source_start, const counter_t size, const counter_t destination_stop)
 {
-    // bitstorage = __builtin_assume_aligned(bitstorage, anticiped_cache_line_bytesize);
     debug printf("Extending sieve size %ju in %ju bit range (%ju-%ju) using shiftleft (%ju copies)\n", (uintmax_t)size, (uintmax_t)destination_stop-(uintmax_t)source_start,(uintmax_t)source_start,(uintmax_t)destination_stop, (uintmax_t)(((uintmax_t)destination_stop-(uintmax_t)source_start)/(uintmax_t)size));
     debug timerLapStart();
     
@@ -615,7 +609,6 @@ static inline void __attribute__((always_inline)) continuePattern(bitword_t* bit
 
 static counter_t sieve_block_stripe(bitword_t* bitstorage, const counter_t block_start, const counter_t block_stop, const counter_t prime_start, const counter_t maxprime)
 {
-    bitstorage = __builtin_assume_aligned(bitstorage, anticiped_cache_line_bytesize);
     counter_t prime = prime_start;
     counter_t start = 0;
     counter_t step  = prime * 2 + 1;

--- a/PrimeC/solution_5/test.sh
+++ b/PrimeC/solution_5/test.sh
@@ -2,7 +2,6 @@
 rm --force *.s
 rm --force *.o
 CC="-Ofast -march=native -funroll-all-loops -mtune=native -fno-asynchronous-unwind-tables -malign-data=cacheline -fno-exceptions -masm=intel -fverbose-asm  -mavx -W -Wall -Wno-unused-function"
-#CC="-Ofast -march=native -mtune=native -funroll-all-loops -malign-data=cacheline" 
 PAR="-fopenmp"
 PAREXT="_epar"
 gcc -c -Wa,-asdlh  $CC $1.c > $1.s

--- a/PrimeC/solution_5/test.sh
+++ b/PrimeC/solution_5/test.sh
@@ -5,8 +5,8 @@ CC="-Ofast -march=native -funroll-all-loops -mtune=native -fno-asynchronous-unwi
 #CC="-Ofast -march=native -mtune=native -funroll-all-loops -malign-data=cacheline" 
 PAR="-fopenmp"
 PAREXT="_epar"
-gcc -c -g -Wa,-asdlh  $CC $1.c > $1.s
-gcc -c -g -Wa,-asdlh  $CC $PAR $1.c > $1$PAREXT.s
+gcc -c -Wa,-asdlh  $CC $1.c > $1.s
+gcc -c -Wa,-asdlh  $CC $PAR $1.c > $1$PAREXT.s
 gcc $CC -o $1 $1.c -lm
 gcc $CC $PAR -o $1$PAREXT $1.c -lm
 ./$1 $2 $3 $4 $5 $6 $7

--- a/PrimeC/solution_5/test.sh
+++ b/PrimeC/solution_5/test.sh
@@ -1,11 +1,11 @@
 #!/bin/sh
 rm --force *.s
 rm --force *.o
-CC="-Ofast -march=native -funroll-all-loops -mtune=native -fno-asynchronous-unwind-tables -malign-data=cacheline -fno-exceptions -masm=intel -fverbose-asm  -mavx -W -Wall -Wno-unused-function"
+CC="-Ofast -march=native -funroll-all-loops -mtune=native -fno-asynchronous-unwind-tables -malign-data=cacheline -fno-exceptions -masm=intel -fverbose-asm  -mavx -W -Wall -Wno-unused-function -Wvector-operation-performance -Wno-psabi"
 PAR="-fopenmp"
 PAREXT="_epar"
 gcc -c -Wa,-asdlh  $CC $1.c > $1.s
 gcc -c -Wa,-asdlh  $CC $PAR $1.c > $1$PAREXT.s
-gcc $CC -o $1 $1.c -lm
+gcc $CC -o $1 $1.c -lm -Du64_v4
 gcc $CC $PAR -o $1$PAREXT $1.c -lm
 ./$1 $2 $3 $4 $5 $6 $7

--- a/PrimeC/solution_5/test.sh
+++ b/PrimeC/solution_5/test.sh
@@ -1,4 +1,12 @@
 #!/bin/sh
-CC="gcc -Ofast -march=native -mtune=native -funroll-all-loops" 
-$CC -o $1 $1.c -lm
+rm --force *.s
+rm --force *.o
+CC="-Ofast -march=native -funroll-all-loops -mtune=native -fno-asynchronous-unwind-tables -malign-data=cacheline -fno-exceptions -masm=intel -fverbose-asm  -mavx -W -Wall -Wno-unused-function"
+#CC="-Ofast -march=native -mtune=native -funroll-all-loops -malign-data=cacheline" 
+PAR="-fopenmp"
+PAREXT="_epar"
+gcc -c -g -Wa,-asdlh  $CC $1.c > $1.s
+gcc -c -g -Wa,-asdlh  $CC $PAR $1.c > $1$PAREXT.s
+gcc $CC -o $1 $1.c -lm
+gcc $CC $PAR -o $1$PAREXT $1.c -lm
 ./$1 $2 $3 $4 $5 $6 $7


### PR DESCRIPTION
Optimized the extend algorithm in C - up to 30% speed increase depending on platform. 
Supports multiprocessor (Gustafson scaling / embarrassingly parallel)

## Description
Highly optimized version for C using word and vector unrolling, hints and other tweaks.
Multiprocessor also supported.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.