### PR TITLE
Fix some incorrect assignments with BOOL version and add BITS version

### DIFF
--- a/PrimeAlgol68g/solution_1/Dockerfile
+++ b/PrimeAlgol68g/solution_1/Dockerfile
@@ -7,8 +7,8 @@ RUN apt-get update -qq \
 
 WORKDIR /opt/app
 COPY primes*.a68 run_primes.sh ./
-RUN a68g -O3 --compile primes.a68
-RUN a68g -O3 --compile primes_bit.a68
+RUN a68g -O3 --compile primes.a68 && \
+    a68g -O3 --compile primes_bit.a68
 
 ENTRYPOINT [ "./run_primes.sh" ]
 

--- a/PrimeAlgol68g/solution_1/Dockerfile
+++ b/PrimeAlgol68g/solution_1/Dockerfile
@@ -6,8 +6,9 @@ RUN apt-get update -qq \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/app
-COPY primes.a68 .
+COPY primes*.a68 run_primes.sh ./
 RUN a68g -O3 --compile primes.a68
+RUN a68g -O3 --compile primes_bit.a68
 
-ENTRYPOINT [ "./primes.sh" ]
+ENTRYPOINT [ "./run_primes.sh" ]
 

--- a/PrimeAlgol68g/solution_1/README.md
+++ b/PrimeAlgol68g/solution_1/README.md
@@ -4,6 +4,12 @@
 ![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
 ![Bit count](https://img.shields.io/badge/Bits-unknown-yellowgreen)
+![Bit count](https://img.shields.io/badge/Bits-1-green)
+
+* `primes.a68` uses `BOOL` for each sieve item
+* `primes_bit.a68` uses `BITS` to contain a machine word worth of sieve items,
+  where a machine word is defined by the `a68g` system variable `bits width`
+  (typically 32 or 64 -- 32 on my system for some reason)
 
 ## Run instructions
 
@@ -25,8 +31,12 @@ On an Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz with 32 GB of memory on a Windows 
 a Ubuntu 22.04 VM in VirtualBox 6.1:
 
 ```
-Passes: 150, Time: 5.02579600, Avg: .03350531, Limit: 1000000, Count1: 78498, Count2: 78498, Valid: true
+Passes: 153, Time: 5.00621800, Avg: .03272038, Limit: 1000000, Count1: 78498, Count2: 78498, Valid: true
 
-rzuckerm;150;5.02579600;1;algorithm=base,faithful=yes,bits=unknown
+rzuckerm;153;5.00621800;1;algorithm=base,faithful=yes
+
+Passes: 14, Time: 5.28676900, Avg: .37762636, Limit: 1000000, Count1: 78498, Count2: 78498, Valid: true
+
+rzuckerm;14;5.28676900;1;algorithm=base,faithful=yes,bits=1
 ```
 

--- a/PrimeAlgol68g/solution_1/primes.a68
+++ b/PrimeAlgol68g/solution_1/primes.a68
@@ -30,7 +30,7 @@ PROC run sieve = (INT sieve size) PRIMESIEVE:
 PROC count primes = (PRIMESIEVE this) INT:
 (
     INT count := 1;
-    REF []BOOL sieve = sieve OF this;
+    REF []BOOL sieve := sieve OF this;
     FOR k TO UPB sieve
     DO
         IF sieve[k]
@@ -45,7 +45,7 @@ PROC validate results = (PRIMESIEVE this) BOOL:
 (
     # Cannot support sieve size over 100 million #
 
-    INT sieve size = sieve size OF this;
+    INT sieve size := sieve size OF this;
     INT expected count := -1;
     IF sieve size = 10 THEN expected count := 4
     ELIF sieve size = 100 THEN expected count := 25
@@ -69,8 +69,8 @@ PROC print results = (PRIMESIEVE this, BOOL show results, REAL duration, INT pas
     FI;
 
     INT count := 1;
-    INT sieve size = sieve size OF this;
-    REF []BOOL sieve = sieve OF this;
+    INT sieve size := sieve size OF this;
+    REF []BOOL sieve := sieve OF this;
     FOR k TO UPB sieve
     DO
         IF sieve[k]

--- a/PrimeAlgol68g/solution_1/primes_bit.a68
+++ b/PrimeAlgol68g/solution_1/primes_bit.a68
@@ -1,0 +1,157 @@
+# Sieve of Eratosthenes in Algol 68g using bits #
+
+PROC set bits = (REF []BITS this, INT num bits) VOID:
+(
+    BITS all ones := NOT 2r0;
+    INT num bytes := UPB this;
+    FOR k TO num bytes - 1
+    DO
+        this[k] := all ones
+    OD;
+
+    BITS remaining ones := all ones SHL ((bits width - num bits) MOD bits width);
+    this[num bytes] := remaining ones
+);
+
+PROC clear bit = (REF []BITS this, INT bit num) VOID:
+(
+    INT byte num := 1 + ENTIER((bit num - 1) / bits width);
+    INT bit pos := 1 + ((bit num - 1) MOD bits width);
+    this[byte num] := bit pos CLEAR this[byte num]
+);
+
+PROC get bit = (REF []BITS this, INT bit num) BOOL:
+(
+    INT byte num := 1 + ENTIER((bit num - 1) / bits width);
+    INT bit pos := 1 + ((bit num - 1) MOD bits width);
+    bit pos ELEM this[byte num]
+);
+
+MODE PRIMESIEVE = STRUCT(INT sieve size, INT num bits, REF []BITS sieve);
+
+PROC run sieve = (INT sieve size) PRIMESIEVE:
+(
+    INT num bits := ENTIER((sieve size - 1) / 2);
+    INT num bytes := ENTIER((num bits + bits width - 1) / bits width);
+    HEAP [num bytes]BITS sieve;
+    set bits(sieve, num bits);
+
+    INT q := ENTIER (sqrt(sieve size) / 2);
+    INT bit := 1;
+    WHILE bit <= q
+    DO
+        IF get bit(sieve, bit)
+        THEN
+            FOR k FROM 2 * bit * (bit + 1) BY 2 * bit + 1 TO num bits
+            DO
+                clear bit(sieve, k)
+            OD
+        FI;
+        bit +:= 1
+    OD;
+    PRIMESIEVE(sieve size, num bits, sieve)
+);
+
+PROC count primes = (PRIMESIEVE this) INT:
+(
+    INT count := 1;
+    REF []BITS sieve := sieve OF this;
+    INT num bits := num bits OF this;
+    FOR k TO num bits
+    DO
+        IF get bit(sieve, k)
+        THEN
+            count +:= 1
+        FI
+    OD;
+    count
+);
+
+PROC validate results = (PRIMESIEVE this) BOOL:
+(
+    # Cannot support sieve size over 100 million #
+
+    INT sieve size := sieve size OF this;
+    INT expected count := -1;
+    IF sieve size = 10 THEN expected count := 4
+    ELIF sieve size = 100 THEN expected count := 25
+    ELIF sieve size = 1 000 THEN expected count := 168
+    ELIF sieve size = 10 000 THEN expected count := 1229
+    ELIF sieve size = 100 000 THEN expected count := 9592
+    ELIF sieve size = 1 000 000 THEN expected count := 78498
+    ELIF sieve size = 10 000 000 THEN expected count := 664579
+    ELIF sieve size = 100 000 000 THEN expected count := 5761455
+    ELSE print(("Invalid sieve size", new line))
+    FI;
+
+    count primes(this) = expected count
+);
+
+PROC print results = (PRIMESIEVE this, BOOL show results, REAL duration, INT passes) VOID:
+(
+    IF show results
+    THEN
+        print("2, ")
+    FI;
+
+    INT count := 1;
+    INT sieve size := sieve size OF this;
+    INT num bits := num bits OF this;
+    REF []BITS sieve := sieve OF this;
+    FOR k TO num bits
+    DO
+        IF get bit(sieve, k)
+        THEN
+            IF show results
+            THEN
+                print((whole(2*k + 1, 0), ", "))
+            FI;
+            count +:= 1
+        FI
+    OD;
+
+    IF show results
+    THEN
+        print(newline)
+    FI;
+
+    print((
+        "Passes: ", whole(passes, 0),
+        ", Time: ", fixed(duration, 0, 8),
+        ", Avg: ", fixed(duration / passes, 0, 8),
+        ", Limit: ", whole(sieve size, 0),
+        ", Count1: ", whole(count, 0),
+        ", Count2: ", whole(count primes(this), 0),
+        ", Valid: ", (validate results(this) | "true" | "false"),
+        newline
+    ));
+    print((
+        newline,
+        "rzuckerm;", whole(passes, 0),
+        ";", fixed(duration, 0, 8),
+        ";1;algorithm=base,faithful=yes,bits=1",
+        newline
+    ))
+    
+);
+
+REAL start = seconds;
+INT passes := 0;
+INT n := 1 000 000;
+BOOL show results := FALSE;
+WHILE 
+    passes +:= 1;
+
+    PRIMESIEVE sieve = run sieve(n);
+
+    IF (seconds - start) >= 5
+    THEN
+        print results(sieve, show results, seconds - start, passes);
+        FALSE
+    ELSE
+        TRUE
+    FI
+DO
+    SKIP
+OD
+

--- a/PrimeAlgol68g/solution_1/run_primes.sh
+++ b/PrimeAlgol68g/solution_1/run_primes.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+for script in primes primes_bit
+do
+    ./${script}.sh
+    echo ""
+done
+


### PR DESCRIPTION
## Description
In the original implementation that uses `BOOL`, there were some `=` operators that should have been `:=`. An equivalent implementation uses the `BITS` data type has been added for comparison. This is 10x slower, but I thought it would be interesting to have. If this should be made a separate solution, please let me know.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
