### PR TITLE
Improve speed of Algol bits by about 1.6

### DIFF
--- a/PrimeAlgol68g/solution_1/README.md
+++ b/PrimeAlgol68g/solution_1/README.md
@@ -35,8 +35,8 @@ Passes: 153, Time: 5.00621800, Avg: .03272038, Limit: 1000000, Count1: 78498, Co
 
 rzuckerm;153;5.00621800;1;algorithm=base,faithful=yes
 
-Passes: 14, Time: 5.28676900, Avg: .37762636, Limit: 1000000, Count1: 78498, Count2: 78498, Valid: true
+Passes: 23, Time: 5.09794500, Avg: .22164978, Limit: 1000000, Count1: 78498, Count2: 78498, Valid: true
 
-rzuckerm;14;5.28676900;1;algorithm=base,faithful=yes,bits=1
+rzuckerm;23;5.09794500;1;algorithm=base,faithful=yes,bits=1
 ```
 

--- a/PrimeAlgol68g/solution_1/primes_bit.a68
+++ b/PrimeAlgol68g/solution_1/primes_bit.a68
@@ -13,11 +13,23 @@ PROC set bits = (REF []BITS this, INT num bits) VOID:
     this[num bytes] := remaining ones
 );
 
-PROC clear bit = (REF []BITS this, INT bit num) VOID:
+PROC clear bits = (REF []BITS this, INT num bits, INT start, INT step) VOID:
 (
-    INT byte num := 1 + ENTIER((bit num - 1) / bits width);
-    INT bit pos := 1 + ((bit num - 1) MOD bits width);
-    this[byte num] := bit pos CLEAR this[byte num]
+    INT byte num := 1 + ENTIER((start - 1) / bits width);
+    INT bit pos := 1 + ((start - 1) MOD bits width);
+    INT byte inc := ENTIER(step / bits width);
+    INT bit inc := step MOD bits width;
+    FOR k FROM start BY step TO num bits
+    DO
+        this[byte num] := bit pos CLEAR this[byte num];
+        byte num +:= byte inc;
+        bit pos +:= bit inc;
+        IF bit pos > bits width
+        THEN
+            bit pos -:= bits width;
+            byte num +:= 1
+        FI
+    OD
 );
 
 PROC get bit = (REF []BITS this, INT bit num) BOOL:
@@ -42,10 +54,7 @@ PROC run sieve = (INT sieve size) PRIMESIEVE:
     DO
         IF get bit(sieve, bit)
         THEN
-            FOR k FROM 2 * bit * (bit + 1) BY 2 * bit + 1 TO num bits
-            DO
-                clear bit(sieve, k)
-            OD
+            clear bits(sieve, num bits, 2 * bit * (bit + 1), 2 * bit + 1)
         FI;
         bit +:= 1
     OD;


### PR DESCRIPTION
## Description
Clearing the bits in a loop improved the speed from 14 to 23 passes (about 1.6 times faster).

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
