### PR TITLE
PHP Solution 2 with Bitwise storage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+PrimePHP/solution_2/vendor

--- a/PrimePHP/solution_2/Dockerfile
+++ b/PrimePHP/solution_2/Dockerfile
@@ -1,0 +1,10 @@
+FROM php:8.2-cli
+
+# Use the default production configuration, enable opcache & JIT
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" && \
+    printf "zend_extension=opcache.so\nopcache.enable=1\nopcache.enable_cli=1\nopcache.jit_buffer_size=100M\nopcache.jit=tracing\nmemory_limit=-1\n" >> "$PHP_INI_DIR/php.ini"
+
+WORKDIR /opt/app
+COPY *.php .
+
+ENTRYPOINT [ "php", "prime.php" ]

--- a/PrimePHP/solution_2/PrimeSieve.php
+++ b/PrimePHP/solution_2/PrimeSieve.php
@@ -1,0 +1,101 @@
+<?php declare(strict_types=1);
+
+class PrimeSieve implements Countable
+{
+    private array $rawbits;
+
+    private readonly int $rbs;
+
+    public function __construct(private readonly int $sieveSize)
+    {
+        $this->rbs = (int)(($sieveSize + 1) / 100);
+        $this->rawbits = array_fill(0, $this->rbs, 0);
+    }
+
+    public function __tostring(): string 
+    {
+        return implode(',', $this->primes());
+    }
+    
+    public function primes(): array 
+    {
+        $indexes = [];
+        for ($i = 3; $i <= $this->sieveSize; $i += 2) {
+            if (! $this->isComposite($i))
+                $indexes[] = $i;
+        }
+        return $indexes;
+    }
+
+    private function isComposite(int $n): bool
+    {
+        if ($n <= 1) return true;
+        if ($n <= 3) return false;
+        if ($n % 2 == 0 || $n % 3 == 0) return true;
+
+        $i = 5;
+        $w = 2;
+
+        while ($i * $i <= $n) {
+            if ($n % $i == 0) return true;
+
+            $i += $w;
+            $w = 6 - $w;
+        }
+
+        return false;
+    }
+
+    public function compute(): void
+    {
+        $factor = 3;
+        $q = sqrt($this->sieveSize);
+    
+        while ($factor <= $q) 
+        {
+            if (! $this->isComposite($factor)) {
+                $start = (int)($factor * $factor / 2);
+                for ($i = $start; $i < $this->rbs; $i += $factor)
+                    $this->rawbits[$i] |= 1 << ($factor % 100);
+            }
+
+            $factor += 2;
+        }
+    }
+
+    public function printResults(): void
+    {
+        echo $this, PHP_EOL;
+    }
+
+    public function count(): int 
+    { 
+        $sum = 1;
+        for ($i = 3; $i <= $this->sieveSize; $i += 2) {
+            if (! $this->isComposite($i))
+                $sum++;
+        }
+        return $sum;
+    }
+    
+    private const primeCounts = [
+        10 => 4, 
+        100 => 25, 
+        1000 => 168, 
+        10000 => 1229, 
+        100_000 => 9592, 
+        1000_000 => 78498,
+        10_000_000 => 664579,
+        100_000_000 => 5761455,
+    ];
+    
+    public function valid(): bool 
+    {
+        $result = $this->count();
+        $expected = self::primeCounts[$this->sieveSize] ?? -1;
+        $valid = ($expected == $result);
+        if (! $valid)
+            echo "correct result should be: $expected, got: $result", PHP_EOL;
+        return $valid;
+    }
+}

--- a/PrimePHP/solution_2/README.md
+++ b/PrimePHP/solution_2/README.md
@@ -13,8 +13,6 @@ The prime count storage utilises bitwise operations, as with many other high per
 
 This solution instead runs a series of ints as storage for every 100 units, storing the whole lot in an array. 
 
-_Finally_, of particular note (especially after the latest episode of Dave's Garage) is the core algorithm in this solution is heavily influenced and aided by ChatGPT, which assisted over many iterations of trial and error in producing a workable solution. In the spirit of that video's key frame - it really did help '10x' my solution!
-
 ### Running with PHP
 
 This solution is designed to run with PHP 8.2 or later. You will need The opcache module enabled and its JIT switched on for best results.

--- a/PrimePHP/solution_2/README.md
+++ b/PrimePHP/solution_2/README.md
@@ -19,10 +19,10 @@ _Finally_, of particular note (especially after the latest episode of Dave's Gar
 
 This solution is designed to run with PHP 8.2 or later. You will need The opcache module enabled and its JIT switched on for best results.
 
-```bash
+```
 cd path/to/sieve
 ```
-```php
+```
 php prime.php [--once] [--print] [--size=sieveSize]
 ```
 
@@ -40,12 +40,12 @@ Unit tests exist for and pass for sieve sizes 10 thru 100,000,000, with sizes 10
 
 First install Unit Test dependancies:
 
- ```bash
+ ```
  cd path/to/sieve
  composer install
  ```
  Then run tests:
- ```php
+ ```
  vendor/bin/phpunit --testdox tests
  ```
  

--- a/PrimePHP/solution_2/README.md
+++ b/PrimePHP/solution_2/README.md
@@ -2,16 +2,14 @@
 
 
 [![Minimum PHP Version](https://img.shields.io/badge/PHP-%3E%3D%208.2-yellow)](https://php.net/)
-![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
-![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
+![Algorithm](https://img.shields.io/badge/Algorithm-other-yellow)
+![Faithfulness](https://img.shields.io/badge/Faithful-no-red)
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
 ![Bit count](https://img.shields.io/badge/Bits-1-yellowgreen)
 
-This solution attempts to boost the performance out of PHP significantly, by using anything that will allow the interpreter and the Opcache JIT to precompile where possible. 
+This solution is in-effective but was a worthwhile test.
 
-The prime count storage utilises bitwise operations, as with many other high performance solutions for other languages. However, PHP has a limitation with regard to its type handling, and the maximum size it can allocate for a single integer. And so in my experiments simply replacing an array of bools with a singular int will only output the correct count for a sieve of 100 or 10. 
-
-This solution instead runs a series of ints as storage for every 100 units, storing the whole lot in an array. 
+The fixed algorithm is functional but impractical for speed.
 
 ### Running with PHP
 
@@ -47,25 +45,4 @@ First install Unit Test dependancies:
  vendor/bin/phpunit --testdox tests
  ```
  
-### Benchmarks / Performance
-
-Personal computer:
-
- - Apple M1 Max (ARM64) 64-bit
- - PHP: 8.2.2
- - Opcache: enabled
- - Opcache JIT: enabled
-
-#### Sieve 100,000
-sqonk;416899;5.00;1;algorithm=base,faithful=yes,bits=1
-
-#### Sieve 1,000,000
- sqonk;47706;5.00;1;algorithm=base,faithful=yes,bits=1
- 
-#### Sieve 10,000,000
- sqonk;4200;5.00;1;algorithm=base,faithful=yes,bits=1
- 
- 
-#### Solution_1 Sieve of 1,000,000
-DennisdeBest;1169;5.011909;1;algorithm=base,faithful=yes,bits=8
 

--- a/PrimePHP/solution_2/README.md
+++ b/PrimePHP/solution_2/README.md
@@ -1,0 +1,73 @@
+# PHP solution by Sqonk
+
+
+[![Minimum PHP Version](https://img.shields.io/badge/PHP-%3E%3D%208.2-yellow)](https://php.net/)
+![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
+![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
+![Parallelism](https://img.shields.io/badge/Parallel-no-green)
+![Bit count](https://img.shields.io/badge/Bits-1-yellowgreen)
+
+This solution attempts to boost the performance out of PHP significantly, by using anything that will allow the interpreter and the Opcache JIT to precompile where possible. 
+
+The prime count storage utilises bitwise operations, as with many other high performance solutions for other languages. However, PHP has a limitation with regard to its type handling, and the maximum size it can allocate for a single integer. And so in my experiments simply replacing an array of bools with a singular int will only output the correct count for a sieve of 100 or 10. 
+
+This solution instead runs a series of ints as storage for every 100 units, storing the whole lot in an array. 
+
+_Finally_, of particular note (especially after the latest episode of Dave's Garage) is the core algorithm in this solution is heavily influenced and aided by ChatGPT, which assisted over many iterations of trial and error in producing a workable solution. In the spirit of that video's key frame - it really did help '10x' my solution!
+
+### Running with PHP
+
+This solution is designed to run with PHP 8.2 or later. You will need The opcache module enabled and its JIT switched on for best results.
+
+```bash
+cd path/to/sieve
+```
+```php
+php prime.php [--once] [--print] [--size=sieveSize]
+```
+
+### Command line arguments
+
+ - `--size=X`: set upper limit for calculating primes. Default is 1_000_000.
+ - `--print`: Output the result of the sieve to StdOut (console).
+ - `--once`: Run the sieve only once, instead of the 5 second loop. Useful for testing output correctness.
+ 
+ 
+### Running tests
+
+Unit tests exist for and pass for sieve sizes 10 thru 100,000,000, with sizes 10, 100 and 1000 also verifying output of found primes.
+
+
+First install Unit Test dependancies:
+
+ ```bash
+ cd path/to/sieve
+ composer install
+ ```
+ Then run tests:
+ ```php
+ vendor/bin/phpunit --testdox tests
+ ```
+ 
+### Benchmarks / Performance
+
+Personal computer:
+
+ - Apple M1 Max (ARM64) 64-bit
+ - PHP: 8.2.2
+ - Opcache: enabled
+ - Opcache JIT: enabled
+
+#### Sieve 100,000
+sqonk;416899;5.00;1;algorithm=base,faithful=yes,bits=1
+
+#### Sieve 1,000,000
+ sqonk;47706;5.00;1;algorithm=base,faithful=yes,bits=1
+ 
+#### Sieve 10,000,000
+ sqonk;4200;5.00;1;algorithm=base,faithful=yes,bits=1
+ 
+ 
+#### Solution_1 Sieve of 1,000,000
+DennisdeBest;1169;5.011909;1;algorithm=base,faithful=yes,bits=8
+

--- a/PrimePHP/solution_2/composer.json
+++ b/PrimePHP/solution_2/composer.json
@@ -1,0 +1,5 @@
+{
+    "require-dev": {
+        "phpunit/phpunit": "^10.0"
+    }
+}

--- a/PrimePHP/solution_2/prime.php
+++ b/PrimePHP/solution_2/prime.php
@@ -42,6 +42,21 @@ function main(array $args): void
     $avg = number_format($duration / $passes, 2);
     $dstr = number_format($duration, 2);
     $valid = $sieve->valid() ? 'True' : 'False';
+    if ($valid == 'False') 
+    {
+        $expected = getPreparedResults($size);
+        if ($expected)
+        {
+            $actual = $sieve->primes();
+            $missing = array_diff($expected, $actual);
+            if (count($missing) > 0)
+                echo "## MISSING: The following primes are missing from the sieve: ", implode(',', $missing), PHP_EOL;
+        
+            $falsePrimes = array_diff($actual, $expected);
+            if (count($falsePrimes) > 0)
+                echo "## INCORRECT PRIMES: The following numbers were miscalculated as primes: ", implode(',', $falsePrimes), PHP_EOL;
+        }
+    }
     echo "Passes: $passes, Time: {$dstr}, Avg: $avg, Limit: $size, Count: $count, Valid: $valid", PHP_EOL;
 
     // Following 2 lines added by rbergen to conform to drag race output format

--- a/PrimePHP/solution_2/prime.php
+++ b/PrimePHP/solution_2/prime.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types=1);
+
+require_once 'PrimeSieve.php';
+
+function main(array $args): void
+{
+    $size = 1_000_000; 
+    $start = microtime(true);       
+    $passes = 0;                            
+    $printResults = false;
+    $onceOnly = false;
+            
+    foreach ($args as $a) {
+        if (str_starts_with(haystack:$a, needle:'--size=')) {
+            $size = max(0, (int)substr($a, strlen('--size=')));
+        } 
+        else if ($a == '--print') {
+            $printResults = true;
+        }
+        else if ($a == '--once') {
+            $onceOnly = true;
+        }
+    }
+            
+    $duration = 0;               
+    do
+    {
+        $sieve = new PrimeSieve($size);
+        $sieve->compute();
+        $passes++;
+        $duration = microtime(true) - $start;
+    }
+    while ($duration < 5 && ! $onceOnly);
+    
+    $count = count($sieve);
+    
+    if ($printResults) {
+        $sieve->printResults();
+    }
+
+    //Print the results
+    $avg = number_format($duration / $passes, 2);
+    $dstr = number_format($duration, 2);
+    $valid = $sieve->valid() ? 'True' : 'False';
+    echo "Passes: $passes, Time: {$dstr}, Avg: $avg, Limit: $size, Count: $count, Valid: $valid", PHP_EOL;
+
+    // Following 2 lines added by rbergen to conform to drag race output format
+    echo PHP_EOL, PHP_EOL;
+    echo "sqonk;$passes;$dstr;1;algorithm=base,faithful=yes,bits=1", PHP_EOL;
+}
+
+
+main($argv);
+

--- a/PrimePHP/solution_2/prime.php
+++ b/PrimePHP/solution_2/prime.php
@@ -46,7 +46,7 @@ function main(array $args): void
 
     // Following 2 lines added by rbergen to conform to drag race output format
     echo PHP_EOL, PHP_EOL;
-    echo "sqonk;$passes;$dstr;1;algorithm=base,faithful=yes,bits=1", PHP_EOL;
+    echo "sqonk;$passes;$dstr;1;algorithm=other,faithful=no,bits=1", PHP_EOL;
 }
 
 

--- a/PrimePHP/solution_2/tests/PrimeSieveCountsTest.php
+++ b/PrimePHP/solution_2/tests/PrimeSieveCountsTest.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+require_once __DIR__.'/../PrimeSieve.php';
+
+use PHPUnit\Framework\TestCase;
+
+class PrimeSieveCountsTest extends TestCase
+{
+    protected function runSieve(int $size, ?array $expectedOutput = null): void 
+    {
+        $sieve = new PrimeSieve($size);
+        $sieve->compute();
+        
+        $this->assertTrue($sieve->valid());
+        if ($expectedOutput)
+            $this->assertEquals(expected:$expectedOutput, actual:$sieve->primes());
+    }
+    
+    public function testSieveSize10(): void 
+    {
+        $this->runSieve(10, [3,5,7]);
+    }
+    
+    public function testSieveSize100(): void 
+    {
+        $this->runSieve(100, [
+            3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97
+        ]);
+    }
+    
+    public function testSieveSize1000(): void 
+    {
+        $this->runSieve(1000, [
+            3, 5, 7, 11, 13, 17, 19, 23, 29, 31, 37, 41, 43, 47, 53, 59, 61, 67, 71, 73, 79, 83, 89, 97, 101, 103, 107, 109, 113, 127, 131, 137, 139, 149, 151, 157, 163, 167, 173, 179, 181, 191, 193, 197, 199, 211, 223, 227, 229, 233, 239, 241, 251, 257, 263, 269, 271, 277, 281, 283, 293, 307, 311, 313, 317, 331, 337, 347, 349, 353, 359, 367, 373, 379, 383, 389, 397, 401, 409, 419, 421, 431, 433, 439, 443, 449, 457, 461, 463, 467, 479, 487, 491, 499, 503, 509, 521, 523, 541, 547, 557, 563, 569, 571, 577, 587, 593, 599, 601, 607, 613, 617, 619, 631, 641, 643, 647, 653, 659, 661, 673, 677, 683, 691, 701, 709, 719, 727, 733, 739, 743, 751, 757, 761, 769, 773, 787, 797, 809, 811, 821, 823, 827, 829, 839, 853, 857, 859, 863, 877, 881, 883, 887, 907, 911, 919, 929, 937, 941, 947, 953, 967, 971, 977, 983, 991, 997
+        ]);
+    }
+    
+    public function testSieveSize10000(): void 
+    {
+        $this->runSieve(10000);
+    }
+    
+    public function testSieveSize100000(): void 
+    {
+        $this->runSieve(100000);
+    }
+    
+    public function testSieveSize1000000(): void 
+    {
+        $this->runSieve(1000000);
+    }
+    
+    public function testSieveSize10000000(): void
+    {
+        $this->runSieve(10000000);
+    }
+
+    public function testSieveSize100000000(): void
+    {
+        $this->runSieve(100000000);
+    }
+}


### PR DESCRIPTION
A ChatGPT-assisted solution for PHP with impressive results.

## Description
This solution attempts to boost the performance out of PHP significantly, by using anything that will allow the interpreter and the Opcache JIT to precompile where possible. 

The prime count storage utilises bitwise operations, as with many other high performance solutions for other languages. However, PHP has a limitation with regard to its type handling, and the maximum size it can allocate for a single integer. And so in my experiments simply replacing an array of bools with a singular int will only output the correct count for a sieve of 100 or 10. 

This solution instead runs a series of ints as storage for every 100 units, storing the whole lot in an array. 

Finally, of particular note (especially after the latest episode of Dave's Garage) is the core algorithm in this solution is heavily influenced and aided by ChatGPT, which assisted over many iterations of trial and error in producing a workable solution. 

@rbergen I believe this solution to be both faithful and inline with the base algorithm. Please glance over the main class, if you feel so inclined, to confirm.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
