### PR TITLE
Pure bash & reduce code duplication

### DIFF
--- a/PrimeBash/solution_1/Dockerfile
+++ b/PrimeBash/solution_1/Dockerfile
@@ -3,6 +3,6 @@
 FROM ubuntu:22.04
 
 WORKDIR /opt/app
-COPY *.sh ./
- 
+COPY *.sh *.common ./
+
 ENTRYPOINT [ "./run.sh" ]

--- a/PrimeBash/solution_1/PrimeBash.common
+++ b/PrimeBash/solution_1/PrimeBash.common
@@ -73,11 +73,11 @@ function printResults {
 	local name="$4"
 
 	# create duration strings from millisecond duration time
-	avg_dur_usec=$[dur_usec/passes]
+	avg_dur_usec=$((dur_usec/passes))
 	printf -v dur_str "%d.%06d" \
-		"$[dur_usec/1000000]" "$[dur_usec%1000000]"
+		$((dur_usec/1000000)) $((dur_usec%1000000))
 	printf -v avg_dur_str "%d.%06d" \
-		"$[avg_dur_usec/1000000]" "$[avg_dur_usec%1000000]"
+		$((avg_dur_usec/1000000)) $((avg_dur_usec%1000000))
 
 	# create validity string
 	if validateResults "$(countPrimes)"; then
@@ -113,28 +113,30 @@ function printResults {
 
 function main {
 	export LC_ALL=C
-	local passes=0 tStart tStop tNow tRun name="$1"
+	local passes=0 tStart tRun name="$1"
 
 	# Keep /dev/null handle open so we don't pay for opening it later
 	exec 3>/dev/null
 
 	initGlobals "1000000"
 
-	tStart="${EPOCHREALTIME/.}"
-	# we are working in microseconds (10^6)
-	tStop="$[tStart + RUNTIME_SEC*1000000]"
+	# Spawning subshells is expensive so run a background task which we can
+	# probe for liveness to determine when time is up.
+	local sleepPid
+	read -rt "$RUNTIME_SEC" <> <(:) & # pure bash sleep
+	sleepPid=$!
 
-	tNow="${EPOCHREALTIME/.}"
-	while [ $tNow -lt $tStop ]
-	do
+	# we are working in microseconds (10^6)
+	tStart="${EPOCHREALTIME/.}"
+
+	while kill -0 "$sleepPid" 2>&3; do
 		emptyBitArray
 		runSieve
 		((++passes))
-		tNow="${EPOCHREALTIME/.}"
 	done
 
 	# calculate real runtime
-	tRun=$[tNow - tStart]
+	tRun=$((${EPOCHREALTIME/.} - tStart))
 	#printf 'Done in %d.%06d seconds. Validating...\n' "$[tRun/1000000]" "$[tRun%1000000]"
 
 	printResults "0" "$tRun" "$passes" "$name"

--- a/PrimeBash/solution_1/PrimeBash.common
+++ b/PrimeBash/solution_1/PrimeBash.common
@@ -137,7 +137,6 @@ function main {
 
 	# calculate real runtime
 	tRun=$((${EPOCHREALTIME/.} - tStart))
-	#printf 'Done in %d.%06d seconds. Validating...\n' "$[tRun/1000000]" "$[tRun%1000000]"
 
 	printResults "0" "$tRun" "$passes" "$name"
 }

--- a/PrimeBash/solution_1/PrimeBash.common
+++ b/PrimeBash/solution_1/PrimeBash.common
@@ -1,0 +1,141 @@
+#
+# Common routines for a simple prome sieve written in pure bash.
+#
+
+# rbergen -- changed number for 10 from 1 to 4
+readonly -A primeCounts=(
+	[10]=4
+	[100]=25
+	[1000]=168
+	[10000]=1229
+	[100000]=9592
+	[1000000]=78498
+	[10000000]=664579
+	[100000000]=576145
+)
+
+declare sieveSize=0
+declare -A bitArray=()
+# rbergen: changed runtime to drag-race default
+readonly RUNTIME_SEC=5
+
+function sqrt {
+	# integer square root using binary search (lilweege)
+	local -n lo=$1 # Output
+	lo=1
+	hi=$2
+	mid=0
+	while ((lo<=hi)); do
+		((mid=(lo+hi)/2))
+		if [[ $((mid*mid)) -le $2 ]]; then
+			((lo=mid+1))
+		else
+			((hi=mid-1))
+		fi
+	done
+	((--lo))
+}
+
+function initGlobals {
+	sieveSize=$1
+}
+
+function emptyBitArray {
+	bitArray=()
+}
+
+function validateResults {
+	local result=$1
+	(( primeCounts[\$sieveSize] == result ))
+}
+
+function countPrimes {
+	local i count=$((sieveSize >= 2))
+	for ((i=3; i < sieveSize; i++)); do
+		if getBit "$i"; then
+			((++count))
+		fi
+	done
+	echo "$count"
+}
+
+function getBit {
+	# Return failure if even if bitArray is set (determined composite)
+	# Return success if known prime
+	(( $1 & 1 && !bitArray[\$1] ))
+}
+
+function printResults {
+	local showresults dur_usec avg_dur_usec dur_str avg_dur_str passes count valid
+	local showresults="$1"
+	local dur_usec="$2"
+	local passes="$3"
+	local name="$4"
+
+	# create duration strings from millisecond duration time
+	avg_dur_usec=$[dur_usec/passes]
+	printf -v dur_str "%d.%06d" \
+		"$[dur_usec/1000000]" "$[dur_usec%1000000]"
+	printf -v avg_dur_str "%d.%06d" \
+		"$[avg_dur_usec/1000000]" "$[avg_dur_usec%1000000]"
+
+	# create validity string
+	if validateResults "$(countPrimes)"; then
+		valid="True"
+	else
+		valid="False"
+	fi
+
+	if ((showresults)); then
+		printf "2, "
+	fi
+
+	count=$((sieveSize >= 2))
+	for ((num=3; num<sieveSize; num+=2)); do
+		if getBit "$num"; then
+			if ((showresults)); then
+				printf "%s, " "$num"
+			fi
+			((count++))
+		fi
+	done
+
+	if ((count != $(countPrimes))); then
+		echo "Internal: Print Results Counted Incorrectly..." >&2
+		exit 1
+	fi
+	printf "\nPasses: %s, Time: %s, Avg: %s, Limit: %s, Count: %s, Valid: %s\n" \
+		"$passes" "$dur_str" "$avg_dur_str" "$sieveSize" "$count" "$valid"
+
+	# rbergen: added drag-race format output
+	printf "%s;%s;%s;1;algorithm=base,faithful=no\n" "$name" "$passes" "$dur_str"
+}
+
+function main {
+	export LC_ALL=C
+	local passes=0 tStart tStop tNow tRun name="$1"
+
+	# Keep /dev/null handle open so we don't pay for opening it later
+	exec 3>/dev/null
+
+	initGlobals "1000000"
+
+	tStart="${EPOCHREALTIME/.}"
+	# we are working in microseconds (10^6)
+	tStop="$[tStart + RUNTIME_SEC*1000000]"
+
+	tNow="${EPOCHREALTIME/.}"
+	while [ $tNow -lt $tStop ]
+	do
+		emptyBitArray
+		runSieve
+		((++passes))
+		tNow="${EPOCHREALTIME/.}"
+	done
+
+	# calculate real runtime
+	tRun=$[tNow - tStart]
+	#printf 'Done in %d.%06d seconds. Validating...\n' "$[tRun/1000000]" "$[tRun%1000000]"
+
+	printResults "0" "$tRun" "$passes" "$name"
+}

--- a/PrimeBash/solution_1/PrimeBash.sh
+++ b/PrimeBash/solution_1/PrimeBash.sh
@@ -1,72 +1,11 @@
-#! /bin/bash
+#! /usr/bin/env bash
 #
 # A simple prime sieve based on https://github.com/davepl/Primes
 # Written in bash.
 #
 # Tyler Hart (nitepone) <admin@night.horse>
 
-# rbergen -- changed number for 10 from 1 to 4
-readonly -A primeCounts=(
-	[10]=4
-	[100]=25
-	[1000]=168
-	[10000]=1229
-	[100000]=9592
-	[1000000]=78498
-	[10000000]=664579
-	[100000000]=576145
-)
-
-declare sieveSize=0
-declare -A bitArray=()
-# rbergen: changed runtime to drag-race default
-readonly RUNTIME_SEC=5
-
-function sqrt {
-	# integer square root using binary search (lilweege)
-	local -n lo=$1 # Output
-	lo=1
-	hi=$2
-	mid=0
-	while ((lo<=hi)); do
-		((mid=(lo+hi)/2))
-		if [[ $((mid*mid)) -le $2 ]]; then
-			((lo=mid+1))
-		else
-			((hi=mid-1))
-		fi
-	done
-	((--lo))
-}
-
-function initGlobals {
-	sieveSize=$1
-}
-
-function emptyBitArray {
-	bitArray=()
-}
-
-function validateResults {
-	local result=$1
-	(( primeCounts[\$sieveSize] == result ))
-}
-
-function countPrimes {
-	local i count=$((sieveSize >= 2))
-	for ((i=3; i < sieveSize; i++)); do
-		if getBit "$i"; then
-			((++count))
-		fi
-	done
-	echo "$count"
-}
-
-function getBit {
-	# Return failure if even if bitArray is set (determined composite)
-	# Return success if known prime
-	(( $1 & 1 && !bitArray[\$1] ))
-}
+source PrimeBash.common
 
 function clearBit {
 	# Mark as composite
@@ -89,77 +28,4 @@ function runSieve {
 	done
 }
 
-function printResults {
-	local showresults dur_usec avg_dur_usec dur_str avg_dur_str passes count valid
-	showresults="$1"
-	dur_usec="$2"
-	passes="$3"
-	# create duration strings from millisecond duration time
-	avg_dur_usec=$[dur_usec/passes]
-	printf -v dur_str "%d.%06d" \
-		"$[dur_usec/1000000]" "$[dur_usec%1000000]"
-	printf -v avg_dur_str "%d.%06d" \
-		"$[avg_dur_usec/1000000]" "$[avg_dur_usec%1000000]"
-	# create validity string
-	if validateResults "$(countPrimes)"; then
-		valid="True"
-	else
-		valid="False"
-	fi
-
-	if ((showresults)); then
-		printf "2, "
-	fi
-
-	count=$((sieveSize >= 2))
-	for ((num=3; num<sieveSize; num+=2)); do
-		if getBit "$num"; then
-			if ((showresults)); then
-				printf "%s, " "$num"
-			fi
-			((count++))
-		fi
-	done
-
-	if ((count != $(countPrimes))); then
-		echo "Internal: Print Results Counted Incorrectly..." >&2
-		exit 1
-	fi
-	printf "\n"
-	printf "Passes: %s, Time: %s, Avg: %s, Limit: %s, Count: %s, Valid: %s\n" \
-		"$passes" "$dur_str" "$avg_dur_str" "$sieveSize" \
-		"$count" "$valid"
-
-	# rbergen: added drag-race format output
-	printf "\nbash;%s;%s;1;algorithm=base,faithful=no\n" "$passes" "$dur_str"
-}
-
-function main {
-	export LC_ALL=C
-	local passes=0 tStart tStop tNow tRun
-
-	# Keep /dev/null handle open so we don't pay for opening it later
-	exec 3>/dev/null
-
-	initGlobals "1000000"
-
-	tStart="${EPOCHREALTIME/.}"
-	# we are working in microseconds (10^6)
-	tStop="$[tStart + RUNTIME_SEC*1000000]"
-
-	tNow="${EPOCHREALTIME/.}"
-	while [ $tNow -lt $tStop ]
-	do
-		emptyBitArray
-		runSieve
-		((++passes))
-		tNow="${EPOCHREALTIME/.}"
-	done
-
-	# calculate real runtime
-	tRun=$[tNow - tStart]
-
-	printResults "0" "$tRun" "$passes"
-}
-
-main
+main 'bash'

--- a/PrimeBash/solution_1/PrimeBashInline.sh
+++ b/PrimeBash/solution_1/PrimeBashInline.sh
@@ -1,72 +1,11 @@
-#! /bin/bash
+#! /usr/bin/env bash
 #
 # A simple prime sieve based on https://github.com/davepl/Primes
 # Written in bash.
 #
 # Tyler Hart (nitepone) <admin@night.horse>
 
-# rbergen -- changed number for 10 from 1 to 4
-readonly -A primeCounts=(
-	[10]=4
-	[100]=25
-	[1000]=168
-	[10000]=1229
-	[100000]=9592
-	[1000000]=78498
-	[10000000]=664579
-	[100000000]=576145
-)
-
-declare sieveSize=0
-declare -A bitArray=()
-# rbergen: changed runtime to drag-race default
-readonly RUNTIME_SEC=5
-
-function sqrt {
-	# integer square root using binary search (lilweege)
-	local -n lo=$1 # Output
-	lo=1
-	hi=$2
-	mid=0
-	while ((lo<=hi)); do
-		((mid=(lo+hi)/2))
-		if [[ $((mid*mid)) -le $2 ]]; then
-			((lo=mid+1))
-		else
-			((hi=mid-1))
-		fi
-	done
-	((--lo))
-}
-
-function initGlobals {
-	sieveSize=$1
-}
-
-function emptyBitArray {
-	bitArray=()
-}
-
-function validateResults {
-	local result=$1
-	(( primeCounts[\$sieveSize] == result ))
-}
-
-function countPrimes {
-	local i count=$((sieveSize >= 2))
-	for ((i=3; i < sieveSize; i++)); do
-		if getBit "$i"; then
-			((++count))
-		fi
-	done
-	echo "$count"
-}
-
-function getBit {
-	# Return failure if even if bitArray is set (determined composite)
-	# Return success if known prime
-	(( $1 & 1 && !bitArray[\$1] ))
-}
+source PrimeBash.common
 
 function runSieve {
 	local factor num q
@@ -84,83 +23,4 @@ function runSieve {
 	done
 }
 
-function printResults {
-	local showresults dur_nano avg_dur_nano dur_str avg_dur_str passes count valid
-	showresults="$1"
-	dur_nano="$2"
-	passes="$3"
-	# create duration strings from nanosecond duration time
-	avg_dur_nano=$((dur_nano/passes))
-	dur_str="$(printf "%d.%09d"\
-		"$((dur_nano/1000000000))"\
-		"$((dur_nano%1000000000))"\
-	)"
-	avg_dur_str="$(printf "%d.%09d"\
-		"$((avg_dur_nano/1000000000))"\
-		"$((avg_dur_nano%1000000000))"\
-	)"
-	# create validity string
-	if validateResults "$(countPrimes)"; then
-		valid="True"
-	else
-		valid="False"
-	fi
-
-	if ((showresults)); then
-		printf "2, "
-	fi
-
-	count=$((sieveSize >= 2))
-	for ((num=3; num<sieveSize; num+=2)); do
-		if getBit "$num"; then
-			if ((showresults)); then
-				printf "%s, " "$num"
-			fi
-			((count++))
-		fi
-	done
-
-	if ((count != $(countPrimes))); then
-		echo "Internal: Print Results Counted Incorrectly..." >&2
-		exit 1
-	fi
-	printf "\n"
-	printf "Passes: %s, Time: %s, Avg: %s, Limit: %s, Count: %s, Valid: %s\n" \
-		"$passes" "$dur_str" "$avg_dur_str" "$sieveSize" \
-		"$count" "$valid"
-
-	# rbergen: added drag-race format output
-	printf "\nbash_inline;%s;%s;1;algorithm=base,faithful=no\n" "$passes" "$dur_str"
-}
-
-function main {
-	export LC_ALL=C
-	local passes=0 sleepPid tStart tRun
-
-	# Keep /dev/null handle open so we don't pay for opening it later
-	exec 3>/dev/null
-
-	initGlobals "1000000"
-
-	# Spawning subshells is expensive so run a background task which we can
-	# probe for liveness to determine when time is up.
-	local sleepPid
-	sleep "$RUNTIME_SEC" &
-	sleepPid=$!
-
-	# we are working in nanoseconds (10^9)
-	tStart=$(date +%s%N)
-
-	while kill -0 "$sleepPid" 2>&3; do
-		emptyBitArray
-		runSieve
-		((++passes))
-	done
-
-	# calculate real runtime
-	tRun=$(($(date +%s%N) - tStart))
-
-	printResults "0" "$tRun" "$passes"
-}
-
-main
+main 'bash_inline'

--- a/PrimeBash/solution_1/PrimeBashPacked.sh
+++ b/PrimeBash/solution_1/PrimeBashPacked.sh
@@ -1,66 +1,11 @@
-#! /bin/bash
+#! /usr/bin/env bash
 #
 # A simple prime sieve based on https://github.com/davepl/Primes
 # Written in bash.
 #
 # Tyler Hart (nitepone) <admin@night.horse>
 
-# rbergen -- changed number for 10 from 1 to 4
-readonly -A primeCounts=(
-	[10]=4
-	[100]=25
-	[1000]=168
-	[10000]=1229
-	[100000]=9592
-	[1000000]=78498
-	[10000000]=664579
-	[100000000]=576145
-)
-
-declare sieveSize=0
-declare -A bitArray=()
-# rbergen: changed runtime to drag-race default
-readonly RUNTIME_SEC=5
-
-function sqrt {
-	# integer square root using binary search (lilweege)
-	local -n lo=$1 # Output
-	lo=1
-	hi=$2
-	mid=0
-	while ((lo<=hi)); do
-		((mid=(lo+hi)/2))
-		if [[ $((mid*mid)) -le $2 ]]; then
-			((lo=mid+1))
-		else
-			((hi=mid-1))
-		fi
-	done
-	((--lo))
-}
-
-function initGlobals {
-	sieveSize=$1
-}
-
-function emptyBitArray {
-	bitArray=()
-}
-
-function validateResults {
-	local result=$1
-	(( primeCounts[\$sieveSize] == result ))
-}
-
-function countPrimes {
-	local i count=$((sieveSize >= 2))
-	for ((i=3; i < sieveSize; i++)); do
-		if getBit "$i"; then
-			((++count))
-		fi
-	done
-	echo "$count"
-}
+source PrimeBash.common
 
 function getBit {
 	local index=$1 bit
@@ -88,83 +33,4 @@ function runSieve {
 	done
 }
 
-function printResults {
-	local showresults dur_nano avg_dur_nano dur_str avg_dur_str passes count valid
-	showresults="$1"
-	dur_nano="$2"
-	passes="$3"
-	# create duration strings from nanosecond duration time
-	avg_dur_nano=$((dur_nano/passes))
-	dur_str="$(printf "%d.%09d"\
-		"$((dur_nano/1000000000))"\
-		"$((dur_nano%1000000000))"\
-	)"
-	avg_dur_str="$(printf "%d.%09d"\
-		"$((avg_dur_nano/1000000000))"\
-		"$((avg_dur_nano%1000000000))"\
-	)"
-	# create validity string
-	if validateResults "$(countPrimes)"; then
-		valid="True"
-	else
-		valid="False"
-	fi
-
-	if ((showresults)); then
-		printf "2, "
-	fi
-
-	count=$((sieveSize >= 2))
-	for ((num=3; num<sieveSize; num+=2)); do
-		if getBit "$num"; then
-			if ((showresults)); then
-				printf "%s, " "$num"
-			fi
-			((count++))
-		fi
-	done
-
-	if ((count != $(countPrimes))); then
-		echo "Internal: Print Results Counted Incorrectly..." >&2
-		exit 1
-	fi
-	printf "\n"
-	printf "Passes: %s, Time: %s, Avg: %s, Limit: %s, Count: %s, Valid: %s\n" \
-		"$passes" "$dur_str" "$avg_dur_str" "$sieveSize" \
-		"$count" "$valid"
-
-	# rbergen: added drag-race format output
-	printf "\nbash_packed;%s;%s;1;algorithm=base,faithful=no\n" "$passes" "$dur_str"
-}
-
-function main {
-	export LC_ALL=C
-	local passes=0 sleepPid tStart tRun
-
-	# Keep /dev/null handle open so we don't pay for opening it later
-	exec 3>/dev/null
-
-	initGlobals "1000000"
-
-	# Spawning subshells is expensive so run a background task which we can
-	# probe for liveness to determine when time is up.
-	local sleepPid
-	sleep "$RUNTIME_SEC" &
-	sleepPid=$!
-
-	# we are working in nanoseconds (10^9)
-	tStart=$(date +%s%N)
-
-	while kill -0 "$sleepPid" 2>&3; do
-		emptyBitArray
-		runSieve
-		((++passes))
-	done
-
-	# calculate real runtime
-	tRun=$(($(date +%s%N) - tStart))
-
-	printResults "0" "$tRun" "$passes"
-}
-
-main
+main 'bash_packed'

--- a/PrimeBash/solution_1/run.sh
+++ b/PrimeBash/solution_1/run.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#! /usr/bin/env bash
+echo "$BASH_VERSION"
 
 cd "${0%/*}"
 


### PR DESCRIPTION
 - sleep and date aren't part of bash
 - also more portable by removing non-standard nanoseconds
 - still uses clock in microseconds - move common routines into single sourced file
 - increase portability by checking env for location of bash
 - some minor code linting
 - also display the bash version in docker run.sh

## Description
This is now pure bash. It might improve performance slightly by reducing syscalls to `sleep` and `date`.

Also only GNU `date` supports `%N` (nanoseconds), so it would have broken on BSD or other platforms that only support `strftim(3)` proper. The only drawback is internal `printf %(datefmt)T` supports only standard `strftim(3)` so we must use microseconds instead of nano.

The other changes are mostly cosmetic. But making the scripts honor the environment, now users can test against their own bash wherever is it installed, not just /bin/bash.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
