### PR TITLE
Improve phix dockerfile

### DIFF
--- a/PrimePhix/solution_1/Dockerfile
+++ b/PrimePhix/solution_1/Dockerfile
@@ -18,9 +18,8 @@ RUN apt-get update -qq \
     && mv p64 /usr/local/phix/p \
     && chmod +x /usr/local/phix/p \
     && rm -f phix*.zip \
-    && printf '#!/bin/bash\n/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 /usr/local/phix/p "$@"\n' >/usr/local/bin/p \
-    && printf '#!/bin/bash\n/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 "$@"\n' >/usr/local/bin/p_exec \
-    && chmod +x /usr/local/bin/p /usr/local/bin/p_exec \
+    && printf '#!/bin/bash\n/usr/local/phix/p "$@"\n' >/usr/local/bin/p \
+    && chmod +x /usr/local/bin/p \
     && echo "" | p
 
 WORKDIR /opt/app

--- a/PrimePhix/solution_1/README.md
+++ b/PrimePhix/solution_1/README.md
@@ -10,11 +10,8 @@ This implementation is almost identical to [Euphoria solution 1](../../PrimeEuph
 [Phix](http://phix.x10.mx/) is a newer language based on
 [Euphoria](https://en.wikipedia.org/wiki/Euphoria_(programming_language)). The performance
 of the `integer` sieve solution is about 2.4 times faster in Phix, but the 1-bit sieve
-solution is about 6.7 times slower. There are a number of problems with Phix.
-The interpreter and compiler need to be run through `ld-linux-x86-64.so`, or it crashes with
-a SEGFAULT. The executable that the compiler produces also needs to be run through
-`ld-linux-x86-64.so`. Sadly, the compiled executable was not significantly faster
-than the interpreted version.
+solution is about 6.7 times slower. Sadly, the compiled executable was not significantly
+faster than the interpreted version.
 
 ## Run instructions
 

--- a/PrimePhix/solution_1/run_primes.sh
+++ b/PrimePhix/solution_1/run_primes.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 for script in primes primes_bit
 do
-    p_exec "./${script}"
+    "./${script}"
     echo ""
 done
 


### PR DESCRIPTION
## Description
In Phix 1.0.1, the `p` executable and the compiled output of `p` had to run through `/usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2` in order to work. In 1.0.2, this is no longer necessary.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
