### PR TITLE
Rust: added non-HT run

### DIFF
--- a/PrimeRust/solution_1/prime-sieve-rust/src/main.rs
+++ b/PrimeRust/solution_1/prime-sieve-rust/src/main.rs
@@ -774,7 +774,11 @@ fn main() {
 
     let thread_options = match opt.threads {
         Some(t) => vec![t],
-        None => vec![1, num_cpus::get_physical(), num_cpus::get()],
+        None => {
+            let mut threads = vec![1, num_cpus::get_physical(), num_cpus::get()];
+            threads.dedup();
+            threads
+        }
     };
 
     // run default implementations if no options are specified

--- a/PrimeRust/solution_1/prime-sieve-rust/src/main.rs
+++ b/PrimeRust/solution_1/prime-sieve-rust/src/main.rs
@@ -774,7 +774,7 @@ fn main() {
 
     let thread_options = match opt.threads {
         Some(t) => vec![t],
-        None => vec![1, num_cpus::get()],
+        None => vec![1, num_cpus::get_physical(), num_cpus::get()],
     };
 
     // run default implementations if no options are specified


### PR DESCRIPTION
## Description

This is a small addition: A multithreaded run using physical cores in addition to the existing run with available hyperthreads. This is relevant for an apples-to-apples comparison of per-thread throughput.

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
