### PR TITLE
Inlined bit operations and moved sieve definition inside loop

### DIFF
--- a/PrimeEuphoria/solution_1/README.md
+++ b/PrimeEuphoria/solution_1/README.md
@@ -7,7 +7,8 @@
 ![Bit count](https://img.shields.io/badge/Bits-1-green)
 
 * `primes.ex` uses `integer` for each sieve item
-* `primes_bit.ex` packs 64 sieve items in an `atom`
+* `primes_bit.ex` packs 32 sieve items in an `integer`. The bit manipulation functions are inlined
+  in the sieve to improve performance.
 
 ## Run instructions
 
@@ -29,11 +30,11 @@ On an Intel(R) Core(TM) i7-8700 CPU @ 3.20GHz with 32 GB of memory on a Windows 
 a Ubuntu 22.04 VM in VirtualBox 6.1:
 
 ```
-Passes: 400, Time: 5.01, Avg: 0.01252500, Limit: 1000000, Count: 78498, Valid: true
+Passes: 388, Time: 5.00, Avg: 0.01288660, Limit: 1000000, Count: 78498, Valid: true
 
-rzuckerm;400;5.01;1;algorithm=base,faithful=yes
+rzuckerm;388;5.00;1;algorithm=base,faithful=yes
 
-Passes: 1409, Time: 5.00, Avg: 0.00354862, Limit: 1000000, Count: 78498, Valid: true
+Passes: 3035, Time: 5.00, Avg: 0.00164745, Limit: 1000000, Count: 78498, Valid: true
 
-rzuckerm;1409;5.00;1;algorithm=base,faithful=yes,bits=1
+rzuckerm;3035;5.00;1;algorithm=base,faithful=yes,bits=1
 ```

--- a/PrimeEuphoria/solution_1/README.md
+++ b/PrimeEuphoria/solution_1/README.md
@@ -32,9 +32,9 @@ a Ubuntu 22.04 VM in VirtualBox 6.1:
 ```
 Passes: 388, Time: 5.00, Avg: 0.01288660, Limit: 1000000, Count: 78498, Valid: true
 
-rzuckerm;388;5.00;1;algorithm=base,faithful=yes
+rzuckerm-bool;388;5.00;1;algorithm=base,faithful=yes
 
 Passes: 3035, Time: 5.00, Avg: 0.00164745, Limit: 1000000, Count: 78498, Valid: true
 
-rzuckerm;3035;5.00;1;algorithm=base,faithful=yes,bits=1
+rzuckerm-bit;3035;5.00;1;algorithm=base,faithful=yes,bits=1
 ```

--- a/PrimeEuphoria/solution_1/primes.ex
+++ b/PrimeEuphoria/solution_1/primes.ex
@@ -97,11 +97,10 @@ procedure main()
     integer n = 1_000_000
     integer passes = 0
     integer show_results = FALSE
-    sequence sieve
     atom duration
     while 1 do
         passes += 1
-        sieve = run_sieve(n)
+        sequence sieve = run_sieve(n)
         duration = time() - start
         if duration >= 5.0
         then

--- a/PrimeEuphoria/solution_1/primes.ex
+++ b/PrimeEuphoria/solution_1/primes.ex
@@ -87,7 +87,7 @@ procedure print_results(sequence this, integer show_results, atom duration, inte
     )
     printf(
         STDOUT,
-        "\nrzuckerm;%d;%.2f;1;algorithm=base,faithful=yes\n",
+        "\nrzuckerm-bool;%d;%.2f;1;algorithm=base,faithful=yes\n",
         {passes, duration}
     )
 end procedure

--- a/PrimeEuphoria/solution_1/primes_bit.ex
+++ b/PrimeEuphoria/solution_1/primes_bit.ex
@@ -199,7 +199,7 @@ procedure print_results(sequence this, integer show_results, atom duration, inte
     )
     printf(
         STDOUT,
-        "\nrzuckerm;%d;%.2f;1;algorithm=base,faithful=yes,bits=1\n",
+        "\nrzuckerm-bit;%d;%.2f;1;algorithm=base,faithful=yes,bits=1\n",
         {passes, duration}
     )
 end procedure


### PR DESCRIPTION
## Description
For the both implementations, I moved the sieve definition inside the main prime loop to ensure that it keeps
getting reallocation every iteration.

For the packed bit implementation (`primes_bit.ex`), I inlined the bit operations. This improved the speed by a factor of about 2.1x.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
