### PR TITLE
update dart solutions to dart3

### DIFF
--- a/PrimeDart/solution_1/Dockerfile
+++ b/PrimeDart/solution_1/Dockerfile
@@ -1,4 +1,4 @@
-FROM dart:2.15.1 AS build
+FROM dart:3.0.0 AS build
 WORKDIR /app
 COPY pubspec.* ./
 RUN pub get

--- a/PrimeDart/solution_1/Dockerfile
+++ b/PrimeDart/solution_1/Dockerfile
@@ -1,9 +1,9 @@
 FROM dart:3.0.0 AS build
 WORKDIR /app
 COPY pubspec.* ./
-RUN pub get
+RUN dart pub get
 COPY . .
-RUN pub get --offline \
+RUN dart pub get --offline \
     && dart compile exe /app/bin/runner.dart -o runner 
 
 FROM scratch AS runtime

--- a/PrimeDart/solution_1/bin/prime_1_bit_par.dart
+++ b/PrimeDart/solution_1/bin/prime_1_bit_par.dart
@@ -4,7 +4,7 @@ import 'dart:isolate';
 import 'dart:math';
 import 'prime_1_bit.dart';
 
-void work(SendPort port) {
+({double time, int passes}) work() {
   var passes = 0;
   final timer = Stopwatch()..start();
 
@@ -14,27 +14,25 @@ void work(SendPort port) {
     passes++;
 
     if (timer.elapsedMicroseconds >= 5000000) {
-      Isolate.exit(port, {
-        'time': timer.elapsedMicroseconds / 1000000,
-        'passes': passes,
-      });
+      return (
+        time: timer.elapsedMicroseconds / 1000000,
+        passes: passes,
+      );
     }
   }
 }
 
 Future<void> main() async {
   final processors = Platform.numberOfProcessors;
-  final receivePort = ReceivePort();
-  for (var i = 0; i < processors; i++) {
-    unawaited(Isolate.spawn(work, receivePort.sendPort));
-  }
+  final isolates = [for (int i = 0; i < processors; i++) Isolate.run(work)];
   var passes = 0;
   var time = 0.0;
-  await for (Map<String, num> message in receivePort.take(processors)) {
-    passes += message['passes'] as int;
-    time = max(time, message['time'] as double);
+
+  await for (final message in Stream.fromFutures(isolates)) {
+    passes += message.passes;
+    time = max(time, message.time);
   }
-  receivePort.close();
+
   stdout.writeln(
       'eagerestwolf&mmcdon20_1bit_par;$passes;$time;$processors;algorithm=base,faithful=yes,bits=1');
 }

--- a/PrimeDart/solution_1/bin/prime_8_bit_par.dart
+++ b/PrimeDart/solution_1/bin/prime_8_bit_par.dart
@@ -4,7 +4,7 @@ import 'dart:isolate';
 import 'dart:math';
 import 'prime_8_bit.dart';
 
-void work(SendPort port) {
+({double time, int passes}) work() {
   var passes = 0;
   final timer = Stopwatch()..start();
 
@@ -14,27 +14,25 @@ void work(SendPort port) {
     passes++;
 
     if (timer.elapsedMicroseconds >= 5000000) {
-      Isolate.exit(port, {
-        'time': timer.elapsedMicroseconds / 1000000,
-        'passes': passes,
-      });
+      return (
+        time: timer.elapsedMicroseconds / 1000000,
+        passes: passes,
+      );
     }
   }
 }
 
 Future<void> main() async {
   final processors = Platform.numberOfProcessors;
-  final receivePort = ReceivePort();
-  for (var i = 0; i < processors; i++) {
-    unawaited(Isolate.spawn(work, receivePort.sendPort));
-  }
+  final isolates = [for (int i = 0; i < processors; i++) Isolate.run(work)];
   var passes = 0;
   var time = 0.0;
-  await for (Map<String, num> message in receivePort.take(processors)) {
-    passes += message['passes'] as int;
-    time = max(time, message['time'] as double);
+
+  await for (final message in Stream.fromFutures(isolates)) {
+    passes += message.passes;
+    time = max(time, message.time);
   }
-  receivePort.close();
+
   stdout.writeln(
       'eagerestwolf&mmcdon20_8bit_par;$passes;$time;$processors;algorithm=base,faithful=yes,bits=8');
 }

--- a/PrimeDart/solution_1/pubspec.yaml
+++ b/PrimeDart/solution_1/pubspec.yaml
@@ -3,7 +3,7 @@ description: A Dart implementation of David Plummer's PrimeSieve application.
 publish_to: none
 
 environment:
-  sdk: '>=2.15.1 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dev_dependencies:
-  lints: ^1.0.1
+  lints: ^2.1.0

--- a/PrimeMixed/solution_4/Dockerfile
+++ b/PrimeMixed/solution_4/Dockerfile
@@ -4,7 +4,7 @@ COPY /c_library .
 RUN gcc -c -Ofast c_sieve.c \
     && gcc -shared -o c_sieve.so c_sieve.o
 
-FROM dart:2.15.1 AS dart
+FROM dart:3.0.0 AS dart
 WORKDIR /app
 COPY /bin .
 RUN dart compile exe runner.dart -o runner 

--- a/PrimeMixed/solution_4/bin/c_1_bit_par.dart
+++ b/PrimeMixed/solution_4/bin/c_1_bit_par.dart
@@ -7,7 +7,7 @@ import 'dart:math';
 import 'add_extension.dart';
 import 'c_sieve.ffigen.dart';
 
-void work(SendPort port) {
+({double time, int passes}) work() {
   final library = CSieve(DynamicLibrary.open(addExtension('c_sieve')));
   var passes = 0;
   final timer = Stopwatch()..start();
@@ -19,27 +19,25 @@ void work(SendPort port) {
     passes++;
 
     if (timer.elapsedMicroseconds >= 5000000) {
-      Isolate.exit(port, {
-        'time': timer.elapsedMicroseconds / 1000000,
-        'passes': passes,
-      });
+      return (
+        time: timer.elapsedMicroseconds / 1000000,
+        passes: passes,
+      );
     }
   }
 }
 
 Future<void> main() async {
   final processors = Platform.numberOfProcessors;
-  final receivePort = ReceivePort();
-  for (var i = 0; i < processors; i++) {
-    unawaited(Isolate.spawn(work, receivePort.sendPort));
-  }
+  final isolates = [for (int i = 0; i < processors; i++) Isolate.run(work)];
   var passes = 0;
   var time = 0.0;
-  await for (Map<String, num> message in receivePort.take(processors)) {
-    passes += message['passes'] as int;
-    time = max(time, message['time'] as double);
+
+  await for (final message in Stream.fromFutures(isolates)) {
+    passes += message.passes;
+    time = max(time, message.time);
   }
-  receivePort.close();
+
   stdout.writeln(
       'mmcdon20_dart+c_1_bit_par;$passes;$time;$processors;algorithm=base,faithful=yes,bits=1');
 }

--- a/PrimeMixed/solution_4/bin/c_sieve.ffigen.dart
+++ b/PrimeMixed/solution_4/bin/c_sieve.ffigen.dart
@@ -54,7 +54,7 @@ class CSieve {
   }
 
   late final ___security_check_cookiePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(uintptr_t)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.UintPtr)>>(
           '__security_check_cookie');
   late final ___security_check_cookie =
       ___security_check_cookiePtr.asFunction<void Function(int)>();
@@ -68,13 +68,13 @@ class CSieve {
   }
 
   late final ___report_gsfailurePtr =
-      _lookup<ffi.NativeFunction<ffi.Void Function(uintptr_t)>>(
+      _lookup<ffi.NativeFunction<ffi.Void Function(ffi.UintPtr)>>(
           '__report_gsfailure');
   late final ___report_gsfailure =
       ___report_gsfailurePtr.asFunction<void Function(int)>();
 
-  late final ffi.Pointer<uintptr_t> ___security_cookie =
-      _lookup<uintptr_t>('__security_cookie');
+  late final ffi.Pointer<ffi.UintPtr> ___security_cookie =
+      _lookup<ffi.UintPtr>('__security_cookie');
 
   int get __security_cookie => ___security_cookie.value;
 
@@ -113,17 +113,16 @@ class CSieve {
     int index,
   ) {
     return _get_bit(
-          sieve,
-          index,
-        ) !=
-        0;
+      sieve,
+      index,
+    );
   }
 
   late final _get_bitPtr = _lookup<
       ffi.NativeFunction<
-          ffi.Uint8 Function(ffi.Pointer<sieve>, ffi.Uint64)>>('get_bit');
+          ffi.Bool Function(ffi.Pointer<sieve>, ffi.Uint64)>>('get_bit');
   late final _get_bit =
-      _get_bitPtr.asFunction<int Function(ffi.Pointer<sieve>, int)>();
+      _get_bitPtr.asFunction<bool Function(ffi.Pointer<sieve>, int)>();
 
   void clear_bit(
     ffi.Pointer<sieve> sieve,
@@ -170,10 +169,9 @@ class CSieve {
       _count_primesPtr.asFunction<int Function(ffi.Pointer<sieve>)>();
 }
 
-typedef va_list = ffi.Pointer<ffi.Int8>;
-typedef uintptr_t = ffi.Uint64;
+typedef va_list = ffi.Pointer<ffi.Char>;
 
-class sieve extends ffi.Struct {
+final class sieve extends ffi.Struct {
   external ffi.Pointer<ffi.Uint64> array;
 
   @ffi.Uint64()

--- a/PrimeMixed/solution_4/pubspec.yaml
+++ b/PrimeMixed/solution_4/pubspec.yaml
@@ -3,8 +3,8 @@ description: dart ffi solution
 publish_to: none
 
 environment:
-  sdk: '>=2.15.1 <3.0.0'
+  sdk: '>=3.0.0 <4.0.0'
 
 dev_dependencies:
-  lints: ^1.0.1
-  ffigen: ^4.1.2
+  lints: ^2.1.0
+  ffigen: ^8.0.0


### PR DESCRIPTION
## Description
Updates the dart solutions to [dart 3](https://medium.com/dartlang/announcing-dart-3-53f065a10635).

The core solution is the same, but I did update the parallel code in the following ways.

1. The result from the `work` function is now a `Record` instead of a `Map`. This has better type safety and it is no longer necessary to do a typecast, for example `message['passes'] as int` can now be written as `message.passes`.

2. I am now using `Isolate.run` instead of `Isolate.spawn`. With `spawn` you had to create a `ReceivePort` in order to send the result back from the spawned isolate, `run` is a newer api that simply returns the result as a `Future` without the need to create a `ReceivePort`, which simplifies the code somewhat.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
