### PR TITLE
Improve Beef speed about 1.6x

### DIFF
--- a/PrimeBeef/solution_1/Primes/src/Primes.bf
+++ b/PrimeBeef/solution_1/Primes/src/Primes.bf
@@ -45,19 +45,9 @@ class PrimeSieve
     [Inline]
     private void ClearBits(uint64 startBit, uint64 inc)
     {
-        int bit = (int)(startBit & 0x1f);
-        int index = (int)(startBit >> 5);
-        int bitInc = (int)(inc & 0x1f);
-        int indexInc = (int)(inc >> 5);
-        for (uint64 currBit = startBit; currBit < mNumBits; currBit += inc)
+        for (uint64 bit = startBit; bit < mNumBits; bit += inc)
         {
-            mSieveBits[index] &= ~(1 << bit);
-            bit += bitInc;
-            index += indexInc;
-            if (bit >= 32) {
-                bit -= 32;
-                index++;
-            }
+            mSieveBits[(int)(bit >> 5)] &= ~(1 << (bit & 0x1f));
         }
     }
 

--- a/PrimeBeef/solution_1/README.md
+++ b/PrimeBeef/solution_1/README.md
@@ -39,6 +39,6 @@ On a 12th Gen Intel(R) Core(TM) i7-12850HX 2.10 GHz with 32 GB of memory on a Wi
 laptop running a Ubuntu 22.04 VM in VirtualBox 7.0.6:
 
 ```
-Passes: 7401, Time: 5000ms, Avg: 0.6755843805ms, Limit: 1000000, Count: 78498, Valid: true
-rzuckerm;7041;5;1;algorithm=base,faithful=yes,bits=1
+Passes: 11905, Time: 5000ms, Avg: 0.4199916002ms, Limit: 1000000, Count: 78498, Valid: True
+rzuckerm;11905;5;1;algorithm=base,faithful=yes,bits=1
 ```


### PR DESCRIPTION
## Description
I found that I was over-complicating the `ClearBits` loop. Simplifying the processing improved performance quite a bit.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
