### PR TITLE
Move Java/solution_1 to adoptopenjdk/openjdk base image

### DIFF
--- a/PrimeJava/solution_1/Dockerfile
+++ b/PrimeJava/solution_1/Dockerfile
@@ -1,4 +1,6 @@
-FROM openjdk:8
+FROM adoptopenjdk/openjdk8:x86_64-alpine-jdk8u402-b06-slim
+
+RUN apk add --no-cache bash
 
 WORKDIR /opt/app
 


### PR DESCRIPTION
## Description

This makes Java/solution_1 use an AdoptOpenJDK-provided, Alpine-based, OpenJDK image as the its base image, because the currently used "official" OpenJDK image has been deprecated since July 2022.

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
