### PR TITLE
Use latest Julia version to represent current performance

### DIFF
--- a/PrimeJulia/solution_1/Dockerfile
+++ b/PrimeJulia/solution_1/Dockerfile
@@ -1,4 +1,4 @@
-FROM julia:1.6-alpine3.13
+FROM julia:1.10-alpine
 
 WORKDIR /opt/app
 

--- a/PrimeJulia/solution_1/Dockerfile
+++ b/PrimeJulia/solution_1/Dockerfile
@@ -1,4 +1,4 @@
-FROM julia:1.10-alpine
+FROM julia:1-alpine
 
 WORKDIR /opt/app
 

--- a/PrimeJulia/solution_2/Dockerfile
+++ b/PrimeJulia/solution_2/Dockerfile
@@ -1,4 +1,4 @@
-FROM julia:1.6.1-alpine3.13
+FROM julia:1.10-alpine
 
 WORKDIR /opt/app
 

--- a/PrimeJulia/solution_2/Dockerfile
+++ b/PrimeJulia/solution_2/Dockerfile
@@ -1,4 +1,4 @@
-FROM julia:1.10-alpine
+FROM julia:1-alpine
 
 WORKDIR /opt/app
 

--- a/PrimeJulia/solution_3/Dockerfile
+++ b/PrimeJulia/solution_3/Dockerfile
@@ -1,4 +1,4 @@
-FROM julia:1.6-buster
+FROM julia:1.10
 
 WORKDIR /opt/app
 

--- a/PrimeJulia/solution_3/Dockerfile
+++ b/PrimeJulia/solution_3/Dockerfile
@@ -1,4 +1,4 @@
-FROM julia:1.10
+FROM julia:1
 
 WORKDIR /opt/app
 

--- a/PrimeJulia/solution_3/README.md
+++ b/PrimeJulia/solution_3/README.md
@@ -10,7 +10,7 @@ optimizations. This is a sort-of "low-level" style implementation in
 Julia to get as much as speed as possible out of the language. It is
 *not* designed to be idiomatic Julia code.
 
-This solution requires at least **Julia 1.5** to run. Julia 1.10 is
+This solution requires at least **Julia 1.5** to run. the latest stable 1.X Julia version is
 recommended and is used in the Docker image.
 
 ## Description

--- a/PrimeJulia/solution_3/README.md
+++ b/PrimeJulia/solution_3/README.md
@@ -10,7 +10,7 @@ optimizations. This is a sort-of "low-level" style implementation in
 Julia to get as much as speed as possible out of the language. It is
 *not* designed to be idiomatic Julia code.
 
-This solution requires at least **Julia 1.5** to run. Julia 1.6 is
+This solution requires at least **Julia 1.5** to run. Julia 1.10 is
 recommended and is used in the Docker image.
 
 ## Description
@@ -40,7 +40,7 @@ and bits are unset when the number is *prime*. This simplifies the
 set_bit operation slightly (`arr[i] |= mask vs. arr[i] &= ~mask`).
 
 If you see any room for improvement in the code or have any
-suggestions, don't hesitate to open an issue, pull request (PR), 
+suggestions, don't hesitate to open an issue, pull request (PR),
 Discussion, or the like. Don't forget to tag me at `@louie-github` so I
 can be notified if my personal input is either wanted or needed.
 I'm open to fixing stylistic issues or discussing cosmetic changes to

--- a/PrimeJulia/solution_4/Dockerfile
+++ b/PrimeJulia/solution_4/Dockerfile
@@ -1,4 +1,4 @@
-FROM julia:1.6-buster
+FROM julia:1.10
 
 WORKDIR /opt/app
 

--- a/PrimeJulia/solution_4/Dockerfile
+++ b/PrimeJulia/solution_4/Dockerfile
@@ -1,4 +1,4 @@
-FROM julia:1.10
+FROM julia:1
 
 WORKDIR /opt/app
 


### PR DESCRIPTION
## Description
This PR updates the version of Julia used in all 4 solutions from 1.6 to 1.10. 1.10 will be the next long-term support release once 1.11 releases in a few weeks, and while I don't think there's a big change in performance, it is more representative of current Julia performance.

@dcbi, @epithet, @louie-github, @GordonBGood