### PR TITLE
Add timeout to benchmark solution runs

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -22,6 +22,7 @@ Some solutions are not included in the automated benchmark runs, either because 
 - [Running a benchmark of all solutions for a particular language](#running-a-benchmark-of-all-solutions-for-a-particular-language)
 - [Running in unconfined mode](#running-in-unconfined-mode)
 - [Output formats](#output-formats)
+- [Setting the solution timeout](#setting-the-solution-timeout)
 
 ## What operating system to use?
 
@@ -374,4 +375,14 @@ The output format can be controlled via the `FORMATTER` variable like this:
 ```shell
 make FORMATTER=json
 make DIRECTORY=PrimeCrystal/solution_1 FORMATTER=csv
+```
+
+## Setting the solution timeout
+
+The run of each solution is limited to a certain duration, which is 10 minutes by default.
+You can change this setting through the `TIMEOUT` variable like this:
+
+```shell
+make TIMEOUT=15
+make DIRECTORY=PrimeCPP/solution_2 TIMEOUT=15
 ```

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ SHELL := /bin/bash
 
 DIRECTORY := $(shell pwd)
 FORMATTER := "table"
+TIMEOUT := "10"
 
 .PHONY: all
 all: benchmark
@@ -14,6 +15,7 @@ benchmark: check-env
 	ARGS=("-d $${REALPATH}" "-f $(FORMATTER)"); \
 	[ ! -z $${OUTPUT_FILE} ] && ARGS+=( "-o $${OUTPUT_FILE}" ); \
 	[ ! -z $${UNCONFINED} ] && ARGS+=( "--unconfined" ); \
+	[ ! -z $${TIMEOUT} ] && ARGS+=( "-t $${TIMEOUT}" ); \
 	cd ./tools; npm ci --silent && npm start --silent -- benchmark $${ARGS[@]}
 
 .PHONY: check-env

--- a/tools/src/services/docker.ts
+++ b/tools/src/services/docker.ts
@@ -7,9 +7,11 @@ export default class DockerService {
     });
   }
 
-  public runContainer(imageName: string, options: Array<string>): string {
+  public runContainer(imageName: string, duration: number, options: Array<string>): string {
     const output = child_process.execSync(`docker run --rm ${options.join(' ')} ${imageName}`, {
-      stdio: 'pipe'
+      stdio: 'pipe',
+      timeout: duration ? duration * 60000 : undefined,
+      killSignal: 'SIGKILL'
     });
     return output.toString('utf8');
   }


### PR DESCRIPTION
## Description

I've found that on certain systems/in certain situations, benchmark runs can get stuck for reasons that are unclear. This adds a timeout for each of the solution runs kicked off during the benchmark.

The default timeout is 10 minutes, this can be changed by a new make variable that's also been added to the documentation.

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
