### PR TITLE
Suppress all checks for calculation

### DIFF
--- a/PrimeAda/solution_1/main.adb
+++ b/PrimeAda/solution_1/main.adb
@@ -1,3 +1,4 @@
+pragma Suppress (All_Checks);
 with Ada.Containers.Ordered_Maps;
 with Ada.Text_IO;   use Ada.Text_IO;
 with Ada.Numerics.Long_Long_Elementary_Functions;


### PR DESCRIPTION
Ada does runtimes checks; using suppress will improve performance by disabling them all. Link to documentation: https://docs.adacore.com/live/wave/gnat-ccg/html/gnatccg_ug/gnat_ccg/gnat_ccg.html#:~:text=3.3.%20Enabling/Disabling%20Runtime%20Checks,-%EF%83%81

Using godbolt, we see a reduction of a few thousand lines of assembly. 