### PR TITLE
Note that CUDA/solution_1 only runs on AMD64

### DIFF
--- a/PrimeCUDA/solution_1/README.md
+++ b/PrimeCUDA/solution_1/README.md
@@ -12,10 +12,11 @@ The solution heavily depends on CUDASieve, a [GitHub-hosted project](https://git
 
 ## Notes
 
+- This solution will only build (and hence run) on ADM64 machines. The reason is that the source code of the CUDASieve dependency includes some embedded Assembly for that architecture.
 - Getting the solution to run on a system with a suitable NVIDIA GPU does take some work, as detailed in the [Run instructions](#run-instructions) below.
 The reason is that the way to setup the primary dependencies (CUDASieve and CUDA Toolkit) varies across platforms and GPUs. It includes some case-specific manual changes to the Makefiles of CUDASieve and this solution.
 - To build this solution and its prerequisites, a basic build toolchain needs be in place. On Ubuntu systems, it can be installed using the following command:
-  
+
   ```text
   sudo apt install build-essential
   ```


### PR DESCRIPTION
## Description

CUDASieve contains embedded AMD64 Assembly, which makes it only builds on that architecture. Hence, the same applies to CUDA/solution_1; this updates the README for that solution to mention this.

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
