### PR TITLE
Mojo/solution_1 Dockerfile: Clean up after apt-get install

### DIFF
--- a/PrimeMojo/solution_1/Dockerfile
+++ b/PrimeMojo/solution_1/Dockerfile
@@ -7,7 +7,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     python3 \
     python3-venv \
-    python3-pip 
+    python3-pip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
 


### PR DESCRIPTION
## Description

We overlooked that the apt-get install in the Dockerfile for Mojo/solution_1 was not followed by the appropriate clean-up. This fixes that.

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
