### PR TITLE
add CITATION.cff and LICENSE files

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,11 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+  - family-names: van Bergen
+    given-names: Rutger
+  - family-names: Marghidanu
+    given-names: Tudor
+  - family-names: Plummer
+    given-names: David W
+title: "Primes | A Software Drag Race"
+url: https://github.com/PlummersSoftwareLLC/


### PR DESCRIPTION
## Description
I am currently writing a research article where I would like to mention the results of this study. Therefore I would like to cite this work. Thus I am adding the `CITATION.cff` file.

Furthermore, I noticed that the project does not seem to have a `LICENSE` file although all submissions are required to be compatible with the [BSD 3-Clause](https://opensource.org/license/BSD-3-clause) license. Within the license file, one typically states the year and the copyright owners. How we might fill the latter is debatable. I view my PR as a suggestion and of course hold no authority over this. Please let me know what you think.

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
