### PR TITLE
Fix build errors in existing solutions

### DIFF
--- a/PrimeAssembly/solution_3/Dockerfile
+++ b/PrimeAssembly/solution_3/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:22-slim
+FROM eclipse-temurin:22-jdk-noble
 
 RUN apt-get update -qq \
     && apt-get install -y gcc git wget \

--- a/PrimeUmple/solution_1/Dockerfile
+++ b/PrimeUmple/solution_1/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM eclipse-temurin:11-jdk
 
 WORKDIR /opt/app
 COPY PrimeUmple.ump .

--- a/PrimeYoix/solution_1/Dockerfile
+++ b/PrimeYoix/solution_1/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11
+FROM eclipse-temurin:11-jdk
 
 WORKDIR /opt/app
 COPY PrimeYoix.yx .


### PR DESCRIPTION
## Description

This PR addresses build errors in 4 existing solutions:

- Assembly/solution_1, Umple/solution_1 and Yoix/solution_1 started failing because the deprecated openjdk Docker Hub images that the solutions' Dockerfiles derived from are no longer available. I have switched these solutions to corresponding eclipse-temurin images instead.
- Mojo/solution_1 fails because the solution's code is no longer compatible with the version of Mojo that the Dockerfile installs. I have disabled the build and hence benchmark runs for this solution until a fix is provided; I have opened issue #1027 to request one.

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
