### PR TITLE
Fix Mojo solution_1 build (meta sieve_size name collision)

### DIFF
--- a/PrimeMojo/solution_1/primesieve.mojo
+++ b/PrimeMojo/solution_1/primesieve.mojo
@@ -150,8 +150,8 @@ struct prime_sieve_1bit_meta[sieve_size: Int](Runnable):
         for i in range(self.bitset_size):
             self.array.set(i)
 
-    fn __call__(self: Self, sieve_size: Int) -> Self:
-        return Self(sieve_size)
+    fn __call__(self: Self, runtime_sieve_size: Int) -> Self:
+        return Self(runtime_sieve_size)
 
     fn getBit(self, index: Int) -> Bool:
         if index % 2 == 0:
@@ -197,8 +197,8 @@ struct prime_sieve_8bit_meta[sieve_size: Int](Runnable):
         self.limit = sieve_size >> 1
         self.array = InlineArray[UInt8, (sieve_size >> 1)](fill=0xFF)
 
-    fn __call__(self: Self, sieve_size: Int) -> Self:
-        return Self(sieve_size)
+    fn __call__(self: Self, runtime_sieve_size: Int) -> Self:
+        return Self(runtime_sieve_size)
 
     fn countPrimes(self) -> Int:
         count = 1


### PR DESCRIPTION
## Description
This fixes issue #1027 where solution_1 fails during the Docker build step with:

`error: invalid redefinition of 'sieve_size'`

Root cause
The meta sieve types declare a compile-time generic parameter named `sieve_size` (e.g. `prime_sieve_1bit_meta[sieve_size: Int]`) and also used `sieve_size` as the runtime parameter name in `__call__`. Newer Mojo treats that as a redeclaration in the same scope.

Fix
Rename the `__call__` runtime parameter in the meta types to avoid colliding with the generic parameter.

Verification
`docker build -t mojosieve .` and `docker run --rm -it mojosieve` succeed again.

Fixes #1027

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
