### PR TITLE
Improve Dockerfile layer caching for PrimeMojo solution_1

### DIFF
--- a/PrimeMojo/solution_1/Dockerfile
+++ b/PrimeMojo/solution_1/Dockerfile
@@ -13,8 +13,6 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /app
 
-COPY . .
-
 RUN python3 -m venv /opt/venv \
     && /opt/venv/bin/pip install modular \
     --extra-index-url https://modular.gateway.scarf.sh/simple/
@@ -22,8 +20,10 @@ RUN python3 -m venv /opt/venv \
 # Ensure venv is on PATH
 ENV PATH="/opt/venv/bin:${PATH}"
 
-# Build the Mojo program defualt
-RUN mojo build primesieve.mojo -o primesieve
+# Copy only the source we need (better layer caching)
+COPY primesieve.mojo ./
 
+# Build the Mojo program default
+RUN mojo build primesieve.mojo -o primesieve
 
 ENTRYPOINT ["./primesieve"]


### PR DESCRIPTION
## Description
This PR improves rebuild times for the Mojo solution’s Docker image by restructuring layers so that the expensive dependency install is cacheable.

What changed

- Install `modular` (via pip) before copying the frequently-changing source.
- Copy only the needed Mojo source into the image (instead of copying the whole directory).
- Fix a minor comment typo.

Why

Previously, edits to the Mojo source invalidated the COPY layer and forced Docker to re-run `pip install modular` on every rebuild. With this ordering, most edits only rerun mojo build, which is much faster than re-installing the toolchain.

Verification

`docker build -t mojosieve .`
`docker run --rm -it mojosieve`

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
