### PR TITLE
Fix Odin solution_1 build to support current Odin (dev-2025-12)

### DIFF
--- a/PrimeOdin/solution_1/Dockerfile
+++ b/PrimeOdin/solution_1/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04 AS odin
+FROM ubuntu:24.04 AS build
 
 ARG ODIN_VERSION=dev-2025-12
 ARG ODIN_ARCHIVE=odin-linux-amd64-${ODIN_VERSION}.tar.gz
@@ -6,20 +6,14 @@ ARG ODIN_URL=https://github.com/odin-lang/Odin/releases/download/${ODIN_VERSION}
 
 RUN apt-get update \
 	&& apt-get install -y --no-install-recommends ca-certificates curl clang lld \
-	&& rm -rf /var/lib/apt/lists/*
-
-RUN mkdir -p /opt/odin \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& mkdir -p /opt/odin \
 	&& curl -fsSL "$ODIN_URL" -o /tmp/odin.tar.gz \
 	&& tar -xzf /tmp/odin.tar.gz -C /opt/odin --strip-components=1 \
 	&& rm /tmp/odin.tar.gz
 
 ENV ODIN_ROOT=/opt/odin
 ENV PATH="/opt/odin:${PATH}"
-
-RUN odin version
-
-
-FROM odin AS build
 
 WORKDIR /opt/app
 

--- a/PrimeOdin/solution_1/Dockerfile
+++ b/PrimeOdin/solution_1/Dockerfile
@@ -1,14 +1,36 @@
-FROM primeimages/odin:commit-481fc8a5b60cf15d AS build
+FROM ubuntu:24.04 AS odin
+
+ARG ODIN_VERSION=dev-2025-12
+ARG ODIN_ARCHIVE=odin-linux-amd64-${ODIN_VERSION}.tar.gz
+ARG ODIN_URL=https://github.com/odin-lang/Odin/releases/download/${ODIN_VERSION}/${ODIN_ARCHIVE}
+
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends ca-certificates curl clang lld \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /opt/odin \
+	&& curl -fsSL "$ODIN_URL" -o /tmp/odin.tar.gz \
+	&& tar -xzf /tmp/odin.tar.gz -C /opt/odin --strip-components=1 \
+	&& rm /tmp/odin.tar.gz
+
+ENV ODIN_ROOT=/opt/odin
+ENV PATH="/opt/odin:${PATH}"
+
+RUN odin version
+
+
+FROM odin AS build
 
 WORKDIR /opt/app
 
 COPY *.odin ./
-RUN odin build main.odin -opt:3 -no-bounds-check -out:primes-odin-1
+RUN odin build . -o:speed -no-bounds-check -out:primes-odin-1
 
-FROM primeimages/odin:commit-481fc8a5b60cf15d AS runtime
+
+FROM ubuntu:24.04 AS runtime
 
 WORKDIR /opt/app
 
 COPY --from=build /opt/app/primes-odin-1 primes-odin-1
 
-ENTRYPOINT [ "./primes-odin-1" ]
+ENTRYPOINT ["./primes-odin-1"]

--- a/PrimeOdin/solution_1/README.md
+++ b/PrimeOdin/solution_1/README.md
@@ -20,7 +20,7 @@ setup a dev environment for your system.
 
 Then run:
 ```
-odin run main.odin -opt:3 -no-bounds-check
+odin run . -o:speed -no-bounds-check
 ```
 
 ### Docker
@@ -38,10 +38,10 @@ Thanks to rbergen for helping me with the Docker image.
 
 Both the 1-bit as well as the 8-bit storage version will be run.
 
-On a Ryzen 1600X using Odin version `dev-2021-07`:
+On a Ryzen 9 9950X3D using Odin version `dev-2025-12`:
 ```
-odin_bit_moe;8985;5.000;1;algorithm=base,faithful=yes,bits=1
-odin_byte_moe;14818;5.000;1;algorithm=base,faithful=yes,bits=8
-odin_bit_threaded_moe;57279;5.005;12;algorithm=base,faithful=yes,bits=1
-odin_byte_threaded_moe;77369;5.038;12;algorithm=base,faithful=yes,bits=8
+odin_bit_moe;20782;5.0001343379999996;1;algorithm=base,faithful=yes,bits=1
+odin_byte_moe;29614;5.000120271;1;algorithm=base,faithful=yes,bits=8
+odin_bit_threaded_moe;325264;5.0082490579999996;32;algorithm=base,faithful=yes,bits=1
+odin_byte_threaded_moe;538477;5.007647265;32;algorithm=base,faithful=yes,bits=8
 ```

--- a/PrimeOdin/solution_1/get_num_cores_linux.odin
+++ b/PrimeOdin/solution_1/get_num_cores_linux.odin
@@ -1,0 +1,19 @@
+package main
+
+import "core:c"
+
+foreign import libc "system:c"
+
+@(default_calling_convention="c")
+foreign libc {
+	// glibc: returns number of processors currently available
+	get_nprocs :: proc() -> c.int ---
+}
+
+get_num_cores :: proc() -> int {
+	n := int(get_nprocs())
+	if n > 0 {
+		return n
+	}
+	return 1
+}

--- a/PrimeOdin/solution_1/get_num_cores_windows.odin
+++ b/PrimeOdin/solution_1/get_num_cores_windows.odin
@@ -1,0 +1,9 @@
+package main
+
+import "core:sys/windows"
+
+get_num_cores :: proc() -> int {
+	sys_info := windows.SYSTEM_INFO{};
+	windows.GetSystemInfo(&sys_info);
+	return int(sys_info.dwNumberOfProcessors);
+}

--- a/PrimeOdin/solution_1/main.odin
+++ b/PrimeOdin/solution_1/main.odin
@@ -7,31 +7,6 @@ import "core:math"
 import "core:thread"
 import "core:sync";
 
-when ODIN_OS == "windows" {
-    import "core:sys/windows"
-
-    get_num_cores :: proc() -> int {
-        sys_info := windows.SYSTEM_INFO{};
-        windows.GetSystemInfo(&sys_info);
-        return int(sys_info.dwNumberOfProcessors);
-    }
-} else when ODIN_OS == "linux" {
-    import "core:c";
-    foreign import sysinfo "system:c"
-
-    @(default_calling_convention="c")
-    foreign sysinfo {
-        // returns number of configured cores on linux
-        get_nprocs_conf :: proc() -> c.int ---;
-    }
-
-    get_num_cores :: proc() -> int {
-        return int(get_nprocs_conf());
-    }
-} else {
-    #assert(0);
-}
-
 
 
 expected :: proc(upper: u64) -> u64 {
@@ -57,7 +32,9 @@ BitSieve :: struct {
 
 make_bits :: proc(using sieve: ^BitSieve, size: u64) {
     // we don't store evens
-    bits = make([]SIEVE_BACKING, math.ceil(f32(size / SIEVE_BACKING_BITS / 2)), context.temp_allocator);
+    half := size / 2;
+    count := (half + SIEVE_BACKING_BITS - 1) / SIEVE_BACKING_BITS;
+    bits = make([]SIEVE_BACKING, int(count), context.allocator);
 }
 
 get_bit :: proc(using sieve: ^BitSieve, index: u64) -> bool #no_bounds_check {
@@ -123,7 +100,7 @@ ByteSieve :: struct {
 
 run_sieve_byte :: proc(upper: u64) -> (sieve: ByteSieve) #no_bounds_check {
     sieve.upper = upper;
-    sieve.bits = make([]bool, upper / 2, context.temp_allocator);
+    sieve.bits = make([]bool, upper / 2, context.allocator);
     factor := u64(3);
     q := u64(math.sqrt(f64(upper)));
 
@@ -171,7 +148,7 @@ measure_run :: proc(size: u64, run_func: $T) -> (passes: u32, total_time: f64) {
         sieve := run_func(size);
         primes = count_primes(&sieve);
         passes += 1;
-        free((^rawptr)(&sieve.bits)^, context.temp_allocator);
+        free((^rawptr)(&sieve.bits)^, context.allocator);
     }
     total_time = time.duration_seconds(time.tick_since(start_time));
 
@@ -182,27 +159,48 @@ measure_run :: proc(size: u64, run_func: $T) -> (passes: u32, total_time: f64) {
     return passes, total_time;
 }
 
-run_threaded :: proc(thread_count: int, $size: u64, $run_func: $T) ->  (total_passes: u32, total_time: f64) {
+thread_worker_bit :: proc(passes: ^u32, wg: ^sync.Wait_Group, size: u64) {
+    passes^, _ = measure_run(size, run_sieve_bit);
+    sync.wait_group_done(wg);
+}
+
+thread_worker_byte :: proc(passes: ^u32, wg: ^sync.Wait_Group, size: u64) {
+    passes^, _ = measure_run(size, run_sieve_byte);
+    sync.wait_group_done(wg);
+}
+
+run_threaded_bit :: proc(thread_count: int, size: u64) -> (total_passes: u32, total_time: f64) {
     start_time := time.tick_now();
 
-    @static sem: sync.Semaphore;
-    sync.semaphore_init(&sem, thread_count);
-    defer sync.semaphore_destroy(&sem);
+    wg := sync.Wait_Group{};
+    sync.wait_group_add(&wg, thread_count);
 
     local_passes := make([]u32, thread_count);
-    for pass, i in &local_passes {
-        // wait/decrement sem here since loop below might otherwise execute
-        // before the wait in the thread
-        sync.semaphore_wait_for(&sem);
-        thread.run_with_poly_data(&pass, proc(passes: ^u32) {
-            passes^, _ = measure_run(size, run_func);
-            sync.semaphore_post(&sem);
-        });
+    for i in 0..<thread_count {
+        thread.run_with_poly_data3(&local_passes[i], &wg, size, thread_worker_bit);
     }
 
-    for i in 0..<thread_count {
-        sync.semaphore_wait_for(&sem);
+    sync.wait_group_wait(&wg);
+
+    for c in local_passes {
+        total_passes += c;
     }
+    total_time = time.duration_seconds(time.tick_since(start_time));
+    return total_passes, total_time;
+}
+
+run_threaded_byte :: proc(thread_count: int, size: u64) -> (total_passes: u32, total_time: f64) {
+    start_time := time.tick_now();
+
+    wg := sync.Wait_Group{};
+    sync.wait_group_add(&wg, thread_count);
+
+    local_passes := make([]u32, thread_count);
+    for i in 0..<thread_count {
+        thread.run_with_poly_data3(&local_passes[i], &wg, size, thread_worker_byte);
+    }
+
+    sync.wait_group_wait(&wg);
 
     for c in local_passes {
         total_passes += c;
@@ -221,11 +219,14 @@ main :: proc() {
 
     // threaded version
     thread_count := get_num_cores();
-    passes, total = run_threaded(thread_count, size, run_sieve_bit);
+    if thread_count < 1 {
+        thread_count = 1;
+    }
+    passes, total = run_threaded_bit(thread_count, size);
     fmt.printf(
         "\nodin_bit_threaded_moe;%v;%v;%v;algorithm=base,faithful=yes,bits=1",
         passes, total, thread_count);
-    passes, total = run_threaded(thread_count, size, run_sieve_byte);
+    passes, total = run_threaded_byte(thread_count, size);
     fmt.printf(
         "\nodin_byte_threaded_moe;%v;%v;%v;algorithm=base,faithful=yes,bits=8",
         passes, total, thread_count);


### PR DESCRIPTION
## Description

Hope it's ok I'm updating this code--seems like it may be abandoned given the issue is 2 years old.  Fixes Odin solution_1 to build and run on the current Odin dev snapshot and updates the Docker build to use a current Odin release tarball.

What changed

Updated the code for compatibility with the current language/toolchain expectations (build flags, import constraints, type/size fixes) per Kelimion's comments (not tagging him here since he seemed surprised to be referenced in the issue).
- Replaced the previous thread synchronization approach with `sync.Wait_Group`.
- Fixed a threaded-mode crash by avoiding passing a procedure value through thread poly-data; split workers by sieve type instead.
- Switched sieve allocations to `context.allocator` to avoid relying on thread-unsafe temporary allocation patterns.
- Implemented Linux core-count via glibc `get_nprocs()` (and kept the Windows implementation separate).
- Updated the Docker setup to download a modern Odin release and build with current odin build flags.

How to verify

`docker build -t odin-primes .`
`docker run --rm odin-primes`

Fixes #956.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
