### PR TITLE
Use dynamic memory allocation for ALGOL 60 implementation

### DIFF
--- a/PrimeALGOL/solution_2/README.md
+++ b/PrimeALGOL/solution_2/README.md
@@ -42,30 +42,30 @@ On a 12th Gen Intel(R) Core(TM) i7-1255U 1.70 GHz with 16 GB of memory on a Wind
 laptop running Ubuntu 22.04 in WSL2:
 
 ```
-Passes: 11246467 Time: 5 Avg: 4.445840636e-07 Limit: 10 Count1: 4 Count2: 4 Valid: true
-rzuckerm-algol60-bool;11246467;5;1;algorithm=base,faithful=no
+Passes: 11883512 Time: 5.000015 Avg: 4.20752299489e-07 Limit: 10 Count1: 4 Count2: 4 Valid: true
+rzuckerm-algol60-bool;11883512;5.000015;1;algorithm=base,faithful=no
 
-Passes: 5499644 Time: 5 Avg: 9.09149755875e-07 Limit: 100 Count1: 25 Count2: 25 Valid: true
-rzuckerm-algol60-bool;5499644;5;1;algorithm=base,faithful=no
+Passes: 5518413 Time: 5 Avg: 9.06057593007e-07 Limit: 100 Count1: 25 Count2: 25 Valid: true
+rzuckerm-algol60-bool;5518413;5;1;algorithm=base,faithful=no
 
-Passes: 916891 Time: 5.000003 Avg: 5.45321417704e-06 Limit: 1000 Count1: 168 Count2: 168 Valid: true
-rzuckerm-algol60-bool;916891;5.000003;1;algorithm=base,faithful=no
+Passes: 972844 Time: 5.000001 Avg: 5.13957119538e-06 Limit: 1000 Count1: 168 Count2: 168 Valid: true
+rzuckerm-algol60-bool;972844;5.000001;1;algorithm=base,faithful=no
 
-Passes: 90992 Time: 5.000007 Avg: 5.49499626341e-05 Limit: 10000 Count1: 1229 Count2: 1229 Valid: true
-rzuckerm-algol60-bool;90992;5.000007;1;algorithm=base,faithful=no
+Passes: 95601 Time: 5.000051 Avg: 5.23012416188e-05 Limit: 10000 Count1: 1229 Count2: 1229 Valid: true
+rzuckerm-algol60-bool;95601;5.000051;1;algorithm=base,faithful=no
 
-Passes: 6499 Time: 5.000693 Avg: 0.000769455762425 Limit: 100000 Count1: 9592 Count2: 9592 Valid: true
-rzuckerm-algol60-bool;6499;5.000693;1;algorithm=base,faithful=no
+Passes: 7003 Time: 5.000661 Avg: 0.000714074111095 Limit: 100000 Count1: 9592 Count2: 9592 Valid: true
+rzuckerm-algol60-bool;7003;5.000661;1;algorithm=base,faithful=no
 
-Passes: 593 Time: 5.004047 Avg: 0.00843852782462 Limit: 1000000 Count1: 78498 Count2: 78498 Valid: true
-rzuckerm-algol60-bool;593;5.004047;1;algorithm=base,faithful=no
+Passes: 568 Time: 5.007156 Avg: 0.00881541549296 Limit: 1000000 Count1: 78498 Count2: 78498 Valid: true
+rzuckerm-algol60-bool;568;5.007156;1;algorithm=base,faithful=no
 
-Passes: 46 Time: 5.051831 Avg: 0.109822413043 Limit: 10000000 Count1: 664579 Count2: 664579 Valid: true
-rzuckerm-algol60-bool;46;5.051831;1;algorithm=base,faithful=no
+Passes: 45 Time: 5.011531 Avg: 0.111367355556 Limit: 10000000 Count1: 664579 Count2: 664579 Valid: true
+rzuckerm-algol60-bool;45;5.011531;1;algorithm=base,faithful=no
 
-Passes: 4 Time: 5.146225 Avg: 1.28655625 Limit: 100000000 Count1: 5761455 Count2: 5761455 Valid: true
-rzuckerm-algol60-bool;4;5.146225;1;algorithm=base,faithful=no
+Passes: 5 Time: 6.014875 Avg: 1.202975 Limit: 100000000 Count1: 5761455 Count2: 5761455 Valid: true
+rzuckerm-algol60-bool;5;6.014875;1;algorithm=base,faithful=no
 
-Passes: 1 Time: 14.276457 Avg: 14.276457 Limit: 1000000000 Count1: 50847534 Count2: 50847534 Valid: true
-rzuckerm-algol60-bool;1;14.276457;1;algorithm=base,faithful=no
+Passes: 1 Time: 13.957539 Avg: 13.957539 Limit: 1000000000 Count1: 50847534 Count2: 50847534 Valid: true
+rzuckerm-algol60-bool;1;13.957539;1;algorithm=base,faithful=no
 ```

--- a/PrimeALGOL/solution_2/README.md
+++ b/PrimeALGOL/solution_2/README.md
@@ -43,24 +43,27 @@ On a 12th Gen Intel(R) Core(TM) i7-1255U 1.70 GHz with 16 GB of memory on a Wind
 laptop running Ubuntu 22.04 in WSL2:
 
 ```
-Passes: 5644434 Time: 5 Avg: 8.85828410785e-07 Limit: 10 Count1: 4 Count2: 4 Valid: true
-rzuckerm-algol60;5644434;5;1;algorithm=base,faithful=no
+Passes: 11246467 Time: 5 Avg: 4.445840636e-07 Limit: 10 Count1: 4 Count2: 4 Valid: true
+rzuckerm-algol60-bool;11246467;5;1;algorithm=base,faithful=no
 
-Passes: 1479489 Time: 5 Avg: 3.37954523488e-06 Limit: 100 Count1: 25 Count2: 25 Valid: true
-rzuckerm-algol60;1479489;5;1;algorithm=base,faithful=no
+Passes: 5499644 Time: 5 Avg: 9.09149755875e-07 Limit: 100 Count1: 25 Count2: 25 Valid: true
+rzuckerm-algol60-bool;5499644;5;1;algorithm=base,faithful=no
 
-Passes: 174405 Time: 5.000004 Avg: 2.86689257762e-05 Limit: 1000 Count1: 168 Count2: 168 Valid: true
-rzuckerm-algol60;174405;5.000004;1;algorithm=base,faithful=no
+Passes: 916891 Time: 5.000003 Avg: 5.45321417704e-06 Limit: 1000 Count1: 168 Count2: 168 Valid: true
+rzuckerm-algol60-bool;916891;5.000003;1;algorithm=base,faithful=no
 
-Passes: 22154 Time: 5.000011 Avg: 0.000225693373657 Limit: 10000 Count1: 1229 Count2: 1229 Valid: true
-rzuckerm-algol60;22154;5.000011;1;algorithm=base,faithful=no
+Passes: 90992 Time: 5.000007 Avg: 5.49499626341e-05 Limit: 10000 Count1: 1229 Count2: 1229 Valid: true
+rzuckerm-algol60-bool;90992;5.000007;1;algorithm=base,faithful=no
 
-Passes: 2258 Time: 5.001467 Avg: 0.00221499867139 Limit: 100000 Count1: 9592 Count2: 9592 Valid: true
-rzuckerm-algol60;2258;5.001467;1;algorithm=base,faithful=no
+Passes: 6499 Time: 5.000693 Avg: 0.000769455762425 Limit: 100000 Count1: 9592 Count2: 9592 Valid: true
+rzuckerm-algol60-bool;6499;5.000693;1;algorithm=base,faithful=no
 
-Passes: 197 Time: 5.014032 Avg: 0.0254519390863 Limit: 1000000 Count1: 78498 Count2: 78498 Valid: true
-rzuckerm-algol60;197;5.014032;1;algorithm=base,faithful=no
+Passes: 593 Time: 5.004047 Avg: 0.00843852782462 Limit: 1000000 Count1: 78498 Count2: 78498 Valid: true
+rzuckerm-algol60-bool;593;5.004047;1;algorithm=base,faithful=no
 
-Passes: 11 Time: 5.308077 Avg: 0.482552454545 Limit: 10000000 Count1: 664579 Count2: 664579 Valid: true
-rzuckerm-algol60;11;5.308077;1;algorithm=base,faithful=no
+Passes: 46 Time: 5.051831 Avg: 0.109822413043 Limit: 10000000 Count1: 664579 Count2: 664579 Valid: true
+rzuckerm-algol60-bool;46;5.051831;1;algorithm=base,faithful=no
+
+Passes: 4 Time: 5.146225 Avg: 1.28655625 Limit: 100000000 Count1: 5761455 Count2: 5761455 Valid: true
+rzuckerm-algol60-bool;4;5.146225;1;algorithm=base,faithful=no
 ```

--- a/PrimeALGOL/solution_2/README.md
+++ b/PrimeALGOL/solution_2/README.md
@@ -65,4 +65,7 @@ rzuckerm-algol60-bool;46;5.051831;1;algorithm=base,faithful=no
 
 Passes: 4 Time: 5.146225 Avg: 1.28655625 Limit: 100000000 Count1: 5761455 Count2: 5761455 Valid: true
 rzuckerm-algol60-bool;4;5.146225;1;algorithm=base,faithful=no
+
+Passes: 1 Time: 14.276457 Avg: 14.276457 Limit: 1000000000 Count1: 50847534 Count2: 50847534 Valid: true
+rzuckerm-algol60-bool;1;14.276457;1;algorithm=base,faithful=no
 ```

--- a/PrimeALGOL/solution_2/README.md
+++ b/PrimeALGOL/solution_2/README.md
@@ -11,7 +11,6 @@ ALGOL 60 has some annoying limitations:
 
 - It has no command-line interface, so command-line arguments are handled though
   `run-primes.sh` and piped to stdin
-- It has no dynamic memory allocation, so all memory allocation is only done once.
 - It has no system timer. However, since
   [GNU MARST](https://ftp.gnu.org/gnu/marst/marst-2.8.tar.gz) is used to translate
   ALGOL 60 to C, C code can be embedded using the `inline` function

--- a/PrimeALGOL/solution_2/primes.a60
+++ b/PrimeALGOL/solution_2/primes.a60
@@ -49,7 +49,7 @@ begin
                 for k := 2 * bit * (bit + 1) step 2 * bit + 1 until numBits do
                     sieve[k] := false
             end
-        end;
+        end
     end runSieve;
 
     integer procedure countPrimes(numBits, sieve);

--- a/PrimeALGOL/solution_2/primes.a60
+++ b/PrimeALGOL/solution_2/primes.a60
@@ -11,13 +11,34 @@ begin
     real timeLimit;
     begin
         boolean done, valid;
-        integer passes, bit, q, k, count;
+        integer passes, count;
         real startTime, duration;
-        boolean array sieve[1:numBits];
 
-        passes := 0;
         startTime := gettime;
-    primeloop:
+        done := false;
+        for passes := 1, passes + 1 while !done do
+        begin
+            boolean array sieve[1:numBits];
+
+            runSieve(sieveSize, numBits, sieve);
+            duration := gettime - startTime;
+            if duration >= timeLimit then
+            begin
+                count := countPrimes(numBits, sieve);
+                if showResults then showPrimes(numBits, sieve);
+                outputResults(sieveSize, passes, duration, count);
+                done := true
+            end
+        end
+    end timedRunSieve;
+
+    procedure runSieve(sieveSize, numBits, sieve);
+    value sieveSize, numBits;
+    integer sieveSize, numBits;
+    boolean array sieve;
+    begin
+        integer bit, q, k;
+
         for bit := 1 step 1 until numBits do sieve[bit] := true;
         q := entier(sqrt(sieveSize / 2));
         for bit := 1 step 1 until q do
@@ -28,19 +49,10 @@ begin
                     sieve[k] := false
             end
         end;
-
-        passes := passes + 1;
-        duration := gettime - startTime;
-        done := duration >= timeLimit;
-        if !done then goto primeloop;
-
-        count := countPrimes(numBits, sieve);
-        if showResults then showPrimes(numBits, sieve);
-        outputResults(sieveSize, passes, duration, count)
-    end timedRunSieve;
+    end runSieve;
 
     integer procedure countPrimes(numBits, sieve);
-    value numBits, sieve;
+    value numBits;
     integer numBits;
     boolean array sieve;
     begin
@@ -54,7 +66,7 @@ begin
     end countPrimes;
 
     procedure showPrimes(numBits, sieve);
-    value numBits, sieve;
+    value numBits;
     integer numBits;
     boolean array sieve;
     begin
@@ -80,6 +92,7 @@ begin
         else if sieveSize = 100000 then expectedCount := 9592
         else if sieveSize = 1000000 then expectedCount := 78498
         else if sieveSize = 10000000 then expectedCount := 664579
+        else if sieveSize = 100000000 then expectedCount := 5761455
         else outstring(1, "Invalid sieve size\n");
         getExpectedCount := expectedCount
     end;

--- a/PrimeALGOL/solution_2/primes.a60
+++ b/PrimeALGOL/solution_2/primes.a60
@@ -14,7 +14,7 @@ begin
         integer numBits, passes, count;
         real startTime, duration;
 
-        numBits := entier((sieveSize - 1) / 2);
+        numBits := (sieveSize - 1) % 2;
         done := false;
         startTime := gettime;
         for passes := 1, passes + 1 while !done do
@@ -41,7 +41,7 @@ begin
         integer bit, q, k;
 
         for bit := 1 step 1 until numBits do sieve[bit] := true;
-        q := entier(sqrt(sieveSize / 2));
+        q := sqrt(sieveSize % 2);
         for bit := 1 step 1 until q do
         begin
             if sieve[bit] then

--- a/PrimeALGOL/solution_2/primes.a60
+++ b/PrimeALGOL/solution_2/primes.a60
@@ -4,18 +4,19 @@ begin
         inline("my_dsa.retval.u.real_val = (double)clock() / CLOCKS_PER_SEC;");
     end gettime;
 
-    procedure timedRunSieve(sieveSize, numBits, showResults, timeLimit);
-    value sieveSize, numBits, showResults, timeLimit;
-    integer sieveSize, numBits;
+    procedure timedRunSieve(sieveSize, showResults, timeLimit);
+    value sieveSize, showResults, timeLimit;
+    integer sieveSize;
     boolean showResults;
     real timeLimit;
     begin
         boolean done, valid;
-        integer passes, count;
+        integer numBits, passes, count;
         real startTime, duration;
 
-        startTime := gettime;
+        numBits := entier((sieveSize - 1) / 2);
         done := false;
+        startTime := gettime;
         for passes := 1, passes + 1 while !done do
         begin
             boolean array sieve[1:numBits];
@@ -140,6 +141,5 @@ begin
     ininteger(0, showResultsInt);
     showResults := showResultsInt != 0;
 
-    numBits := entier((sieveSize - 1) / 2);
-    timedRunSieve(sieveSize, numBits, showResults, timeLimit)
+    timedRunSieve(sieveSize, showResults, timeLimit)
 end

--- a/PrimeALGOL/solution_2/primes.a60
+++ b/PrimeALGOL/solution_2/primes.a60
@@ -93,6 +93,7 @@ begin
         else if sieveSize = 1000000 then expectedCount := 78498
         else if sieveSize = 10000000 then expectedCount := 664579
         else if sieveSize = 100000000 then expectedCount := 5761455
+        else if sieveSize = 1000000000 then expectedCount := 50847534
         else outstring(1, "Invalid sieve size\n");
         getExpectedCount := expectedCount
     end;


### PR DESCRIPTION
## Description
It turns out that ALGOL 60 **does** support dynamic memory allocation. This can be done inside a `begin/end` construct. I changed the code to do this inside a `for` loop that keeps track of the number of passes. Also, it turns out that arrays should be passed by name, not value. Removing `value sieve` from each procedure gave a significant speed improvement (2 to 5x). This allows a sieve size up to 1 billion to be supported.

## Contributing requirements
<!--
Make sure your PR conforms to the requirements set out in CONTRIBUTING.md:
-->

<!--
When ticking below boxes, please don't leave spaces between the 'x' and the square brackets, as that breaks the checkbox rendering in the PRs.
Right: [x]
Wrong: [x ]
-->
* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
