### PR TITLE
Fix assembly4 extreme timing ABI issue

### DIFF
--- a/PrimeAssembly/solution_4/cwager_x64ff_mt_extreme.asm
+++ b/PrimeAssembly/solution_4/cwager_x64ff_mt_extreme.asm
@@ -232,7 +232,7 @@ init_benchmark:
     jmp .worker_init_loop
 
 .time_init:
-    sub rsp, 16
+    sub rsp, 24
     mov edi, CLOCK_MONOTONIC
     mov rsi, rsp
     call clock_gettime wrt ..plt
@@ -240,7 +240,7 @@ init_benchmark:
     mov [r12 + benchmark_state.start_sec], rax
     mov rax, [rsp + 8]
     mov [r12 + benchmark_state.start_nsec], rax
-    add rsp, 16
+    add rsp, 24
 
     pop r13
     pop r12
@@ -465,7 +465,8 @@ worker_main:
     ret
 
 elapsed_ge_runtime:
-    mov r8, rdi
+    push rbx
+    mov rbx, rdi
     sub rsp, 16
     mov edi, CLOCK_MONOTONIC
     mov rsi, rsp
@@ -474,8 +475,8 @@ elapsed_ge_runtime:
     mov rdx, [rsp + 8]
     add rsp, 16
 
-    sub rax, [r8 + benchmark_state.start_sec]
-    sub rdx, [r8 + benchmark_state.start_nsec]
+    sub rax, [rbx + benchmark_state.start_sec]
+    sub rdx, [rbx + benchmark_state.start_nsec]
     jns .time_ok
     dec rax
     add rdx, 1000000000
@@ -485,6 +486,7 @@ elapsed_ge_runtime:
     cmp rax, RUNTIME
     setae cl
     mov eax, ecx
+    pop rbx
     ret
 
 run_sieve:


### PR DESCRIPTION
Fixes a native Linux segfault in cwager_x64ff_mt_extreme.

The timing helper was keeping the benchmark-state pointer in r8 across a call to clock_gettime. r8 is caller-saved under the x86-64 SysV ABI, so native glibc could clobber it. The pointer is now preserved in rbx with the required save/restore.

This also corrects stack alignment around the other clock_gettime call in init_benchmark.

I reproduced the failure on a native Ubuntu 22.04 Docker runner. Before the fix, the extreme variant exited with SIGSEGV/139. After the fix, both variants complete successfully and the direct extreme-only test exits with rc=0.

Native Ubuntu 22.04 runner, after fix:

cwager_x64ff_mt_extreme;43175;5.008;16;algorithm=base,faithful=yes,bits=1
cwager_x64ff_mt;21740;5.005;16;algorithm=base,faithful=yes,bits=1

Direct extreme-only test on the same runner:

cwager_x64ff_mt_extreme;43757;5.002;16;algorithm=base,faithful=yes,bits=1
extreme_rc=0

As a sanity check, I also reran it on my normal WSL2/Docker Desktop test machine after the fix:

cwager_x64ff_mt_extreme;329816;5.000;12;algorithm=base,faithful=yes,bits=1
cwager_x64ff_mt;120749;5.000;12;algorithm=base,faithful=yes,bits=1

The native runner pass counts are much lower because it is a substantially slower host; they are included only to show the crash is fixed. The WSL2 run is included only as a quick check that the fix did not obviously regress the normal test environment.