### PR TITLE
Add LOLCODE cwager_lolcode solution

### DIFF
--- a/PrimeLOLCODE/solution_1/Dockerfile
+++ b/PrimeLOLCODE/solution_1/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:20.04 AS build
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qq \
+    && apt-get install -y --no-install-recommends build-essential ca-certificates cmake git libreadline-dev patch python3 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/app
+COPY build.sh lci-clock.patch ./
+RUN chmod +x build.sh \
+    && ./build.sh
+
+COPY lolprime.lol run.sh README.md ./
+
+FROM ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update -qq \
+    && apt-get install -y --no-install-recommends libreadline8 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /opt/app
+COPY --from=build /opt/app/.build/prefix /opt/lci
+COPY lolprime.lol run.sh README.md ./
+RUN chmod +x run.sh
+
+ENTRYPOINT ["/opt/app/run.sh"]

--- a/PrimeLOLCODE/solution_1/Dockerfile
+++ b/PrimeLOLCODE/solution_1/Dockerfile
@@ -1,31 +1,45 @@
-FROM ubuntu:20.04 AS build
+FROM debian:bookworm AS build
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qq \
-    && apt-get install -y --no-install-recommends build-essential ca-certificates cmake git libreadline-dev patch python3 \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        cmake \
+        git \
+        libreadline-dev \
+        patch \
+        python3 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/app
+
 COPY build.sh lci-clock.patch ./
+
 RUN chmod +x build.sh \
     && ./build.sh
 
 COPY lolprime.lol run.sh README.md ./
 
-FROM ubuntu:20.04
+
+FROM debian:bookworm-slim
 
 ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update -qq \
-    && apt-get install -y --no-install-recommends libreadline8 \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libreadline8 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/app
+
 COPY --from=build /opt/app/.build/prefix /opt/lci
 COPY lolprime.lol run.sh README.md ./
+
 RUN chmod +x run.sh
 
 ENTRYPOINT ["/opt/app/run.sh"]

--- a/PrimeLOLCODE/solution_1/README.md
+++ b/PrimeLOLCODE/solution_1/README.md
@@ -1,0 +1,56 @@
+# LOLCODE solution by cwager
+
+This is a LOLCODE implementation of the Prime Drag Race base Sieve of Eratosthenes using the `lci` interpreter. The benchmark output name is exactly `cwager_lolcode`.
+
+The sieve, timing loop, pass counting, validation, elapsed-time calculation, and final output formatting are all implemented in [lolprime.lol](./lolprime.lol). The final output line remains:
+
+```text
+cwager_lolcode;<passes>;<seconds>;1;algorithm=base,faithful=yes,bits=1
+```
+
+The implementation stores odd candidates only. Candidate `n` maps to `n / 2`, and each odd candidate uses one packed bit inside integer words stored in a runtime-sized `BUKKIT`. Composite marking uses inverted logic: `0` means the candidate is still potentially prime, and `1` means the candidate has been marked composite.
+
+`MASKS` and `POP8` are process-wide lookup tables only. They are not per-pass sieve state. Each timed pass creates a fresh `SieveBase` instance and a fresh backing `BUKKIT`, then runs the faithful base sieve against that new buffer.
+
+`build.sh` builds a pinned `lci` commit from source and applies the local [lci-clock.patch](./lci-clock.patch). That patch only exposes a clock binding, `CLOCK'Z NAO`, which returns the current wall-clock time in microseconds. The patch does not implement the sieve, pass counting, validation, benchmark loop, elapsed-time calculation, or output formatting.
+
+Because one interpreted LOLCODE pass takes longer than the five-second target interval, the implementation runs one full validated pass and reports the actual elapsed time for that pass. This follows the Prime Drag Race clarification that if a single pass cannot complete within 5 seconds, one completed pass is sufficient. The submission is correctness-focused and esoteric-language-focused, not performance competitive.
+
+## Licensing note
+
+The LOLCODE solution files in this directory are intended to be contributed under the repository's normal solution license terms.
+
+The `lci-clock.patch` file is a small modification patch against the external `lci` interpreter/toolchain by Justin Meza and contributors. Since `lci` is GPL-3.0 licensed, this patch should be treated as applying to that external GPL-licensed toolchain code, not as BSD-3 solution code. The patch changes are by Chris Wager, 2026.
+
+GPLv3 does not require this patch to be pushed upstream to `lci`; it is included here as source so the Docker/local build can apply it. The patch only exposes a wall-clock binding, `CLOCK'Z NAO`, returning the current time in microseconds. It does not implement the sieve, pass counting, validation, benchmark loop, elapsed-time calculation, or output formatting.
+
+## Run instructions
+
+Build the pinned local `lci` toolchain:
+
+```bash
+./build.sh
+```
+
+Local builds expect standard development tools including `cmake`, a C compiler toolchain, `git`, `patch`, `python3`, and `libreadline-dev`.
+
+Run the benchmark locally:
+
+```bash
+./run.sh
+```
+
+Or build and run with Docker:
+
+```bash
+docker build -t prime-lolcode PrimeLOLCODE/solution_1
+docker run --rm prime-lolcode
+```
+
+## Output
+
+Example output from one run:
+
+```text
+cwager_lolcode;1;19.300320;1;algorithm=base,faithful=yes,bits=1
+```

--- a/PrimeLOLCODE/solution_1/build.sh
+++ b/PrimeLOLCODE/solution_1/build.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+BUILD_ROOT="$SCRIPT_DIR/.build"
+SRC_DIR="$BUILD_ROOT/lci"
+BUILD_DIR="$BUILD_ROOT/cmake"
+PREFIX_DIR="$BUILD_ROOT/prefix"
+LCI_REPO="https://github.com/justinmeza/lci.git"
+LCI_COMMIT="9377c404c79a122a4698d98118eef44310c751be"
+
+mkdir -p "$BUILD_ROOT"
+
+if [ ! -d "$SRC_DIR/.git" ]; then
+  git clone "$LCI_REPO" "$SRC_DIR" >&2
+fi
+
+git -C "$SRC_DIR" fetch --depth 1 origin "$LCI_COMMIT" >&2
+git -C "$SRC_DIR" checkout --force --detach "$LCI_COMMIT" >&2
+patch -d "$SRC_DIR" -p1 < "$SCRIPT_DIR/lci-clock.patch" >&2
+
+cmake -S "$SRC_DIR" -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX="$PREFIX_DIR" >&2
+cmake --build "$BUILD_DIR" --parallel >&2
+cmake --install "$BUILD_DIR" >&2

--- a/PrimeLOLCODE/solution_1/lci-clock.patch
+++ b/PrimeLOLCODE/solution_1/lci-clock.patch
@@ -1,0 +1,63 @@
+From: Chris Wager <cwager@56kprojects.com>
+Subject: [PATCH] Add CLOCK binding for Prime Drag Race LOLCODE timing
+
+Patch for lci, a LOLCODE interpreter by Justin Meza and contributors.
+lci is licensed under the GNU General Public License v3.0.
+
+Patch changes by Chris Wager, 2026.
+
+This patch adds a small CLOCK binding for the Prime Drag Race LOLCODE
+solution. The binding exposes CLOCK'Z NAO, returning the current wall-clock
+time in microseconds. It does not implement the sieve, benchmark loop,
+validation, pass counting, elapsed-time calculation, or output formatting.
+
+---
+ binding.c | 28 ++++++++++++++++++++++++++++
+ 1 file changed, 28 insertions(+)
+
+diff --git a/binding.c b/binding.c
+index 6f7a71e..561a1ae 100644
+--- a/binding.c
++++ b/binding.c
+@@ -284,6 +284,17 @@ ReturnObject *randWrapper(struct scopeobject *scope)
+ 	return createReturnObject(RT_RETURN, ret);
+ }
+ 
++ReturnObject *clockNowMicrosWrapper(struct scopeobject *scope)
++{
++	struct timeval tv;
++	long long micros = 0;
++	(void)scope;
++
++	gettimeofday(&tv, NULL);
++	micros = ((long long)tv.tv_sec * 1000000LL) + (long long)tv.tv_usec;
++	return createReturnObject(RT_RETURN, createIntegerValueObject(micros));
++}
++
+ void loadLibrary(ScopeObject *scope, IdentifierNode *target)
+ {
+ 	char *name = NULL;
+@@ -375,6 +386,23 @@ void loadLibrary(ScopeObject *scope, IdentifierNode *target)
+ 		if (!val) goto loadLibraryAbort;
+ 		lib = NULL;
+ 
++		if (!updateScopeValue(scope, scope, id, val)) goto loadLibraryAbort;
++		deleteIdentifierNode(id);
++	} else if (!strcmp(name, "CLOCK")) {
++		lib = createScopeObject(scope);
++		if (!lib) goto loadLibraryAbort;
++
++		loadBinding(lib, "NAO", "dummy", &clockNowMicrosWrapper);
++
++		id = createIdentifierNode(IT_DIRECT, (void *)copyString("CLOCK"), NULL, NULL, 0);
++		if (!id) goto loadLibraryAbort;
++
++		if (!createScopeValue(scope, scope, id)) goto loadLibraryAbort;
++
++		val = createArrayValueObject(lib);
++		if (!val) goto loadLibraryAbort;
++		lib = NULL;
++
+ 		if (!updateScopeValue(scope, scope, id, val)) goto loadLibraryAbort;
+ 		deleteIdentifierNode(id);
+ 	}

--- a/PrimeLOLCODE/solution_1/lolprime.lol
+++ b/PrimeLOLCODE/solution_1/lolprime.lol
@@ -5,21 +5,8 @@ CAN HAS CLOCK?
 I HAS A SIEVE_SIZE ITZ 1000000
 I HAS A EXPECTED_COUNT ITZ 78498
 I HAS A TARGET_USEC ITZ 5000000
-BTW MASKS and POP8 are process-wide lookup tables, not per-pass sieve state.
-I HAS A MASKS ITZ A BUKKIT
+BTW POP8 is a process-wide lookup table, not per-pass sieve state.
 I HAS A POP8 ITZ A BUKKIT
-
-I HAS A mask_idx ITZ 0
-I HAS A mask_value ITZ 1
-IM IN YR init_masks
-    BOTH SAEM mask_idx AN 32, O RLY?
-        YA RLY
-            GTFO
-    OIC
-    MASKS HAS A SRS mask_idx ITZ mask_value
-    mask_idx R SUM OF mask_idx AN 1
-    mask_value R PRODUKT OF mask_value AN 2
-IM OUTTA YR init_masks
 
 I HAS A pop_idx ITZ 0
 IM IN YR init_pop8
@@ -86,10 +73,6 @@ O HAI IM SieveBase
 
     HOW IZ I bit_index YR odd_value
         FOUND YR QUOSHUNT OF odd_value AN 2
-    IF U SAY SO
-
-    HOW IZ I mask_for YR bit_offset
-        FOUND YR MASKS'Z SRS bit_offset
     IF U SAY SO
 
     HOW IZ I init YR limit

--- a/PrimeLOLCODE/solution_1/lolprime.lol
+++ b/PrimeLOLCODE/solution_1/lolprime.lol
@@ -1,0 +1,233 @@
+HAI 1.4
+CAN HAS STRING?
+CAN HAS CLOCK?
+
+I HAS A SIEVE_SIZE ITZ 1000000
+I HAS A EXPECTED_COUNT ITZ 78498
+I HAS A TARGET_USEC ITZ 5000000
+BTW MASKS and POP8 are process-wide lookup tables, not per-pass sieve state.
+I HAS A MASKS ITZ A BUKKIT
+I HAS A POP8 ITZ A BUKKIT
+
+I HAS A mask_idx ITZ 0
+I HAS A mask_value ITZ 1
+IM IN YR init_masks
+    BOTH SAEM mask_idx AN 32, O RLY?
+        YA RLY
+            GTFO
+    OIC
+    MASKS HAS A SRS mask_idx ITZ mask_value
+    mask_idx R SUM OF mask_idx AN 1
+    mask_value R PRODUKT OF mask_value AN 2
+IM OUTTA YR init_masks
+
+I HAS A pop_idx ITZ 0
+IM IN YR init_pop8
+    BOTH SAEM pop_idx AN 256, O RLY?
+        YA RLY
+            GTFO
+    OIC
+    I HAS A pop_value ITZ pop_idx
+    I HAS A pop_count ITZ 0
+    IM IN YR count_pop_bits
+        BOTH SAEM pop_value AN 0, O RLY?
+            YA RLY
+                GTFO
+        OIC
+        pop_count R SUM OF pop_count AN MOD OF pop_value AN 2
+        pop_value R QUOSHUNT OF pop_value AN 2
+    IM OUTTA YR count_pop_bits
+    POP8 HAS A SRS pop_idx ITZ pop_count
+    pop_idx R SUM OF pop_idx AN 1
+IM OUTTA YR init_pop8
+
+HOW IZ I select_mask YR bit_offset
+    bit_offset, WTF?
+        OMG 0, FOUND YR 1
+        OMG 1, FOUND YR 2
+        OMG 2, FOUND YR 4
+        OMG 3, FOUND YR 8
+        OMG 4, FOUND YR 16
+        OMG 5, FOUND YR 32
+        OMG 6, FOUND YR 64
+        OMG 7, FOUND YR 128
+        OMG 8, FOUND YR 256
+        OMG 9, FOUND YR 512
+        OMG 10, FOUND YR 1024
+        OMG 11, FOUND YR 2048
+        OMG 12, FOUND YR 4096
+        OMG 13, FOUND YR 8192
+        OMG 14, FOUND YR 16384
+        OMG 15, FOUND YR 32768
+        OMG 16, FOUND YR 65536
+        OMG 17, FOUND YR 131072
+        OMG 18, FOUND YR 262144
+        OMG 19, FOUND YR 524288
+        OMG 20, FOUND YR 1048576
+        OMG 21, FOUND YR 2097152
+        OMG 22, FOUND YR 4194304
+        OMG 23, FOUND YR 8388608
+        OMG 24, FOUND YR 16777216
+        OMG 25, FOUND YR 33554432
+        OMG 26, FOUND YR 67108864
+        OMG 27, FOUND YR 134217728
+        OMG 28, FOUND YR 268435456
+        OMG 29, FOUND YR 536870912
+        OMG 30, FOUND YR 1073741824
+        OMG 31, FOUND YR 2147483648
+    OIC
+IF U SAY SO
+
+O HAI IM SieveBase
+    I HAS A size ITZ 0
+    I HAS A max_index ITZ 0
+    I HAS A word_count ITZ 0
+    I HAS A data ITZ A BUKKIT
+
+    HOW IZ I bit_index YR odd_value
+        FOUND YR QUOSHUNT OF odd_value AN 2
+    IF U SAY SO
+
+    HOW IZ I mask_for YR bit_offset
+        FOUND YR MASKS'Z SRS bit_offset
+    IF U SAY SO
+
+    HOW IZ I init YR limit
+        I HAS A words ITZ A BUKKIT
+        I HAS A idx ITZ 0
+        ME'Z size R limit
+        ME'Z max_index R QUOSHUNT OF DIFF OF limit AN 1 AN 2
+        ME'Z word_count R QUOSHUNT OF SUM OF ME'Z max_index AN 32 AN 32
+        BTW Each pass gets a fresh SieveBase instance and a fresh backing BUKKIT.
+        IM IN YR fill
+            BOTH SAEM idx AN ME'Z word_count, O RLY?
+                YA RLY
+                    GTFO
+            OIC
+            words HAS A SRS idx ITZ 0
+            idx R SUM OF idx AN 1
+        IM OUTTA YR fill
+        ME'Z data R words
+    IF U SAY SO
+
+    HOW IZ I run
+        I HAS A data ITZ ME'Z data
+        I HAS A factor_idx ITZ 1
+        I HAS A factor ITZ 3
+        I HAS A square_idx ITZ 4
+        BTW Packed flags use inverted logic: 0 means still potentially prime, 1 means composite.
+        IM IN YR sieve_loop
+            DIFFRINT square_idx AN SMALLR OF square_idx AN ME'Z max_index, O RLY?
+                YA RLY
+                    GTFO
+            OIC
+
+            I HAS A multiple_idx ITZ square_idx
+            IM IN YR mark_composite_loop
+                DIFFRINT multiple_idx AN SMALLR OF multiple_idx AN ME'Z max_index, O RLY?
+                    YA RLY
+                        GTFO
+                OIC
+                I HAS A word_idx ITZ QUOSHUNT OF multiple_idx AN 32
+                I HAS A bit_offset ITZ MOD OF multiple_idx AN 32
+                I HAS A mask ITZ I IZ select_mask YR bit_offset MKAY
+                I HAS A current_word ITZ data'Z SRS word_idx
+                BOTH SAEM MOD OF QUOSHUNT OF current_word AN mask AN 2 AN 0, O RLY?
+                    YA RLY
+                        data'Z SRS word_idx R SUM OF current_word AN mask
+                OIC
+                multiple_idx R SUM OF multiple_idx AN factor
+            IM OUTTA YR mark_composite_loop
+
+            IM IN YR find_loop
+                factor_idx R SUM OF factor_idx AN 1
+                I HAS A word_idx ITZ QUOSHUNT OF factor_idx AN 32
+                I HAS A bit_offset ITZ MOD OF factor_idx AN 32
+                I HAS A mask ITZ I IZ select_mask YR bit_offset MKAY
+                I HAS A current_word ITZ data'Z SRS word_idx
+                BOTH SAEM MOD OF QUOSHUNT OF current_word AN mask AN 2 AN 0, O RLY?
+                    YA RLY
+                        factor R SUM OF PRODUKT OF factor_idx AN 2 AN 1
+                        I HAS A factor_idx_plus ITZ SUM OF factor_idx AN 1
+                        square_idx R PRODUKT OF PRODUKT OF factor_idx AN factor_idx_plus AN 2
+                        GTFO
+                OIC
+            IM OUTTA YR find_loop
+        IM OUTTA YR sieve_loop
+    IF U SAY SO
+
+    HOW IZ I count_primes
+        I HAS A data ITZ ME'Z data
+        I HAS A composite_count ITZ 0
+        I HAS A word_idx ITZ 0
+        IM IN YR count_loop
+            BOTH SAEM word_idx AN ME'Z word_count, O RLY?
+                YA RLY
+                    GTFO
+            OIC
+            I HAS A current_word ITZ data'Z SRS word_idx
+            composite_count R SUM OF composite_count AN POP8'Z SRS MOD OF current_word AN 256
+            current_word R QUOSHUNT OF current_word AN 256
+            composite_count R SUM OF composite_count AN POP8'Z SRS MOD OF current_word AN 256
+            current_word R QUOSHUNT OF current_word AN 256
+            composite_count R SUM OF composite_count AN POP8'Z SRS MOD OF current_word AN 256
+            current_word R QUOSHUNT OF current_word AN 256
+            composite_count R SUM OF composite_count AN POP8'Z SRS MOD OF current_word AN 256
+            word_idx R SUM OF word_idx AN 1
+        IM OUTTA YR count_loop
+        FOUND YR SUM OF DIFF OF ME'Z max_index AN composite_count AN 1
+    IF U SAY SO
+KTHX
+
+HOW IZ I pad_six YR value
+    I HAS A out ITZ SMOOSH value MKAY
+    IM IN YR pad_loop
+        BOTH SAEM I IZ STRING'Z LEN YR out MKAY AN 6, O RLY?
+            YA RLY
+                GTFO
+        OIC
+        out R SMOOSH "0" AN out MKAY
+    IM OUTTA YR pad_loop
+    FOUND YR out
+IF U SAY SO
+
+HOW IZ I format_seconds YR elapsed_usec
+    I HAS A whole ITZ QUOSHUNT OF elapsed_usec AN 1000000
+    I HAS A frac ITZ MOD OF elapsed_usec AN 1000000
+    FOUND YR SMOOSH whole AN "." AN I IZ pad_six YR frac MKAY MKAY
+IF U SAY SO
+
+I HAS A start_usec ITZ I IZ CLOCK'Z NAO YR 0 MKAY
+I HAS A elapsed_usec ITZ 0
+I HAS A passes ITZ 0
+I HAS A prime_count ITZ 0
+I HAS A valid ITZ WIN
+I HAS A last_sieve
+
+IM IN YR benchmark
+    I HAS A sieve ITZ LIEK A SieveBase
+    I IZ sieve'Z init YR SIEVE_SIZE MKAY
+    I IZ sieve'Z run MKAY
+    last_sieve R sieve
+    passes R SUM OF passes AN 1
+    elapsed_usec R DIFF OF I IZ CLOCK'Z NAO YR 0 MKAY AN start_usec
+    BOTH SAEM BIGGR OF elapsed_usec AN TARGET_USEC AN elapsed_usec, O RLY?
+        YA RLY
+            GTFO
+        NO WAI
+    OIC
+IM OUTTA YR benchmark
+
+prime_count R I IZ last_sieve'Z count_primes MKAY
+DIFFRINT prime_count AN EXPECTED_COUNT, O RLY?
+    YA RLY
+        valid R FAIL
+    NO WAI
+OIC
+
+BOTH SAEM valid AN WIN, O RLY?
+    YA RLY
+        VISIBLE SMOOSH "cwager_lolcode;" AN passes AN ";" AN I IZ format_seconds YR elapsed_usec MKAY AN ";1;algorithm=base,faithful=yes,bits=1" MKAY
+    NO WAI
+OIC
+KTHXBYE

--- a/PrimeLOLCODE/solution_1/run.sh
+++ b/PrimeLOLCODE/solution_1/run.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+LCI_BIN="$SCRIPT_DIR/.build/prefix/bin/lci"
+if [ ! -x "$LCI_BIN" ] && [ -x /opt/lci/bin/lci ]; then
+  LCI_BIN=/opt/lci/bin/lci
+fi
+
+cd "$SCRIPT_DIR"
+
+if [ ! -x "$LCI_BIN" ]; then
+  ./build.sh >&2
+fi
+
+exec "$LCI_BIN" ./lolprime.lol


### PR DESCRIPTION
## Summary

This adds a correctness-focused LOLCODE solution, `cwager_lolcode`, using the `lci` interpreter.

The sieve, timing loop, pass counting, validation, elapsed-time calculation, and final Drag Race output formatting are implemented in `lolprime.lol`. The Docker build builds a pinned `lci` commit from source and applies a small local patch, `lci-clock.patch`, to expose a wall-clock binding as `CLOCK'Z NAO`.

The patch is limited to providing current time in microseconds. It does not implement the sieve, benchmark loop, pass counting, validation, elapsed-time calculation, or output formatting.

## Notes

This implementation uses the base Sieve of Eratosthenes with odd-only candidates and packed one-bit composite markers. Each stored bit records whether an odd candidate has been marked composite.

Because this interpreted LOLCODE implementation cannot complete a full pass within the five-second target interval, it runs one full validated pass and reports the actual elapsed time for that pass. This follows the clarification that if a single pass cannot complete within 5 seconds, one completed pass is sufficient.

The `lci-clock.patch` file is a modification patch against the external GPL-3.0-licensed `lci` interpreter/toolchain, not part of the BSD-3 solution code. It is included as source so the Docker/local build can apply it.

## Example output

```text
cwager_lolcode;1;19.468820;1;algorithm=base,faithful=yes,bits=1