### PR TITLE
Upgrade Dockerfile to use Lucee 7.0.5.17-SNAPSHOT

### DIFF
--- a/PrimeCFML/solution_1/Dockerfile
+++ b/PrimeCFML/solution_1/Dockerfile
@@ -1,4 +1,4 @@
-FROM lucee/lucee:6.2.0.321-light-tomcat10.1-jre21-temurin-jammy
+FROM lucee/lucee:7.0.5.17-SNAPSHOT-zero
 
 RUN apt-get update && \
     apt-get install -y html2text && \


### PR DESCRIPTION
Updates docker image to Lucee 7 with around 30% performance improvement.
