### PR TITLE
PrimeLean4/solution_1: report bits as unknown

### DIFF
--- a/PrimeLean4/solution_1/PrimeLean4.lean
+++ b/PrimeLean4/solution_1/PrimeLean4.lean
@@ -104,7 +104,7 @@ def benchmark_impl (impl : Impl) (size : Nat := 1000000) (dur_ms : Nat := 5000) 
 def sieve_impls : List Impl := [{
   label := "badly-drawn-wizards"
   num_threads := 1
-  tags := [⟨"algorithm", "base"⟩, ⟨"faithful", "yes"⟩, ⟨"bits", "8"⟩]
+  tags := [⟨"algorithm", "base"⟩, ⟨"faithful", "yes"⟩, ⟨"bits", "unknown"⟩]
   array := PrimeBitArray $ Array Bool
   run := run_sieve
 }]

--- a/PrimeLean4/solution_1/README.md
+++ b/PrimeLean4/solution_1/README.md
@@ -3,7 +3,7 @@
 ![Algorithm](https://img.shields.io/badge/Algorithm-base-green)
 ![Faithfulness](https://img.shields.io/badge/Faithful-yes-green)
 ![Parallelism](https://img.shields.io/badge/Parallel-no-green)
-![Bit count](https://img.shields.io/badge/Bits-8-yellowgreen)
+![Bit count](https://img.shields.io/badge/Bits-unknown-yellowgreen)
 
 This is an initial stab at a Lean4 implementation. Other than directly translating the algorithm, not much has been done to optimize this implementation.
 
@@ -16,5 +16,5 @@ This is an initial stab at a Lean4 implementation. Other than directly translati
 ## Output
 
 ```
-badly-drawn-wizards;1352;5.001000;1;algorithm=base;faithful=yes;bits=8
+badly-drawn-wizards;1352;5.001000;1;algorithm=base,faithful=yes,bits=unknown
 ```


### PR DESCRIPTION
## Description

`PrimeLean4/solution_1` reports `bits=8`, which is incorrect.

The solution stores flags in an `Array Bool`. From `include/lean/lean.h`:

```c
typedef struct {
    lean_object   m_header;
    size_t        m_size;
    size_t        m_capacity;
    lean_object * m_data[];
} lean_array_object;
```

One object reference per element. Nothing is allocated behind those references for a `Bool` - scalars are tagged immediates - so the slot is the entire per-flag cost:

```c
static inline lean_object * lean_box(size_t n) { return (lean_object*)(((size_t)(n) << 1) | 1); }
```

Measured, a 20,000,000-element `Array Bool` moves `VmRSS` from 8,232 kB to 166,068 kB, or 8.08 bytes per flag on x86-64. A per-flag heap object would cost 24 bytes or more, since a Lean object header alone is 16.

So a flag occupies one machine word, not one byte. The exact count is `sizeof(lean_object *)` and therefore platform-dependent, so `bits=64` would overstate what can be claimed. Per CONTRIBUTING, unknown applies when "an implementation uses a `boolean` basic type provided by the language, and the language does not define how booleans are logically stored in memory".

Verified by building and running the container:

```
badly-drawn-wizards;2935;5.000000;1;algorithm=base,faithful=yes,bits=unknown
```

Pass counts are unchanged (2830-2935, against 2772-2937 before), as expected for a change that only touches an output tag.

This also corrects the tag separators in the README's sample output, which showed semicolons where the code emits commas. The original author's measured figures are left as they were.

## Contributing requirements

* [x] I read the contribution guidelines in CONTRIBUTING.md.
* [x] I placed my solution in the correct solution folder.
* [x] I added a README.md with the right badge(s).
* [x] I added a Dockerfile that builds and runs my solution.
* [x] I selected `drag-race` as the target branch.
* [x] All code herein is licensed compatible with BSD-3.
