### PR TITLE
Fix CI build failures and move actions off the Node.js 20 runtime

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: "Find Dockerfiles"
         id: "solutions"
@@ -44,7 +44,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: "Normalize solution name"
         id: solution-name
@@ -75,21 +75,21 @@ jobs:
           config_file: ./config/hadolint.yml
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to DockerHub
         if: ${{ env.ENABLE_DOCKER_PUSH == 'true' }}
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build amd64
         if: steps.arch-amd64.outputs.build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           tags: primeimages/primes:${{ steps.solution-name.outputs.normalized }}
           context: ${{ matrix.solution }}
@@ -100,7 +100,7 @@ jobs:
 
       - name: Build arm64
         if: steps.arch-arm64.outputs.build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           tags: primeimages/primes:${{ steps.solution-name.outputs.normalized }}
           context: ${{ matrix.solution }}

--- a/PrimeCrystal/solution_2/Dockerfile
+++ b/PrimeCrystal/solution_2/Dockerfile
@@ -1,15 +1,7 @@
-FROM debian:13
-
-ENV CRYSTAL_VER="1.21"
-
-WORKDIR /opt
-
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN apt-get update && apt-get install -y curl && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* && \
-    curl -fsSL https://crystal-lang.org/install.sh | bash -s -- --version="${CRYSTAL_VER}"
-# compiler build has been finished here, image ready for use...
+# The Crystal project's own image. Installing via the openSUSE build service
+# repo instead means depending on its mirror network, which is not always in
+# sync and intermittently returns 404 for a package that exists upstream.
+FROM crystallang/crystal:1.21.0
 
 WORKDIR /app
 

--- a/PrimeCrystal/solution_2/Dockerfile
+++ b/PrimeCrystal/solution_2/Dockerfile
@@ -1,6 +1,6 @@
-FROM debian:11
+FROM debian:13
 
-ENV CRYSTAL_VER="1.14"
+ENV CRYSTAL_VER="1.21"
 
 WORKDIR /opt
 

--- a/PrimeMojo/solution_1/Dockerfile
+++ b/PrimeMojo/solution_1/Dockerfile
@@ -13,8 +13,11 @@ RUN apt-get update && apt-get install -y \
 
 WORKDIR /app
 
+# Pin the toolchain. Mojo makes breaking language changes between releases, and
+# an unpinned install has broken this build repeatedly. 26.4 removed `fn`, so the
+# source below builds on 26.2 and 26.3 only.
 RUN python3 -m venv /opt/venv \
-    && /opt/venv/bin/pip install modular \
+    && /opt/venv/bin/pip install modular==26.3.0 \
     --extra-index-url https://modular.gateway.scarf.sh/simple/
 
 # Ensure venv is on PATH


### PR DESCRIPTION
## Description

Three solutions failed CI on the current `drag-race` tip. Two are genuinely broken and are fixed here; the third was transient. This also moves the workflow's actions off the unsupported Node.js 20 runtime.

## Build failures

### PrimeCrystal/solution_2 - stale base image and unreliable package mirrors

Two separate problems, found one after the other.

The solution built on `debian:11`. Bullseye has reached the end of its LTS window and packages have been dropped from the mirrors, so the build failed during `apt-get install curl`, before Crystal was reached at all:

```
E: Failed to fetch .../openssl_1.1.1w-0+deb11u8_amd64.deb       404  Not Found
E: Failed to fetch .../libcurl4_7.74.0-1.3+deb11u16_amd64.deb   404  Not Found
```

Moving to `debian:13` fixed that, and built cleanly locally. It then failed in CI anyway, for a different reason:

```
E: Failed to fetch http://mirror.aardsoft.fi/opensuse/repositories/devel:/languages:/crystal/
   Debian_13/amd64/crystal1.21_1.21.0-1+1.2_amd64.deb  404  Not Found
```

The solution installed Crystal from the openSUSE build service repo via `crystal-lang.org`'s install script. `download.opensuse.org` redirects to regional mirrors that are not always in sync, so whether the build works depends on which mirror the runner is assigned. That is not specific to trixie and would recur on any Debian release.

This now builds on `crystallang/crystal:1.21.0`, the Crystal project's own image, which removes apt, curl, the install script and the mirror dependency entirely. The image is multi-arch, so no architecture support is lost. CONTRIBUTING points at a language's official image first where one exists, which this is.

Source unchanged. All five implementations still validate:

```
GordonBGood_bittwiddle;10645;5.000404;1;algorithm=base,faithful=yes,bits=1
GordonBGood_stride8;13890;5.000170;1;algorithm=base,faithful=yes,bits=1
GordonBGood_stride8-rblock16K;20317;5.000650;1;algorithm=base,faithful=yes,bits=1
GordonBGood_extreme;22240;5.000248;1;algorithm=base,faithful=yes,bits=1
GordonBGood_extreme-hybrid;30378;5.000052;1;algorithm=base,faithful=yes,bits=1
```

All five report `Count1: 78498 Count2: 78498 Valid: true`, built with `--no-cache`.

### PrimeMojo/solution_1 - unpinned toolchain

The Dockerfile installed the Mojo toolchain unpinned, so it always pulled the latest release. Mojo 26.4 removed `fn`:

```
/app/primesieve.mojo:154:5: error: 'fn' has been removed; use 'def' instead
```

This solution has needed repeated source fixes to track Mojo's breaking changes. Rather than chase another one, the toolchain is now pinned. I tested the range to find the working window:

| modular | result |
| --- | --- |
| 25.7.0 | fails - `function effect 'raises' was already specified` |
| 26.1.0 | fails - same |
| 26.2.0 | builds |
| 26.3.0 | builds |
| 26.4.0 | fails - `'fn' has been removed` (34 occurrences) |
| 26.5.0 | fails - same |

Pinned to 26.3.0, the newest release the current source compiles on. The source is untouched, and output is unchanged in form:

```
ELucasCurrie_1bit_meta;5744;5.0;1;algorithm=base,faithful=no,bits=1
ELucasCurrie_8bit_meta;13445;5.0;1;algorithm=base,faithful=no,bits=8
ELucasCurrie_1bit;12071;5.0;1;algorithm=base,faithful=yes,bits=1
ELucasCurrie_8bit;13782;5.0;1;algorithm=base,faithful=yes,bits=8
```

Moving past 26.3 requires `fn` to become `def` in the source. That is a semantic change, so it is left to the contributor rather than folded into a build fix.

### PrimePHP/solution_1 - transient, not changed

This failed in the same run, but on a Docker Hub outage rather than anything in the solution:

```
ERROR: unexpected status from HEAD request to
https://registry-1.docker.io/v2/library/php/manifests/8.1.7-cli: 502 Bad Gateway
```

It is unchanged, and has since passed CI on this branch.

## Action runtimes

GitHub no longer supports the Node.js 20 action runtime. Five of the actions in use ran on node20:

| Action | Was | Now |
| --- | --- | --- |
| `actions/checkout` (build job) | v4 | v7 |
| `docker/setup-qemu-action` | v3 | v4 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/build-push-action` | v6 | v7 |

All five now resolve to `using: node24`. The four docker action majors are runtime bumps only, with no input changes; `checkout` v7 blocks fork checkout for `pull_request_target` and `workflow_run`, neither of which this workflow uses.

The `checkout` in `collect-solutions` was already on v6, which is node24 - it is moved to v7 so both jobs use one version. `jbergstroem/hadolint-gh-action` is a composite action with no Node runtime, so it is unchanged.

Note that the docker action majors require Actions Runner v2.327.1 or later. GitHub-hosted runners keep the runner binary current, so this should be satisfied.

## Notes

Both changed Dockerfiles pass hadolint against `config/hadolint.yml`.

`PrimePHP/solution_1` pins `php:8.1.7-cli` and PHP 8.1 is past end of life, but that is a relevance question rather than a build failure and is deliberately not addressed here. No `build-no` flags were added.
